### PR TITLE
fix: #30 較好讀取的比較改成逐句，單句修正不再被同批其他句抵銷

### DIFF
--- a/src/OverTranslate/Services/Realtime/RealtimeReadingMerge.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeReadingMerge.cs
@@ -1,0 +1,202 @@
+namespace OverTranslate.Services.Realtime;
+
+/// <summary>One line as it currently stands on screen, and how well it was read.</summary>
+/// <remarks>
+/// Held per line rather than per pass because that is the granularity a correction arrives at: the
+/// recogniser fixes one word in one sentence while the sentence beside it wobbles, and a single
+/// score for the whole reading cannot tell those apart.
+/// </remarks>
+internal readonly record struct RenderedLine(string Text, double Confidence);
+
+/// <summary>
+/// What one pass's reading does to what is already on screen, line by line.
+/// </summary>
+/// <param name="Blocks">The lines to show: this pass's boxes, carrying whichever reading won.</param>
+/// <param name="Lines">Those same lines as the new record of what the region shows.</param>
+internal readonly record struct ReadingMerge(
+    List<OcrTextBlock> Blocks,
+    List<RenderedLine> Lines,
+    int Improved,
+    int Kept,
+    int Added,
+    int Dropped)
+{
+    /// <summary>Whether anything the reader can see is different from what is on screen now.</summary>
+    public bool Changed => Improved > 0 || Added > 0 || Dropped > 0;
+}
+
+/// <summary>
+/// Decides, sentence by sentence, whether a fresh reading may replace the one on screen.
+/// </summary>
+/// <remarks>
+/// The rule itself — a re-reading of a sentence has to be better read than the one already shown
+/// before it may take its place — is not new, and the reason for it has not changed: without it the
+/// overlay shows the newest reading rather than the best one, and a line is rewritten several times
+/// while saying the same thing, which reads far worse than one wrong character.
+///
+/// What is new is the granularity. Applied to a whole pass, the rule compared one weighted average
+/// against another, so a sentence that had just been read correctly could be thrown away because a
+/// second sentence in the same frame happened to score a little lower than last time. Measured on a
+/// live subtitle track: <c>"a facility to study that weird guitar..."</c> was read correctly at 0.99
+/// and rejected, leaving <c>guitr</c> on screen, because the line above it had wobbled. The
+/// correction had no way to land on its own — it had to wait for the whole batch to beat the whole
+/// batch, which for that sentence never happened.
+///
+/// So each line is compared against the line it is a re-reading of, and nothing else. A sentence is
+/// only ever rewritten when its <em>own</em> reading improves, which is strictly stronger than the
+/// pass-level rule was: that one also let a sentence be overwritten by a worse reading of itself
+/// whenever its neighbour improved enough to carry the average.
+///
+/// Lines are paired across passes by what they say, not where they are. Position sorts the
+/// candidates — the same sentence rarely jumps up the frame between two polls 250ms apart — but the
+/// text decides, because a line appearing above the current one shifts every box below it while the
+/// words stay put. A read line that pairs with nothing is new, and a shown line nothing pairs with
+/// has gone; both are real changes and neither is held back.
+/// </remarks>
+internal static class RealtimeReadingMerge
+{
+    /// <summary>
+    /// How much better a re-reading has to score before it may take a sentence's place.
+    /// </summary>
+    /// <remarks>
+    /// Not zero, because the score stops discriminating near the top of its range: measured over
+    /// five sessions (3,398 passes that read text), the readings separated by 0.01–0.02 are as often
+    /// a step backwards as forwards — <c>"Where have you gone?!"</c> at 0.98 was replaced by
+    /// <c>"Where have vou gone?!"</c> at 1.00, <c>"really"</c> by <c>"eally"</c>, <c>"Thank you"</c>
+    /// by <c>"Thankyou"</c>. Believing every improvement rewrote a sentence already on screen 176
+    /// times over that sample against 66 under the rule this replaces, and most of the difference
+    /// was that churn rather than corrections.
+    ///
+    /// At 0.02 the same sample rewrites 91 times, and what survives is overwhelmingly real:
+    /// <c>relly→really</c>, <c>șong→song</c>, <c>WwWil→W-Will</c>, <c>"This is nice!ブハ"→"This is
+    /// nice!"</c>. That is still 25 rewrites more than before, roughly one extra every four minutes
+    /// of watching, and it is a deliberate trade: the rewrites bought are corrections that land,
+    /// while what the old rule bought with its lower count was <c>guitr</c> staying on screen for
+    /// the rest of the line's life.
+    ///
+    /// It cannot go higher without giving that back. The reading this whole issue is about gained
+    /// 0.03 (0.96 → 0.99); a threshold of 0.04 brings the count to 59 — below the old rule — and
+    /// rejects the correction it was raised for.
+    ///
+    /// Tried and dropped: refusing to rewrite a sentence already scoring above a ceiling, on the
+    /// theory that a 0.99 reading is not worth arguing with. It removed almost nothing on top of
+    /// this (89 against 91 at a 0.97 ceiling), because the wobbles that matter are further down.
+    /// </remarks>
+    public const double MinConfidenceGain = 0.02;
+
+    /// <summary>
+    /// Works out what the region should show, given what it shows now and what has just been read.
+    /// </summary>
+    public static ReadingMerge Merge(IReadOnlyList<RenderedLine> shown, IReadOnlyList<OcrTextBlock> read)
+    {
+        var pairedTo = Pair(shown, read);
+
+        var blocks = new List<OcrTextBlock>(read.Count);
+        var lines = new List<RenderedLine>(read.Count);
+        int improved = 0, kept = 0, added = 0, paired = 0;
+
+        for (var i = 0; i < read.Count; i++)
+        {
+            var block = read[i];
+            // Null scores count as perfectly read, matching the filters upstream, which let a block
+            // through when there is nothing to judge it by.
+            var confidence = block.Confidence ?? 1.0;
+            var partner = pairedTo[i];
+
+            if (partner < 0)
+            {
+                added++;
+                blocks.Add(block);
+                lines.Add(new RenderedLine(block.Text, confidence));
+                continue;
+            }
+
+            paired++;
+            var current = shown[partner];
+
+            // Better read than what is on screen, so the correction lands — this is the whole point.
+            // Any difference in the words counts, not only one big enough to clear the noise
+            // tolerance: "guitr." against "guitar..." is three characters in forty, and it is also
+            // the whole sentence from the reader's side. What has to clear a bar is the score, by
+            // MinConfidenceGain — which is also what bounds how often one sentence can be redrawn,
+            // since each redraw has to climb.
+            if (!TextSimilarity.IsSameWording(block.Text, current.Text) &&
+                confidence > current.Confidence + MinConfidenceGain)
+            {
+                improved++;
+                blocks.Add(block);
+                lines.Add(new RenderedLine(block.Text, confidence));
+                continue;
+            }
+
+            // The same sentence, read no better: the words stay as they were rendered, and so does
+            // the score they are defended with. Anchoring both at what actually reached the screen is
+            // what stops a line drifting away one tolerated character at a time. The box, though, is
+            // this pass's — the sentence has not moved for the wrong reason just because its reading
+            // was not worth taking.
+            kept++;
+            blocks.Add(block with { Text = current.Text });
+            lines.Add(current);
+        }
+
+        return new ReadingMerge(blocks, lines, improved, kept, added, shown.Count - paired);
+    }
+
+    /// <summary>
+    /// Pairs each read line with the shown line it is a re-reading of, or -1 where it is new.
+    /// </summary>
+    /// <remarks>
+    /// Two rounds, because an exact re-reading is stronger evidence of a pairing than a similar one:
+    /// with a line duplicated on screen — the same shout twice, a menu entry repeated — matching on
+    /// similarity alone could consume the exact partner and leave the exact reading paired with the
+    /// wrong copy.
+    /// </remarks>
+    private static int[] Pair(IReadOnlyList<RenderedLine> shown, IReadOnlyList<OcrTextBlock> read)
+    {
+        var pairedTo = new int[read.Count];
+        Array.Fill(pairedTo, -1);
+
+        if (shown.Count == 0) return pairedTo;
+
+        var taken = new bool[shown.Count];
+
+        for (var i = 0; i < read.Count; i++)
+            pairedTo[i] = Claim(i, taken, shown, read[i].Text, TextSimilarity.IsSameContent);
+
+        for (var i = 0; i < read.Count; i++)
+            if (pairedTo[i] < 0)
+                pairedTo[i] = Claim(i, taken, shown, read[i].Text, TextSimilarity.IsSameSentence);
+
+        return pairedTo;
+    }
+
+    /// <summary>
+    /// Takes the nearest unclaimed shown line this reading matches, measuring nearness by position in
+    /// the reading order — which is top to bottom, so it stands in for how far the line has moved.
+    /// </summary>
+    private static int Claim(
+        int index,
+        bool[] taken,
+        IReadOnlyList<RenderedLine> shown,
+        string text,
+        Func<string, string, bool> matches)
+    {
+        var best = -1;
+        var bestDistance = int.MaxValue;
+
+        for (var j = 0; j < shown.Count; j++)
+        {
+            if (taken[j]) continue;
+
+            var distance = Math.Abs(index - j);
+            if (distance >= bestDistance) continue;
+            if (!matches(text, shown[j].Text)) continue;
+
+            best = j;
+            bestDistance = distance;
+        }
+
+        if (best >= 0) taken[best] = true;
+        return best;
+    }
+}

--- a/src/OverTranslate/Services/Realtime/RealtimeRegionState.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeRegionState.cs
@@ -74,6 +74,7 @@ internal sealed class RealtimeRegionState
     public const int EmptyPassesBeforeClearing = 2;
 
     private static readonly IReadOnlyList<Rectangle> NoBands = [];
+    private static readonly IReadOnlyList<RenderedLine> NoLines = [];
 
     private IReadOnlyList<Rectangle> _watchBands = NoBands;
     private FrameFingerprint? _rendered;
@@ -83,14 +84,27 @@ internal sealed class RealtimeRegionState
     private int _pollsSinceFullScan;
     private int _emptyPasses;
 
+    /// <summary>
+    /// What the region shows, one entry per line, each with the score it was read at — so a later
+    /// reading of one sentence can be judged against that same sentence rather than against the
+    /// average of everything that happened to be in frame with it. See
+    /// <see cref="RealtimeReadingMerge"/> for why that distinction is the whole of issue #30.
+    /// </summary>
+    public IReadOnlyList<RenderedLine> RenderedLines { get; private set; } = NoLines;
+
     /// <summary>The source text currently on screen for this region.</summary>
     public string RenderedText { get; private set; } = "";
 
     /// <summary>
-    /// How well <see cref="RenderedText"/> was read, so a later reading of the same sentence can be
-    /// compared against it instead of simply replacing it. Zero when nothing is shown, which lets
-    /// any reading at all win the first time.
+    /// How well <see cref="RenderedText"/> was read as a whole — the per-line scores weighted by how
+    /// much text each line contributes, so a long line read well is not outvoted by a stray
+    /// two-character block beside it. Zero when nothing is shown.
     /// </summary>
+    /// <remarks>
+    /// Nothing decides anything by this any more; it is what the log reports so a session can still
+    /// be read as "this pass scored better than what was up". The decisions are per line, against
+    /// <see cref="RenderedLines"/>.
+    /// </remarks>
     public double RenderedConfidence { get; private set; }
 
     /// <summary>True once a pass has found text and the state is watching its strips.</summary>
@@ -159,7 +173,17 @@ internal sealed class RealtimeRegionState
         IReadOnlyList<Rectangle> textBounds,
         Func<IReadOnlyList<Rectangle>?, FrameFingerprint> capture,
         string sourceText,
-        double confidence = 0)
+        double confidence = 0) =>
+        MarkRendered(textBounds, capture, ToLines(sourceText, confidence));
+
+    /// <summary>
+    /// The same, told what each line says and how well each was read — which is what the pass itself
+    /// knows and what <see cref="RealtimeReadingMerge"/> needs back on the next pass.
+    /// </summary>
+    public void MarkRendered(
+        IReadOnlyList<Rectangle> textBounds,
+        Func<IReadOnlyList<Rectangle>?, FrameFingerprint> capture,
+        IReadOnlyList<RenderedLine> lines)
     {
         if (textBounds.Count > 0)
         {
@@ -176,9 +200,37 @@ internal sealed class RealtimeRegionState
         _pending = _rendered;
         _unsettledPolls = 0;
         _pollsSinceFullScan = 0;
-        RenderedText = sourceText;
-        RenderedConfidence = confidence;
+        RenderedLines = lines;
+        RenderedText = string.Join('\n', lines.Select(line => line.Text));
+        RenderedConfidence = WeightedConfidence(lines);
     }
+
+    /// <summary>
+    /// One score for a whole reading, weighted by how much text each line contributes.
+    /// </summary>
+    private static double WeightedConfidence(IReadOnlyList<RenderedLine> lines)
+    {
+        double weighted = 0;
+        double weight = 0;
+
+        foreach (var line in lines)
+        {
+            var characters = Math.Max(1, line.Text.Trim().Length);
+            weighted += line.Confidence * characters;
+            weight += characters;
+        }
+
+        return weight > 0 ? weighted / weight : 0;
+    }
+
+    /// <summary>
+    /// Splits a whole reading back into lines scored alike, for callers that only have the joined
+    /// text — the empty pass, which has no lines at all, and the tests.
+    /// </summary>
+    private static IReadOnlyList<RenderedLine> ToLines(string sourceText, double confidence) =>
+        sourceText.Length == 0
+            ? NoLines
+            : [.. sourceText.Split('\n').Select(line => new RenderedLine(line, confidence))];
 
     /// <summary>
     /// Forgets what the region is known to show, so the next poll reads it again.
@@ -196,6 +248,7 @@ internal sealed class RealtimeRegionState
         _renderedFull = null;
         _pending = null;
         _unsettledPolls = 0;
+        RenderedLines = NoLines;
         RenderedText = "";
         RenderedConfidence = 0;
     }

--- a/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
@@ -305,7 +305,7 @@ public sealed class RealtimeTranslationSession
         Cleared,
         /// <summary>Read, and the words are the ones already on screen — see TextSimilarity.</summary>
         Unchanged,
-        /// <summary>Read as the same sentence, but less well than the reading already on screen.</summary>
+        /// <summary>Read differently, but no line of it better than the reading already on screen.</summary>
         WorseReading,
         /// <summary>Read, the words are new, and they have been handed to the pump.</summary>
         Translating,
@@ -428,68 +428,68 @@ public sealed class RealtimeTranslationSession
             // the region has genuinely gone quiet and only this branch counts that towards clearing.
             RealtimeFrameDump.SaveUnread(frame, region.Id);
 
-            var shownBefore = state.RenderedText.Length;
+            var shownWhenEmpty = state.RenderedText.Length;
             state.MarkRendered(textBounds, capture, sourceText);
 
             var cleared = state.ShouldClearOverlay;
             if (cleared) pump.Publish(pass, []);
 
             return new PassReading(
-                cleared ? PassOutcome.Cleared : PassOutcome.Empty, ocrMs, 0, 0, shownBefore);
+                cleared ? PassOutcome.Cleared : PassOutcome.Empty, ocrMs, 0, 0, shownWhenEmpty);
         }
 
-        // Close enough to what is already on screen to be the same words read twice. The strips are
-        // still updated — they may have shifted a pixel — but the anchor text deliberately is not:
-        // holding it at what was actually rendered stops a line from drifting away one tolerated
-        // character at a time, which comparing against the previous frame instead would allow.
-        if (TextSimilarity.IsSameContent(sourceText, state.RenderedText))
+        // Line by line against what is on screen: each sentence keeps the better of its own two
+        // readings, and a sentence nothing on screen answers to is simply new. Doing this per pass
+        // instead — one weighted average against another — is what let a correctly read sentence be
+        // thrown away because the line beside it had wobbled; see RealtimeReadingMerge.
+        var merged = RealtimeReadingMerge.Merge(state.RenderedLines, recognized);
+        var shownBefore = state.RenderedText.Length;
+
+        // Whether this pass read the region differently at all, as opposed to reading it the same
+        // way again. Taken before the state is written, because that is what it is a statement about.
+        var reread = !TextSimilarity.IsSameContent(sourceText, state.RenderedText);
+
+        // Nothing the reader can see is different: every line either says what it already said or
+        // was read no better than the version already up. The strips are still updated — they may
+        // have shifted a pixel — but the words and the scores they are defended with deliberately
+        // are not, which stops a line drifting away one tolerated character at a time.
+        if (!merged.Changed)
         {
-            var shownBefore = state.RenderedText.Length;
-            state.MarkRendered(textBounds, capture, state.RenderedText, state.RenderedConfidence);
-            return new PassReading(
-                PassOutcome.Unchanged, ocrMs, recognized.Count, sourceText.Length, shownBefore);
-        }
+            // Only worth a line when a reading was actually turned down; a pass that merely read the
+            // same words again is the ordinary case and says nothing.
+            if (reread)
+                Log.Debug(
+                    "Realtime region {Region} kept the better reading of {Kept} line(s): " +
+                    "shown={Shown:0.00} \"{Old}\" against \"{Text}\"",
+                    region.Id, merged.Kept, state.RenderedConfidence, state.RenderedText, sourceText);
 
-        var confidence = ReadingConfidence(recognized);
-
-        // The same sentence, read differently — a lost space, a run of i/l confusions. Left alone
-        // this replaces a correct translation with a worse one several times per line, which is
-        // most of what "the recognition is unreliable" looks like from the reader's seat: the
-        // overlay was showing the newest reading rather than the best one. So the newer reading has
-        // to be better read than the one on screen before it may take its place.
-        if (TextSimilarity.IsSameSentence(sourceText, state.RenderedText) &&
-            confidence <= state.RenderedConfidence)
-        {
-            var shownBefore = state.RenderedText.Length;
-            state.MarkRendered(textBounds, capture, state.RenderedText, state.RenderedConfidence);
-
-            Log.Debug(
-                "Realtime region {Region} kept the better reading: shown={Shown:0.00} \"{Old}\" " +
-                "beat {New:0.00} \"{Text}\"",
-                region.Id, state.RenderedConfidence, state.RenderedText, confidence, sourceText);
+            state.MarkRendered(textBounds, capture, merged.Lines);
 
             return new PassReading(
-                PassOutcome.WorseReading, ocrMs, recognized.Count, sourceText.Length, shownBefore);
+                reread ? PassOutcome.WorseReading : PassOutcome.Unchanged,
+                ocrMs, recognized.Count, sourceText.Length, shownBefore);
         }
 
         // Recorded as shown before it has been translated, and deliberately: the frame has been
         // read and the words are known, so holding this region's state open until the network
         // answers would only stop the region being watched. A translation that never arrives asks
         // for this record to be undone — see RegionTranslationPump.
-        var shown = state.RenderedText.Length;
-        state.MarkRendered(textBounds, capture, sourceText, confidence);
-        pump.Post(pass, recognized, ocrMs);
+        //
+        // The merged lines rather than the raw reading: a sentence whose re-reading lost keeps the
+        // wording already on screen, which the session has translated once and cached, so carrying
+        // it along with a corrected neighbour costs nothing on the network.
+        state.MarkRendered(textBounds, capture, merged.Lines);
+        pump.Post(pass, merged.Blocks, ocrMs);
+
+        Log.Debug(
+            "Realtime region {Region} redrew {Improved} improved, {Added} new, {Dropped} gone, " +
+            "{Kept} held",
+            region.Id, merged.Improved, merged.Added, merged.Dropped, merged.Kept);
 
         return new PassReading(
-            PassOutcome.Translating, ocrMs, recognized.Count, sourceText.Length, shown);
+            PassOutcome.Translating, ocrMs, recognized.Count, sourceText.Length, shownBefore);
     }
 
-    /// <summary>
-    /// One score for a whole reading, weighted by how much text each line contributes — a long line
-    /// read well should not be outvoted by a stray two-character block beside it.
-    /// </summary>
-    /// <remarks>Lines the engine scored nothing for count as perfectly read, matching the filter,
-    /// which lets a block through when it has no scores to judge it by.</remarks>
     /// <summary>Drops boxes the detector threw across the whole block — see CollapsedDetection.</summary>
     private static List<OcrTextBlock> RejectCollapsedBlocks(
         List<OcrTextBlock> blocks, double blockHeight, int regionId)
@@ -565,21 +565,6 @@ public sealed class RealtimeTranslationSession
         }
 
         return kept ?? blocks;
-    }
-
-    private static double ReadingConfidence(IReadOnlyList<OcrTextBlock> blocks)
-    {
-        double weighted = 0;
-        double weight = 0;
-
-        foreach (var block in blocks)
-        {
-            var characters = Math.Max(1, block.Text.Trim().Length);
-            weighted += (block.Confidence ?? 1.0) * characters;
-            weight += characters;
-        }
-
-        return weight > 0 ? weighted / weight : 0;
     }
 
     private void RaiseRegionUpdated(RealtimeRegionUpdate update) => RegionUpdated?.Invoke(this, update);

--- a/src/OverTranslate/Services/Realtime/TextSimilarity.cs
+++ b/src/OverTranslate/Services/Realtime/TextSimilarity.cs
@@ -98,6 +98,21 @@ internal static class TextSimilarity
         return EditDistanceWithin(left, right, allowed);
     }
 
+    /// <summary>
+    /// Whether two readings say the very same thing, spacing aside — the one comparison here with no
+    /// tolerance in it at all.
+    /// </summary>
+    /// <remarks>
+    /// What <see cref="RealtimeReadingMerge"/> asks to decide whether a line has anything new in it.
+    /// The tolerant comparisons cannot answer that: <c>"weird guitr."</c> and <c>"weird guitar..."</c>
+    /// are three characters apart in forty, well inside what <see cref="IsSameContent"/> forgives,
+    /// and they are also the difference between the reader getting the sentence and not. Tolerance is
+    /// for deciding whether to pay for a translation and whether two readings are of one sentence;
+    /// it is not for deciding whether the better of two readings of that sentence is worth showing.
+    /// </remarks>
+    public static bool IsSameWording(string a, string b) =>
+        ReferenceEquals(a, b) || NormaliseWhitespace(a) == NormaliseWhitespace(b);
+
     public static bool IsSameContent(string a, string b)
     {
         if (ReferenceEquals(a, b)) return true;

--- a/tests/OverTranslate.Tests/RealtimeReadingMergeTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeReadingMergeTests.cs
@@ -1,0 +1,256 @@
+using System.Windows;
+using OverTranslate.Services;
+using OverTranslate.Services.Realtime;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The rule that decides what a fresh reading is allowed to change, and the reason it exists: an
+/// overlay showing the best reading of each sentence rather than the newest one, without rewriting
+/// any sentence more often than the pass-level rule it replaces did.
+/// </summary>
+public class RealtimeReadingMergeTests
+{
+    // The reading that made issue #30: two sentences in frame, the second one finally read correctly
+    // while the first wobbled. As one batch the pass scores lower than what is on screen, so the
+    // correction was thrown away and "guitr" stayed up.
+    private const string FirstLine = "The news did say they were building";
+    private const string WrongSecondLine = "a facility to study that weird guitr.";
+    private const string RightSecondLine = "a facility to study that weird guitar...";
+
+    [Fact]
+    public void ACorrectedSentenceReplacesTheWrongOneEvenWhenItsNeighbourWobbled()
+    {
+        var shown = new List<RenderedLine>
+        {
+            new(FirstLine, 0.98),
+            new(WrongSecondLine, 0.96),
+        };
+
+        var merged = RealtimeReadingMerge.Merge(shown,
+        [
+            Read(FirstLine + "q", 0, 0.90),          // the same sentence, read worse
+            Read(RightSecondLine, 1, 0.99),          // the correction
+        ]);
+
+        Assert.True(merged.Changed);
+        Assert.Equal(1, merged.Improved);
+        Assert.Equal(1, merged.Kept);
+
+        // The corrected sentence is up, and the neighbour kept the better of its own two readings
+        // rather than being dragged down with it.
+        Assert.Equal([FirstLine, RightSecondLine], merged.Blocks.Select(block => block.Text));
+        Assert.Equal([0.98, 0.99], merged.Lines.Select(line => line.Confidence));
+    }
+
+    [Fact]
+    public void ThePassLevelRuleThisReplacesWouldHaveThrownThatCorrectionAway()
+    {
+        // Not a test of the merge, but of why it had to change: the batch this pass read scores no
+        // better than the batch on screen, so a single comparison of the two averages — which is
+        // what the code did before — rejects the whole reading and the correction with it.
+        var shown = new List<RenderedLine> { new(FirstLine, 0.98), new(WrongSecondLine, 0.96) };
+        var read = new List<RenderedLine> { new(FirstLine + "q", 0.90), new(RightSecondLine, 0.99) };
+
+        Assert.True(Weighted(read) <= Weighted(shown));
+    }
+
+    [Fact]
+    public void ASentenceNothingOnScreenAnswersToIsShownHoweverItScored()
+    {
+        // The confidence rule only ever settles an argument between two readings of one sentence. A
+        // new line has no argument to lose, and holding it back for scoring low would be the failure
+        // this whole feature exists to prevent.
+        var merged = RealtimeReadingMerge.Merge(
+            [new RenderedLine("Something else entirely was said here", 0.99)],
+            [Read("A completely different line of dialogue", 0, 0.42)]);
+
+        Assert.True(merged.Changed);
+        Assert.Equal(1, merged.Added);
+        Assert.Equal(1, merged.Dropped);
+        Assert.Equal("A completely different line of dialogue", merged.Blocks[0].Text);
+    }
+
+    [Fact]
+    public void ReadingTheSameWordsAgainChangesNothing()
+    {
+        var shown = new List<RenderedLine> { new(FirstLine, 0.94), new(RightSecondLine, 0.94) };
+
+        var merged = RealtimeReadingMerge.Merge(shown,
+            [Read(FirstLine, 0, 0.97), Read(RightSecondLine, 1, 0.97)]);
+
+        // Same words, so nothing is redrawn — and the score stays at what was actually rendered, so
+        // the line cannot drift away one tolerated character at a time on the back of a higher one.
+        Assert.False(merged.Changed);
+        Assert.Equal(2, merged.Kept);
+        Assert.Equal([0.94, 0.94], merged.Lines.Select(line => line.Confidence));
+    }
+
+    [Fact]
+    public void ALineDroppedByThisPassIsNotHeldOnScreenByItsNeighbour()
+    {
+        var merged = RealtimeReadingMerge.Merge(
+            [new RenderedLine(FirstLine, 0.98), new RenderedLine(RightSecondLine, 0.98)],
+            [Read(FirstLine, 0, 0.90)]);
+
+        Assert.True(merged.Changed);
+        Assert.Equal(1, merged.Dropped);
+        Assert.Single(merged.Blocks);
+    }
+
+    [Fact]
+    public void TwoLinesReadAsOneAreNotMistakenForAReReadingOfEither()
+    {
+        // The detector joining a two-line subtitle into one box is a real change of what is on
+        // screen, not one sentence read differently — pairing it with either half would hold the
+        // other half's translation up beside it.
+        var merged = RealtimeReadingMerge.Merge(
+            [new RenderedLine(FirstLine, 0.98), new RenderedLine(RightSecondLine, 0.98)],
+            [Read(FirstLine + " " + RightSecondLine, 0, 0.95)]);
+
+        Assert.Equal(1, merged.Added);
+        Assert.Equal(2, merged.Dropped);
+        Assert.Equal(0, merged.Kept);
+    }
+
+    [Fact]
+    public void ASentenceThatMovedDownTheFrameIsStillTheSameSentence()
+    {
+        // A new line arriving above pushes everything below it down. Pairing by position alone would
+        // call the moved line new and the new line a re-reading of it, translating both again.
+        var merged = RealtimeReadingMerge.Merge(
+            [new RenderedLine(FirstLine, 0.98)],
+            [Read("Somebody else started speaking", 0, 0.95), Read(FirstLine + "n", 1, 0.80)]);
+
+        Assert.Equal(1, merged.Added);
+        Assert.Equal(1, merged.Kept);
+        Assert.Equal(0, merged.Dropped);
+        Assert.Equal(FirstLine, merged.Blocks[1].Text);
+    }
+
+    [Fact]
+    public void TheSameSentenceTwiceOnScreenKeepsItsOwnReadingEach()
+    {
+        // Exact matches are paired before similar ones, so a duplicated line cannot have its partner
+        // consumed by the copy beside it.
+        var shown = new List<RenderedLine>
+        {
+            new("Are you seriously telling me that", 0.99),
+            new("Are you seriously telling me that", 0.70),
+        };
+
+        var merged = RealtimeReadingMerge.Merge(shown,
+        [
+            Read("Are you seriousIy telling me that", 0, 0.80),   // a re-reading of the first
+            Read("Are you seriously telling me that", 1, 0.75),   // exactly the second
+        ]);
+
+        Assert.Equal(0, merged.Dropped);
+        Assert.Equal(2, merged.Kept);
+
+        // The exact reading paired with the copy it matches exactly, leaving the misread one arguing
+        // with the 0.99 line — which it loses. Had it paired the other way round, 0.80 would have
+        // beaten 0.70 and put "seriousIy" on screen.
+        Assert.All(merged.Blocks, block =>
+            Assert.Equal("Are you seriously telling me that", block.Text));
+    }
+
+    [Fact]
+    public void ReadingsThatOnlyWobbleAtTheSameScoreNeverRewriteAnything()
+    {
+        // The reason the rule this replaces existed at all: a line rewritten every time recognition
+        // wobbles reads far worse than one wrong character. Recognition of an unchanged subtitle
+        // wanders by a character or two at a score that says nothing about which reading is right,
+        // and none of that may reach the screen.
+        var random = new Random(30);
+        var shown = new List<RenderedLine> { new(FirstLine, 0.97), new(RightSecondLine, 0.97) };
+        var rewrites = 0;
+
+        for (var poll = 0; poll < 200; poll++)
+        {
+            // Within MinConfidenceGain of what is up, either side of it — which is where the score
+            // stops telling a better reading from a worse one.
+            var merged = RealtimeReadingMerge.Merge(shown,
+            [
+                Read(Wobble(FirstLine, random), 0, 0.97 + (random.NextDouble() - 0.5) * 0.04),
+                Read(Wobble(RightSecondLine, random), 1, 0.97 + (random.NextDouble() - 0.5) * 0.04),
+            ]);
+
+            for (var i = 0; i < merged.Lines.Count; i++)
+                if (merged.Lines[i].Text != shown[i].Text)
+                    rewrites++;
+
+            shown = [.. merged.Lines];
+        }
+
+        Assert.Equal(0, rewrites);
+    }
+
+    [Fact]
+    public void ASentenceCanOnlyEverBeRewrittenByAScoreThatClimbs()
+    {
+        // What bounds the flicker: every rewrite of one sentence has to clear the last one by
+        // MinConfidenceGain, so a line cannot be redrawn more than a handful of times however long
+        // it stays up, and each redraw is a step towards the best reading rather than the newest.
+        var random = new Random(30);
+        var shown = new List<RenderedLine> { new(FirstLine, 0.80) };
+        var scores = new List<double>();
+
+        for (var poll = 0; poll < 200; poll++)
+        {
+            var merged = RealtimeReadingMerge.Merge(shown,
+                [Read(Wobble(FirstLine, random), 0, 0.80 + random.NextDouble() * 0.20)]);
+
+            if (merged.Lines[0].Text != shown[0].Text) scores.Add(merged.Lines[0].Confidence);
+            shown = [.. merged.Lines];
+        }
+
+        Assert.NotEmpty(scores);
+        Assert.Equal(scores.OrderBy(score => score), scores);
+        for (var i = 1; i < scores.Count; i++)
+            Assert.True(scores[i] > scores[i - 1] + RealtimeReadingMerge.MinConfidenceGain);
+
+        // 200 polls of a sentence being re-read, and the reader saw it change this few times.
+        Assert.True(scores.Count <= 10, $"one sentence was rewritten {scores.Count} times");
+    }
+
+    [Fact]
+    public void ABetterScoreThatIsOnlyBetterByNoiseIsNotEnough()
+    {
+        // Where the engine stops discriminating: measured over five sessions, readings 0.01 apart
+        // step backwards about as often as forwards ("Where have you gone?!" at 0.98 replaced by
+        // "Where have vou gone?!" at 1.00).
+        var merged = RealtimeReadingMerge.Merge(
+            [new RenderedLine("Where have you gone?!", 0.98)],
+            [Read("Where have vou gone?!", 0, 0.99)]);
+
+        Assert.False(merged.Changed);
+        Assert.Equal("Where have you gone?!", merged.Blocks[0].Text);
+    }
+
+    /// <summary>One character read wrong, now and then — what recognition noise looks like.</summary>
+    private static string Wobble(string text, Random random)
+    {
+        if (random.Next(3) == 0) return text;
+
+        var at = random.Next(text.Length);
+        return text[..at] + "l" + text[(at + 1)..];
+    }
+
+    private static double Weighted(List<RenderedLine> lines)
+    {
+        double weighted = 0, weight = 0;
+        foreach (var line in lines)
+        {
+            var characters = Math.Max(1, line.Text.Trim().Length);
+            weighted += line.Confidence * characters;
+            weight += characters;
+        }
+
+        return weight > 0 ? weighted / weight : 0;
+    }
+
+    private static OcrTextBlock Read(string text, int line, double confidence) =>
+        new(text, new Rect(10, 40 + line * 30, 300, 24), Confidence: confidence);
+}


### PR DESCRIPTION
Closes #30

## 問題

「較好的讀取才准上畫面」這條規則是對的，但它比較的是**整個 pass 的加權平均**。同一批裡第二句被
修正、第一句剛好抖了一下，整批就一起被判為 WorseReading —— 單句的修正沒有機會單獨生效。

## 改法

新增 `RealtimeReadingMerge`，把比較粒度降到單句：

- **配對**用文字內容而非位置（先配完全相同的，再配同一句的，同分取位置最近）。上方插入新句把下方
  整批往下推時不會誤判成「全部都是新句」。
- **取捨**：配對到的句子各比各的分數；沒配對到的新句直接上；畫面上沒被配對到的句子視為消失。
- **沿用舊句時**帶的是這次的框、舊的文字與分數 —— 位置會更新，但不會一個容忍字元一個容忍字元地
  漂走。沿用的文字命中翻譯快取，所以「一句修正 + 一句沿用」不會多打網路。

`RealtimeRegionState` 改記 `RenderedLines`（逐句文字＋分數）；`RenderedText` / `RenderedConfidence`
改為推導值，後者現在只給 log 用。pump 的 pass 序號機制未動：仍是一個 pass 一個序號、一次 publish。

## 取捨：這個 PR 增加了畫面重寫次數，請看這裡

用五份真實 session log 重放（3398 個讀到文字的 pass）：

| 規則 | 同一句被重寫 | 畫面重繪 |
|---|---|---|
| 改動前（整個 pass 比較） | 66 | 2552 |
| 本 PR（逐句，需高出 0.02） | 91 | 2654 |

**沒有做到 issue 裡「不得增加畫面覆蓋次數」的字面要求。** 多出來的 25 次攤在 3398 個 pass 上約
每四分鐘一次，抽樣看多數是真的修正（`relly→really`、`șong→song`、`This is nice!ブハ→This is nice!`）。

門檻 `MinConfidenceGain = 0.02` 是量出來的，不是猜的：v6 的分數在 0.98–1.00 之間幾乎沒有分辨力，
不設門檻會出現 `Where have you gone?!`(0.98) 被 `Where have vou gone?!`(1.00) 換掉，重寫次數會衝到
176。往上調到 0.04 可以把重寫壓到 59（低於現況），但 issue 那個 guitar 情境的差距只有 0.03，
會連它一起擋掉 —— 那等於這張單白做。各檔位的實測數字記在 `RealtimeReadingMerge.MinConfidenceGain`
的註解裡，之後要調有依據。

也試過「畫面上那句已經很高分就不動它」，幾乎沒有效果（0.97 上限只從 91 降到 89），已記在同一份註解。

## 測試

- 新增 `RealtimeReadingMergeTests`（11 個）：issue 的 guitar 情境、舊規則會丟掉它的證明、同分噪音
  200 輪不得造成任何重寫、一句只能被爬升的分數重寫、兩行併一行／一行移位不得誤配對、畫面上同一句
  出現兩次時各自守住自己的讀取。
- 既有測試全過（279 個，含字幕 fixture）。
- 已人工實測：字幕連續播放，無明顯閃爍或句子錯位。