### PR TITLE
feat: #35 字幕／遊戲介面改由使用者逐框選擇，並修掉貼邊畫框的辨識懸崖

### DIFF
--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -10,6 +10,21 @@ public class AppSettings
     public uint HotkeyModifiers { get; set; } = 3;
     public uint HotkeyVirtualKey { get; set; } = 0x41;
     public string HotkeyDisplay { get; set; } = "Ctrl+Alt+A";
+
+    /// <summary>
+    /// The shortcut that opens the translation window. Ctrl+Alt+S by default.
+    /// </summary>
+    /// <remarks>
+    /// A convenience, not a headline: unlike the capture shortcut above it is not announced at
+    /// startup and nothing in the interface advertises it, because the window it opens is already
+    /// one click away in the tray. It opens and only opens — pressing it again brings the window
+    /// forward rather than closing it, which is what every other way into this window does.
+    /// </remarks>
+    public uint TranslationWindowHotkeyModifiers { get; set; } = 3;
+
+    public uint TranslationWindowHotkeyVirtualKey { get; set; } = 0x53;
+
+    public string TranslationWindowHotkeyDisplay { get; set; } = "Ctrl+Alt+S";
     public string SourceLanguage { get; set; } = "EN";
     public string TargetLanguage { get; set; } = "ZH-HANT";
     public TranslationProvider Provider { get; set; } = TranslationProvider.Microsoft;

--- a/src/OverTranslate/Services/GlobalHotkey.cs
+++ b/src/OverTranslate/Services/GlobalHotkey.cs
@@ -6,8 +6,26 @@ namespace OverTranslate.Services;
 
 public class GlobalHotkey : IDisposable
 {
-    private const int HOTKEY_ID = 9001;
     private const int WM_HOTKEY = 0x0312;
+
+    /// <summary>
+    /// Identifies this registration to Windows, which keys them per window handle.
+    /// </summary>
+    /// <remarks>
+    /// Every instance needs its own: the application registers more than one combination against
+    /// the same hidden window, and a shared id would have the second registration refused and the
+    /// first one's messages answered by both hooks. The number itself means nothing beyond being
+    /// distinct — see the constants below for the ones in use.
+    /// </remarks>
+    private readonly int _id;
+
+    /// <summary>The screenshot capture shortcut, the application's original and main one.</summary>
+    public const int CaptureId = 9001;
+
+    /// <summary>The shortcut that opens the translation window.</summary>
+    public const int TranslationWindowId = 9002;
+
+    public GlobalHotkey(int id) => _id = id;
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
@@ -29,14 +47,14 @@ public class GlobalHotkey : IDisposable
         _source = HwndSource.FromHwnd(hwnd);
         _source?.AddHook(WndProc);
 
-        _registered = RegisterHotKey(hwnd, HOTKEY_ID, modifiers, virtualKey);
+        _registered = RegisterHotKey(hwnd, _id, modifiers, virtualKey);
     }
 
     public void Unregister()
     {
         if (_registered)
         {
-            UnregisterHotKey(_hwnd, HOTKEY_ID);
+            UnregisterHotKey(_hwnd, _id);
             _registered = false;
         }
         _source?.RemoveHook(WndProc);
@@ -44,7 +62,7 @@ public class GlobalHotkey : IDisposable
 
     private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
     {
-        if (msg == WM_HOTKEY && wParam.ToInt32() == HOTKEY_ID)
+        if (msg == WM_HOTKEY && wParam.ToInt32() == _id)
         {
             HotkeyPressed?.Invoke(this, EventArgs.Empty);
             handled = true;

--- a/src/OverTranslate/Services/Realtime/CollapsedDetection.cs
+++ b/src/OverTranslate/Services/Realtime/CollapsedDetection.cs
@@ -5,14 +5,39 @@ namespace OverTranslate.Services.Realtime;
 /// which the recogniser reads a character or two of nonsense.
 /// </summary>
 /// <remarks>
+/// Both halves of that sentence are tested, and the second half is what makes the first one safe to
+/// use. The block's height is the user's, so a rule that reads only the box's share of it hands the
+/// user's dragging a say in whether correct readings survive: a block drawn tight around one line of
+/// subtitle makes that line 100% of the block, and issue #35 measured 22 of 45 frames read as
+/// nothing that way. Requiring the reading to be short as well costs nothing — the text is already
+/// in hand by the time this runs — and the two populations do not overlap anywhere near the middle:
+/// every collapse on record read "A", "M", "A" or "Yay!", and the sentence the height test alone
+/// threw away was 39 characters of correct English.
+///
+/// What it is worth, from <c>OcrHarness --margin-sweep</c> over 39 real region dumps, scored as the
+/// share of each frame's own best reading:
+///
+/// <code>
+///   margin        height only   + short reading      frames reading nothing
+///   0 (tight)        47.8%          75.3%              20/39  ->  9/39
+///   0.15 lines       70.8%          77.6%              11/39  ->  8/39
+///   0.50 lines       86.4%          85.2%               5/39      5/39
+///   1.50 lines       97.2%          96.9%               1/39      1/39
+/// </code>
+///
+/// The cliff at the tight end loses half its drop and the loose end does not move — the 0.3pp there
+/// is the run-to-run noise of the same sweep. It is not flat yet, and what remains at 0 is issue
+/// #35's second root cause, which no filter can fix: strokes clipped at the block's edge were never
+/// captured.
+///
 /// Measured on a 1226x196 block whose real lines were 88 to 117 pixels tall. Four collapses in one
 /// session returned boxes of 194, 253, 303 and 343 pixels — 99% to 175% of the block's own height —
 /// holding "A", "M" and "A". They do real damage: a one-character reading looks nothing like the
 /// subtitle on screen, so it counts as a new sentence and replaces a correct translation with a
 /// giant A.
 ///
-/// The test is against the block the user drew, and nothing else. An earlier version learned each
-/// region's usual line height and rejected anything far above it, which worked on a block holding
+/// The height test is against the block the user drew, and nothing else. An earlier version learned
+/// each region's usual line height and rejected anything far above it, which worked on a block holding
 /// only subtitles and failed badly on anything else: over a game with a chat log in the corner, the
 /// 13-pixel chat lines taught the region that text is 13 pixels tall, and every 55-pixel subtitle
 /// after that was thrown away as a misdetection. Worse, it could not recover — a rejected line was
@@ -42,6 +67,34 @@ internal static class CollapsedDetection
     /// </remarks>
     public const double MaxShareOfBlockHeight = 0.95;
 
-    public static bool IsCollapsed(double boxHeight, double blockHeight) =>
-        blockHeight > 0 && boxHeight >= blockHeight * MaxShareOfBlockHeight;
+    /// <summary>
+    /// Characters a block-spanning box may hold and still be a collapse rather than a line.
+    /// </summary>
+    /// <remarks>
+    /// Every collapse ever recorded here read four characters or fewer — "A", "M", "A", "Yay!" —
+    /// and the real sentences the height test was throwing away were 39 and 40. Ten sits in that
+    /// gap rather than on either edge of it.
+    ///
+    /// The failure this leaves open is a collapse that reads long: a stretched crop that returns
+    /// "Mainasm ar you lay" would now be kept. That is the cheaper failure by a wide margin. A
+    /// collapse that gets through puts one bad line on screen for one pass, and the next pass
+    /// replaces it; a real sentence rejected never reaches the screen at all, and it is rejected
+    /// every pass it appears in, because what caused it is the shape of the block and the block
+    /// does not change.
+    ///
+    /// Deliberately not <see cref="ShortReadingDetection.ShortTextLength"/>, which happens to be
+    /// the same number. That one separates real short lines from scenery over any box; this
+    /// separates collapses from sentences over a box that already spans the block. Two measurements
+    /// that agree today, not one measurement used twice.
+    /// </remarks>
+    public const int MaxCollapsedReadingLength = 10;
+
+    /// <param name="text">
+    /// What the recogniser read out of the box. Null or empty counts as short: a box thrown across
+    /// the whole block that produced nothing is the same event by the quietest route.
+    /// </param>
+    public static bool IsCollapsed(double boxHeight, double blockHeight, string? text) =>
+        blockHeight > 0
+        && boxHeight >= blockHeight * MaxShareOfBlockHeight
+        && (text?.Trim().Length ?? 0) <= MaxCollapsedReadingLength;
 }

--- a/src/OverTranslate/Services/Realtime/RealtimeBlockMode.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeBlockMode.cs
@@ -1,0 +1,30 @@
+namespace OverTranslate.Services.Realtime;
+
+/// <summary>
+/// What a watched block holds, as the user says it rather than as the block's shape implies it.
+/// </summary>
+/// <remarks>
+/// The two kinds need opposite corrections from the detector — a subtitle strip's glyphs are large
+/// and want downscaling, an interface panel's are already small and want none — so something has to
+/// say which is which. That used to be the block's width-to-height ratio, and the ratio is a
+/// property of how the user happened to drag, not of what they are translating: the same subtitle
+/// drawn 8:1 and drawn 3:1 landed on opposite sides of the threshold and got two different sets of
+/// behaviour.
+///
+/// Measured on one session (2026-08-09 18:33, a 1894x269 block over English subtitles) the guess
+/// was right and nothing was lost — but only because the block never dropped below 7.0. The same
+/// afternoon, blocks drawn over the same video reached 3.33, and there the ratio alone would have
+/// switched every pass to the panel fraction, which this type's own measurements put at a third of
+/// passes reading nothing. Being right depended on how the user dragged.
+///
+/// The user knows what they are looking at and the program does not, so this is asked rather than
+/// inferred. See <see cref="RealtimeDetectorSize"/> for what each mode is worth in detector size.
+/// </remarks>
+public enum RealtimeBlockMode
+{
+    /// <summary>A wide band of dialogue text — film subtitles, captions, a visual novel's text box.</summary>
+    Subtitle,
+
+    /// <summary>An interface panel, a tooltip, an item description — smaller text, chunkier block.</summary>
+    Panel,
+}

--- a/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
@@ -17,8 +17,9 @@ namespace OverTranslate.Services.Realtime;
 ///
 /// The glyphs in those frames are around 60px tall; halving puts them near 30px, which is where the
 /// model was trained. That is why a subtitle strip is read at half scale — but only a strip: an
-/// interface panel holds much smaller text and needs the opposite correction. See
-/// <see cref="StripFraction"/>, <see cref="PanelFraction"/> and <see cref="StripAspectRatio"/>.
+/// interface panel holds much smaller text and needs the opposite correction. Which of the two a
+/// block is comes from <see cref="RealtimeBlockMode"/>, i.e. from the user; see
+/// <see cref="StripFraction"/> and <see cref="PanelFraction"/>.
 ///
 /// None of this reaches the screenshot flow, which asks for no downscale at all and is right to:
 /// its text is interface-sized, already inside the detector's range, and downscaling it would
@@ -83,29 +84,6 @@ internal static class RealtimeDetectorSize
     public const double PanelFraction = 0.68;
 
     /// <summary>
-    /// Width-to-height ratio at or above which a block is treated as a subtitle strip.
-    /// </summary>
-    /// <remarks>
-    /// One fraction cannot serve both shapes, and trying briefly made subtitles much worse: with
-    /// 0.68 applied to everything, a session over a 1432x224 subtitle read nothing on a third of its
-    /// passes and paid for two more inferences each time, while the game panels it was meant to help
-    /// succeeded on 95–98% of theirs.
-    ///
-    /// The two shapes separate cleanly in the blocks users actually draw. From one afternoon's
-    /// sessions:
-    ///
-    /// <code>
-    ///   strips  1432x224  1549x203  1361x139  1856x152  1522x166   ratio 5.8 – 12.2
-    ///   panels  1273x647  1395x636  1380x657  1295x696  1865x1050  ratio  1.8 –  2.9
-    /// </code>
-    ///
-    /// Nothing lands between 2.9 and 5.8, so the threshold sits in the gap rather than on a measured
-    /// edge. A ratio is the right test rather than an absolute height: it says the same thing about
-    /// a block on a 1080p screen and a 4K one.
-    /// </remarks>
-    public const double StripAspectRatio = 4.0;
-
-    /// <summary>
     /// Fractions of the block to fall back to, in the order to try them, when the first size reads
     /// nothing at all.
     /// </summary>
@@ -125,8 +103,8 @@ internal static class RealtimeDetectorSize
     /// Those frames were kept precisely because the shipped pair failed on them, so the sample
     /// cannot say 0.68 is a better first choice than 0.52 — it never saw the frames 0.52 reads
     /// happily. What it does say is that neighbouring fractions land on opposite sides of working,
-    /// which is why the shape rule above picks a starting point rather than one size trying to
-    /// serve everything.
+    /// which is why the mode above picks a starting point rather than one size trying to serve
+    /// everything.
     ///
     /// The fallbacks are still earning their place under PP-OCRv6_det_tiny, on a smaller margin
     /// and for a different reason. Of 84 control frames the old detector read at the primary size,
@@ -136,13 +114,20 @@ internal static class RealtimeDetectorSize
     /// now reads 9 of 15 rather than 4, which is the trigger rate coming down. Rarely used is what
     /// a fallback is supposed to be.
     ///
-    /// The first fallback is whichever shape fraction the rule did not choose: the two fail on
-    /// opposite content, so the rejected one is the best answer for the case where the rule was
-    /// wrong. Native goes last as the only size that can read text too small to survive any
-    /// downscale — it recovered nine lines in a single measured session.
+    /// The first fallback is whichever mode's fraction was not chosen: the two fail on opposite
+    /// content, so the one the mode turned down is the best answer for the case where the mode was
+    /// not the whole story — a subtitle block that also caught a line of interface text, say. Native
+    /// goes last as the only size that can read text too small to survive any downscale — it
+    /// recovered nine lines in a single measured session.
     /// </remarks>
     public const double NativeFraction = 1.0;
 
+    /// <param name="mode">
+    /// What the user says the block holds. This used to be guessed from the block's width-to-height
+    /// ratio, which is a fact about how the user dragged rather than about what they are reading —
+    /// see <see cref="RealtimeBlockMode"/> for what that cost. Issue #35 replaced the guess with
+    /// the question.
+    /// </param>
     /// <param name="primary">Detector input size to read with first.</param>
     /// <param name="fallbacks">
     /// Sizes to try, in order, when a read finds nothing at all — stopping at the first that reads
@@ -150,7 +135,8 @@ internal static class RealtimeDetectorSize
     /// produces it: text too large collapses into one unreadable box, text too small is never
     /// detected, and a scale the model simply dislikes returns nothing.
     /// </param>
-    public static (int Primary, IReadOnlyList<int> Fallbacks) For(int width, int height)
+    public static (int Primary, IReadOnlyList<int> Fallbacks) For(
+        int width, int height, RealtimeBlockMode mode)
     {
         var native = Math.Max(width, height);
 
@@ -158,9 +144,9 @@ internal static class RealtimeDetectorSize
         if (native < HalfScaleMinSide)
             return (native, []);
 
-        // Which shape this is decides where to start; the other shape's fraction is then the first
-        // thing to try if that was wrong.
-        var isStrip = height > 0 && (double)width / height >= StripAspectRatio;
+        // The mode decides where to start; the other mode's fraction is then the first thing to try
+        // if that start read nothing.
+        var isStrip = mode == RealtimeBlockMode.Subtitle;
         var chosen = isStrip ? StripFraction : PanelFraction;
         var other = isStrip ? PanelFraction : StripFraction;
 
@@ -188,8 +174,8 @@ internal static class RealtimeDetectorSize
     /// </code>
     ///
     /// That last 14% is a new line arriving after a quiet stretch — the one nobody can afford to
-    /// miss — so the fallbacks are not dropped there. But within it, the shape rule's other
-    /// fraction rescued 17 of the 23 and native only 6, while native costs 190–220ms against the
+    /// miss — so the fallbacks are not dropped there. But within it, the other mode's fraction
+    /// rescued 17 of the 23 and native only 6, while native costs 190–220ms against the
     /// primary's ~90ms. Dropping it while the region is blank saves about a sixth of a subtitle
     /// session's whole recognition time for about 3.7% of its rescues.
     ///

--- a/src/OverTranslate/Services/Realtime/RealtimeRegion.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeRegion.cs
@@ -10,7 +10,22 @@ namespace OverTranslate.Services.Realtime;
 /// Stable for as long as the block exists, so a result arriving after the user has re-entered edit
 /// mode and rearranged things can be matched to the window it belongs to (or dropped).
 /// </param>
-public sealed record RealtimeRegion(int Id, Rectangle Bounds);
+/// <param name="Mode">
+/// What the user says this block holds. Lives here rather than in the settings file because it
+/// belongs to one block of one session: the same user watches a subtitle strip and a game panel at
+/// once, and the answer is different for each. Defaults to <see cref="RealtimeBlockMode.Subtitle"/>,
+/// which is what the great majority of blocks are.
+/// </param>
+public sealed record RealtimeRegion(
+    int Id, Rectangle Bounds, RealtimeBlockMode Mode = RealtimeBlockMode.Subtitle);
+
+/// <summary>
+/// One block as the user has it arranged, before a session gives it an id — what edit mode hands
+/// back and what the controller keeps between edits, so re-entering edit mode restores the modes
+/// along with the rectangles.
+/// </summary>
+public sealed record RealtimeBlockPlacement(
+    Rectangle Bounds, RealtimeBlockMode Mode = RealtimeBlockMode.Subtitle);
 
 /// <summary>
 /// The translated lines currently showing for one region. An empty list is a real result — it means

--- a/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
@@ -500,7 +500,7 @@ public sealed class RealtimeTranslationSession
         for (var index = 0; index < blocks.Count; index++)
         {
             var block = blocks[index];
-            if (!CollapsedDetection.IsCollapsed(block.Bounds.Height, blockHeight))
+            if (!CollapsedDetection.IsCollapsed(block.Bounds.Height, blockHeight, block.Text))
             {
                 kept?.Add(block);
                 continue;

--- a/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
@@ -337,7 +337,8 @@ public sealed class RealtimeTranslationSession
 
         // Try, not wait: a queued pass would be reading a frame that has already been replaced, and
         // would hold this region's loop shut while it did. Skipping costs one poll.
-        var (primarySize, fallbackSizes) = RealtimeDetectorSize.For(frame.Width, frame.Height);
+        var (primarySize, fallbackSizes) =
+            RealtimeDetectorSize.For(frame.Width, frame.Height, region.Mode);
         var recognized = await _ocr.TryRecognizeAsync(frame, sourceLanguage, primarySize, token);
         if (recognized is null)
         {

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ public partial class MainWindow : Window
     private NotifyIcon? _notifyIcon;
     private TrayMenuWindow? _trayMenu;
     private GlobalHotkey? _hotkey;
+    private GlobalHotkey? _windowHotkey;
     private OverlayWindow? _overlayWindow;
     private ScreenCaptureWindow? _captureWindow;
     private ToolbarWindow? _toolbarWindow;
@@ -76,9 +77,20 @@ public partial class MainWindow : Window
     {
         var settings = SettingsService.Instance.Current;
         var hwnd = new WindowInteropHelper(this).Handle;
-        _hotkey = new GlobalHotkey();
+
+        _hotkey = new GlobalHotkey(GlobalHotkey.CaptureId);
         _hotkey.HotkeyPressed += OnHotkeyPressed;
         _hotkey.Register(hwnd, settings.HotkeyModifiers, settings.HotkeyVirtualKey);
+
+        // Deliberately quiet, unlike the one above: no startup notification and nothing in the
+        // interface naming it. It saves a trip to the tray for a user who already knows it is
+        // there, and a user who does not loses nothing by never finding it.
+        _windowHotkey = new GlobalHotkey(GlobalHotkey.TranslationWindowId);
+        _windowHotkey.HotkeyPressed += OnTranslationWindowHotkeyPressed;
+        _windowHotkey.Register(
+            hwnd,
+            settings.TranslationWindowHotkeyModifiers,
+            settings.TranslationWindowHotkeyVirtualKey);
     }
 
     private void ShowStartupBalloon()
@@ -111,9 +123,18 @@ public partial class MainWindow : Window
         _notifyIcon.ShowBalloonTip(3000);
     }
 
+    /// <summary>
+    /// Rebinds every shortcut, after any one of them has been changed.
+    /// </summary>
+    /// <remarks>
+    /// All of them rather than the one that changed, because the cost is two Win32 calls and the
+    /// alternative is a second entry point that has to be kept in step with which setting the
+    /// settings page happened to write.
+    /// </remarks>
     public void ReRegisterHotkey()
     {
         _hotkey?.Unregister();
+        _windowHotkey?.Unregister();
         RegisterHotkey();
     }
 
@@ -122,6 +143,36 @@ public partial class MainWindow : Window
         {
             if (RefuseWhileRealtimeRuns()) return;
             await RunCaptureSessionAsync();
+        });
+
+    /// <summary>
+    /// Opens the translation window, and during a realtime session brings its layers to the front
+    /// instead — the same two answers the tray icon gives, for the same reasons.
+    /// </summary>
+    /// <remarks>
+    /// It never closes the window: every other way in opens or activates, and a shortcut that also
+    /// dismissed would be the one thing in the application whose meaning depends on what is already
+    /// on screen.
+    ///
+    /// Two states it does nothing in, for opposite reasons.
+    ///
+    /// A realtime session is not one of them. The window is no use during a session, but the
+    /// shortcut is the fastest way to a control bar that something else has covered, so it does
+    /// what the tray icon does and lifts the layers instead.
+    ///
+    /// A capture in progress is. The selection layer, the overlay and the toolbar are a single
+    /// piece of work with its own controls, and dropping a window into the middle of it takes the
+    /// foreground away from a screen the user is in the act of framing or reading. The toolbar has
+    /// a button for everything reachable from there, so nothing is lost by staying out. Silently,
+    /// unlike the capture shortcut's own refusal: that one announces itself because it is the
+    /// feature's main entry point and its silence would read as breakage, while this is a
+    /// convenience nothing advertises and a notification would be more intrusive than the miss.
+    /// </remarks>
+    private void OnTranslationWindowHotkeyPressed(object? sender, EventArgs e) =>
+        Dispatcher.Invoke(() =>
+        {
+            if (HasActiveSession) return;
+            OnTrayLeftClick();
         });
 
     /// <summary>
@@ -775,6 +826,7 @@ public partial class MainWindow : Window
         RealtimeSessionController.Instance.Stop();
         DisposeEscapeHook();
         _hotkey?.Dispose();
+        _windowHotkey?.Dispose();
         if (_notifyIcon != null)
         {
             _notifyIcon.Visible = false;

--- a/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
@@ -3,8 +3,10 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
 using OverTranslate.Services;
+using OverTranslate.Services.Realtime;
 using Button = System.Windows.Controls.Button;
 using Color = System.Windows.Media.Color;
 using Cursor = System.Windows.Input.Cursor;
@@ -39,13 +41,30 @@ public partial class RealtimeEditWindow : Window
     private const double BaseRemoveSize = 22;
     private const double BaseRemoveGap = 6;
 
+    /// <summary>
+    /// Width of one segment of the mode control. Both segments are this wide whichever label is
+    /// longer, because a segmented control whose halves change width as the selection moves reads
+    /// as two buttons rather than as one control with two states.
+    /// </summary>
+    private const double BaseModeSegmentWidth = 62;
+
+    /// <summary>Gap between the mode control's track and the selected pill inside it.</summary>
+    private const double BaseModeInset = 2;
+
     private static readonly SolidColorBrush FrameStroke = Freeze(Color.FromArgb(0xE6, 0x1E, 0x90, 0xD5));
     private static readonly SolidColorBrush FrameFill = Freeze(Color.FromArgb(0x1C, 0x99, 0xC8, 0xF0));
     private static readonly SolidColorBrush HandleFill = Freeze(Color.FromRgb(0xFF, 0xFF, 0xFF));
     private static readonly SolidColorBrush RemoveForeground = Freeze(Color.FromRgb(0xFF, 0xFF, 0xFF));
 
+    // The mode control floats over whatever is playing underneath, so its own surface has to carry
+    // the contrast: a near-opaque dark track, and a hairline along the top edge in place of the
+    // light a real material would catch. Anything lighter stops being legible over a bright scene.
+    private static readonly SolidColorBrush ModeTrack = Freeze(Color.FromArgb(0xD8, 0x1C, 0x1C, 0x1E));
+    private static readonly SolidColorBrush ModeTrackEdge = Freeze(Color.FromArgb(0x2E, 0xFF, 0xFF, 0xFF));
+    private static readonly SolidColorBrush ModeIdleForeground = Freeze(Color.FromArgb(0x99, 0xFF, 0xFF, 0xFF));
+
     private readonly System.Drawing.Rectangle _physBounds;
-    private readonly IReadOnlyList<System.Drawing.Rectangle> _initialBlocks;
+    private readonly IReadOnlyList<RealtimeBlockPlacement> _initialBlocks;
     private readonly int _maxBlocks;
     private readonly List<BlockVisual> _blocks = [];
 
@@ -59,13 +78,15 @@ public partial class RealtimeEditWindow : Window
     private double _handleSize = BaseHandleSize;
     private double _removeSize = BaseRemoveSize;
     private double _removeGap = BaseRemoveGap;
+    private double _modeSegmentWidth = BaseModeSegmentWidth;
+    private double _modeInset = BaseModeInset;
 
     private Point _drawOrigin;
     private Shape? _drawPreview;
 
     public RealtimeEditWindow(
         System.Drawing.Rectangle physBounds,
-        IReadOnlyList<System.Drawing.Rectangle> initialBlocks,
+        IReadOnlyList<RealtimeBlockPlacement> initialBlocks,
         int maxBlocks)
     {
         InitializeComponent();
@@ -85,7 +106,7 @@ public partial class RealtimeEditWindow : Window
             ApplyScreenScale();
 
             foreach (var block in _initialBlocks)
-                AddBlock(ToCanvas(block), notify: false);
+                AddBlock(ToCanvas(block.Bounds), block.Mode, notify: false);
 
             RaiseBlocksChanged();
         };
@@ -100,8 +121,9 @@ public partial class RealtimeEditWindow : Window
     public int BlockCount => _blocks.Count;
 
     /// <summary>The current blocks in physical screen pixels, ready to be watched.</summary>
-    public IReadOnlyList<System.Drawing.Rectangle> GetPhysicalBlocks() =>
-        [.. _blocks.Select(block => ToPhysical(block.Bounds))];
+    public IReadOnlyList<RealtimeBlockPlacement> GetPhysicalBlocks() =>
+        [.. _blocks.Select(block =>
+            new RealtimeBlockPlacement(ToPhysical(block.Bounds), block.ModeControl.Value))];
 
     protected override void OnSourceInitialized(EventArgs e)
     {
@@ -130,6 +152,8 @@ public partial class RealtimeEditWindow : Window
         _handleSize = BaseHandleSize * _uiScale;
         _removeSize = BaseRemoveSize * _uiScale;
         _removeGap = BaseRemoveGap * _uiScale;
+        _modeSegmentWidth = BaseModeSegmentWidth * _uiScale;
+        _modeInset = BaseModeInset * _uiScale;
     }
 
     // ── Drawing a new block ──────────────────────────────────────────────────────────────────────
@@ -197,7 +221,10 @@ public partial class RealtimeEditWindow : Window
         // A click, or a slip of the hand, should not leave a useless sliver behind.
         if (box.Width < _minBlockWidth || box.Height < _minBlockHeight) return;
 
-        AddBlock(box, notify: true);
+        // Subtitle is the default because it is what nearly every block is, and because it is the
+        // cheaper mistake: the other mode's fraction is the first fallback either way, so a panel
+        // left on 字幕 costs one extra inference rather than a block that reads nothing.
+        AddBlock(box, RealtimeBlockMode.Subtitle, notify: true);
     }
 
     // Capture lost to something else entirely (an Alt+Tab, another window taking it). The drag is
@@ -229,9 +256,10 @@ public partial class RealtimeEditWindow : Window
 
     // ── Blocks ───────────────────────────────────────────────────────────────────────────────────
 
-    private void AddBlock(Rect bounds, bool notify)
+    private void AddBlock(Rect bounds, RealtimeBlockMode mode, bool notify)
     {
-        var visual = new BlockVisual(bounds, _handleSize, _removeSize, _uiScale);
+        var visual = new BlockVisual(
+            bounds, mode, _handleSize, _removeSize, _modeSegmentWidth, _modeInset, _uiScale);
 
         visual.Body.DragDelta += (_, e) => Move(visual, e.HorizontalChange, e.VerticalChange);
         visual.Remove.Click += (_, e) =>
@@ -239,6 +267,7 @@ public partial class RealtimeEditWindow : Window
             e.Handled = true;   // must not fall through and start drawing a new block underneath
             RemoveBlock(visual);
         };
+        visual.ModeControl.SelectionChanged += (_, _) => RaiseBlocksChanged();
 
         for (int corner = 0; corner < visual.Corners.Length; corner++)
         {
@@ -274,6 +303,7 @@ public partial class RealtimeEditWindow : Window
             foreach (var corner in block.Corners)
                 BlockCanvas.Children.Add(corner);
             BlockCanvas.Children.Add(block.Remove);
+            BlockCanvas.Children.Add(block.ModeControl);
         }
 
         foreach (var block in _blocks)
@@ -336,6 +366,21 @@ public partial class RealtimeEditWindow : Window
             removeLeft = bounds.Right - _removeSize - _removeGap;
         Canvas.SetLeft(visual.Remove, removeLeft);
         Canvas.SetTop(visual.Remove, Math.Max(0, bounds.Top));
+
+        // Above the block's top-left corner: it reads as a label on the block without covering the
+        // content being framed, and it is the far corner from the remove button — the two are one
+        // click apart otherwise, and one of them destroys the block. Tucked inside the top edge when
+        // the block is against the top of the screen, which is where a subtitle strip often is.
+        double modeTop = bounds.Top - _removeSize - _removeGap;
+        if (modeTop < 0) modeTop = Math.Min(bounds.Top + _removeGap, BlockCanvas.ActualHeight - _removeSize);
+
+        // Kept whole rather than allowed to run off the side: this is the control that says what the
+        // block is, and half of it off-screen says nothing.
+        double modeLeft = Math.Clamp(
+            bounds.Left, 0, Math.Max(0, BlockCanvas.ActualWidth - visual.ModeControl.TrackWidth));
+
+        Canvas.SetLeft(visual.ModeControl, modeLeft);
+        Canvas.SetTop(visual.ModeControl, Math.Max(0, modeTop));
     }
 
     private void PlaceHandle(Thumb handle, double centreX, double centreY)
@@ -377,7 +422,14 @@ public partial class RealtimeEditWindow : Window
         private static readonly Cursor[] CornerCursors =
             [Cursors.SizeNWSE, Cursors.SizeNESW, Cursors.SizeNESW, Cursors.SizeNWSE];
 
-        public BlockVisual(Rect bounds, double handleSize, double removeSize, double uiScale)
+        public BlockVisual(
+            Rect bounds,
+            RealtimeBlockMode mode,
+            double handleSize,
+            double removeSize,
+            double modeSegmentWidth,
+            double modeInset,
+            double uiScale)
         {
             Bounds = bounds;
 
@@ -403,12 +455,17 @@ public partial class RealtimeEditWindow : Window
                 ToolTip = "移除此區塊",
                 Template = BuildRemoveTemplate(removeSize, uiScale),
             };
+
+            ModeControl = new ModeSegments(mode, removeSize, modeSegmentWidth, modeInset, uiScale);
         }
 
         public Rect Bounds { get; set; }
         public Thumb Body { get; }
         public Thumb[] Corners { get; }
         public Button Remove { get; }
+
+        /// <summary>What the user says this block holds — see <see cref="RealtimeBlockMode"/>.</summary>
+        public ModeSegments ModeControl { get; }
 
         private static ControlTemplate BuildFrameTemplate(double uiScale)
         {
@@ -456,5 +513,213 @@ public partial class RealtimeEditWindow : Window
 
             return new ControlTemplate(typeof(Button)) { VisualTree = chip };
         }
+    }
+
+    /// <summary>
+    /// The per-block mode control: both choices always on screen, the selected one filled in.
+    /// </summary>
+    /// <remarks>
+    /// A two-state chip that flips when clicked would be smaller, and it was tried first. It reads
+    /// badly for this job in two ways: a chip labelled only with its state reads equally well as a
+    /// state and as an action, and the two readings are opposites; and with several blocks on screen
+    /// there is no way to see that a choice exists at all, let alone what the other option is. Both
+    /// segments being visible answers "what is this block?" and "what else could it be?" at a glance,
+    /// and switching is one click rather than read-then-flip.
+    ///
+    /// Everything here is built in code rather than as a template because the whole edit layer is —
+    /// see <see cref="BlockVisual"/> — and because the pill has to be animated by hand: the control
+    /// floats over content the user is still watching, so it has to settle rather than jump.
+    /// </remarks>
+    private sealed class ModeSegments : Border
+    {
+        // Response, not duration, in the sense the motion is designed for: long enough to be seen
+        // as one thing moving rather than two things swapping, short enough that a second click
+        // never queues up behind it. Eased out with no overshoot — nothing was thrown here, a
+        // button was pressed, and a bounce would be motion the gesture did not pay for.
+        private static readonly Duration SlideDuration = new(TimeSpan.FromMilliseconds(260));
+
+        // Feedback on press has to be immediate or the control feels dead, so this is short enough
+        // to read as instant while still being a movement rather than a jump.
+        private static readonly Duration PressDuration = new(TimeSpan.FromMilliseconds(100));
+
+        private const double PressedScale = 0.97;
+
+        private readonly TranslateTransform _pillOffset = new();
+        private readonly ScaleTransform _pressScale = new(1, 1);
+        private readonly Border[] _segments;
+        private readonly TextBlock[] _labels;
+        private readonly double _segmentWidth;
+
+        // Which segment the pointer went down on, or -1. The click is committed on release and only
+        // if the pointer is still over that segment, so a press the user thought better of can be
+        // taken back by sliding off it — the same forgiveness every other button on the desktop has.
+        private int _pressedSegment = -1;
+
+        public ModeSegments(
+            RealtimeBlockMode mode, double height, double segmentWidth, double inset, double uiScale)
+        {
+            Value = mode;
+            _segmentWidth = segmentWidth;
+            TrackWidth = segmentWidth * 2 + inset * 2;
+
+            Width = TrackWidth;
+            Height = height;
+            CornerRadius = new CornerRadius(height / 2);
+            Background = ModeTrack;
+            BorderBrush = ModeTrackEdge;
+            BorderThickness = new Thickness(0, 1 * uiScale, 0, 0);
+            Effect = new DropShadowEffect
+            {
+                BlurRadius = 8 * uiScale, ShadowDepth = 0, Opacity = 0.4, Color = Colors.Black
+            };
+
+            // Scaled about its own centre so the press reads as the control being pushed, not as it
+            // sliding towards a corner.
+            RenderTransformOrigin = new Point(0.5, 0.5);
+            RenderTransform = _pressScale;
+
+            var pill = new Border
+            {
+                Width = segmentWidth,
+                Height = height - inset * 2,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(inset, 0, 0, 0),
+                CornerRadius = new CornerRadius((height - inset * 2) / 2),
+                Background = FrameStroke,
+                RenderTransform = _pillOffset,
+            };
+
+            _labels = [BuildLabel("字幕", uiScale), BuildLabel("遊戲介面", uiScale)];
+            _segments =
+            [
+                BuildSegment(_labels[0], segmentWidth, "整條字幕、對話框——文字大，讀取時會縮小"),
+                BuildSegment(_labels[1], segmentWidth, "遊戲面板、物品說明——文字小，讀取時不縮小"),
+            ];
+
+            var row = new StackPanel
+            {
+                Orientation = System.Windows.Controls.Orientation.Horizontal,
+                Margin = new Thickness(inset, 0, inset, 0),
+            };
+            foreach (var segment in _segments) row.Children.Add(segment);
+
+            // The pill goes in first so the labels sit on top of it; a label the pill slid over
+            // would otherwise disappear underneath it halfway through the move.
+            var stack = new Grid();
+            stack.Children.Add(pill);
+            stack.Children.Add(row);
+            Child = stack;
+
+            for (var index = 0; index < _segments.Length; index++)
+            {
+                var segment = _segments[index];
+                var picked = index;
+
+                segment.MouseLeftButtonDown += (_, e) =>
+                {
+                    // Must not fall through to the canvas underneath, which would take this as the
+                    // start of a new block being drawn.
+                    e.Handled = true;
+                    _pressedSegment = picked;
+                    segment.CaptureMouse();
+                    SetPressed(true);
+                };
+                segment.MouseLeftButtonUp += (_, e) =>
+                {
+                    e.Handled = true;
+                    var commit = _pressedSegment == picked && segment.IsMouseOver;
+                    _pressedSegment = -1;
+                    segment.ReleaseMouseCapture();
+                    SetPressed(false);
+                    if (commit) Select(picked == 0 ? RealtimeBlockMode.Subtitle : RealtimeBlockMode.Panel);
+                };
+
+                // Dragged off and back on again while held: the press follows the pointer, so the
+                // control keeps saying what releasing right now would do.
+                segment.MouseEnter += (_, _) => { if (_pressedSegment == picked) SetPressed(true); };
+                segment.MouseLeave += (_, _) => { if (_pressedSegment == picked) SetPressed(false); };
+            }
+
+            ApplySelection(animate: false);
+        }
+
+        /// <summary>Raised when the user picks the mode this block is not already on.</summary>
+        public event EventHandler? SelectionChanged;
+
+        public RealtimeBlockMode Value { get; private set; }
+
+        /// <summary>Full width of the control, so the caller can keep all of it on screen.</summary>
+        public double TrackWidth { get; }
+
+        private void Select(RealtimeBlockMode mode)
+        {
+            if (mode == Value) return;
+
+            Value = mode;
+            ApplySelection(animate: true);
+            SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void ApplySelection(bool animate)
+        {
+            var selected = Value == RealtimeBlockMode.Subtitle ? 0 : 1;
+            for (var index = 0; index < _labels.Length; index++)
+                _labels[index].Foreground = index == selected ? RemoveForeground : ModeIdleForeground;
+
+            Move(_pillOffset, TranslateTransform.XProperty, selected * _segmentWidth, SlideDuration, animate);
+        }
+
+        private void SetPressed(bool pressed)
+        {
+            var target = pressed ? PressedScale : 1.0;
+            Move(_pressScale, ScaleTransform.ScaleXProperty, target, PressDuration, animate: true);
+            Move(_pressScale, ScaleTransform.ScaleYProperty, target, PressDuration, animate: true);
+        }
+
+        /// <summary>
+        /// Animates one transform property to a new value, from wherever it is on screen right now.
+        /// </summary>
+        /// <remarks>
+        /// The animation is given a target and no start, which is what makes a second click part way
+        /// through the first one's movement continue from where the pill actually is rather than
+        /// jumping back to where it started. Skipped entirely when the desktop has animation turned
+        /// off, and then the property is cleared first — an animation left in place would otherwise
+        /// hold the value it finished on and ignore everything set afterwards.
+        /// </remarks>
+        private static void Move(
+            Transform transform, DependencyProperty property, double to, Duration duration, bool animate)
+        {
+            if (!animate || !SystemParameters.ClientAreaAnimation)
+            {
+                transform.BeginAnimation(property, null);
+                transform.SetValue(property, to);
+                return;
+            }
+
+            transform.BeginAnimation(property, new DoubleAnimation(to, duration)
+            {
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+            });
+        }
+
+        private static TextBlock BuildLabel(string text, double uiScale) => new()
+        {
+            Text = text,
+            FontSize = 11.0 * uiScale,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+
+        // Transparent rather than unset: a null background is not hit-testable, and the segment is
+        // the thing being clicked.
+        private static Border BuildSegment(TextBlock label, double width, string tip) => new()
+        {
+            Width = width,
+            Background = System.Windows.Media.Brushes.Transparent,
+            Cursor = Cursors.Hand,
+            ToolTip = tip,
+            Child = label,
+        };
     }
 }

--- a/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
@@ -46,10 +46,43 @@ public partial class RealtimeEditWindow : Window
     /// longer, because a segmented control whose halves change width as the selection moves reads
     /// as two buttons rather than as one control with two states.
     /// </summary>
-    private const double BaseModeSegmentWidth = 62;
+    private const double BaseModeSegmentWidth = 82;
+
+    /// <summary>
+    /// Height of the mode control, deliberately larger than the remove button beside it.
+    /// </summary>
+    /// <remarks>
+    /// The two are not peers. The remove button is a single glyph the user aims at and clicks; this
+    /// carries two words that have to be read at a glance, off a surface floating over moving
+    /// picture, before the user has decided anything. Matching the smaller of the two made it look
+    /// like a second piece of window furniture rather than the question it is.
+    /// </remarks>
+    private const double BaseModeHeight = 30;
 
     /// <summary>Gap between the mode control's track and the selected pill inside it.</summary>
     private const double BaseModeInset = 2;
+
+    private const double BaseModeFontSize = 13.5;
+
+    /// <summary>
+    /// Width of the guidance plate under the mode control, and with it how the sentence wraps.
+    /// </summary>
+    /// <remarks>
+    /// Fixed rather than sized to whichever sentence is showing: the two modes' guidance is a
+    /// different length, and a plate that resized as the selection moved would make choosing a mode
+    /// look like it had rearranged the screen.
+    ///
+    /// The number is the one that puts each sentence on a single line at
+    /// <see cref="BaseHintFontSize"/> — measured, not chosen: both are fifty characters and both
+    /// lay out at 640 points, so this is that plus the padding and a little slack for a machine
+    /// whose font metrics differ. One line rather than two because a sentence read in one sweep is
+    /// read; the plate is wider for it but shorter, and it hangs over content the user is trying to
+    /// see. Worth re-measuring if either sentence is ever edited — the text still wraps rather than
+    /// clips if it outgrows this, so the failure is a taller plate and not a lost half-sentence.
+    /// </remarks>
+    private const double BaseHintWidth = 680;
+
+    private const double BaseHintFontSize = 13;
 
     private static readonly SolidColorBrush FrameStroke = Freeze(Color.FromArgb(0xE6, 0x1E, 0x90, 0xD5));
     private static readonly SolidColorBrush FrameFill = Freeze(Color.FromArgb(0x1C, 0x99, 0xC8, 0xF0));
@@ -79,7 +112,9 @@ public partial class RealtimeEditWindow : Window
     private double _removeSize = BaseRemoveSize;
     private double _removeGap = BaseRemoveGap;
     private double _modeSegmentWidth = BaseModeSegmentWidth;
+    private double _modeHeight = BaseModeHeight;
     private double _modeInset = BaseModeInset;
+    private double _hintWidth = BaseHintWidth;
 
     private Point _drawOrigin;
     private Shape? _drawPreview;
@@ -153,7 +188,9 @@ public partial class RealtimeEditWindow : Window
         _removeSize = BaseRemoveSize * _uiScale;
         _removeGap = BaseRemoveGap * _uiScale;
         _modeSegmentWidth = BaseModeSegmentWidth * _uiScale;
+        _modeHeight = BaseModeHeight * _uiScale;
         _modeInset = BaseModeInset * _uiScale;
+        _hintWidth = BaseHintWidth * _uiScale;
     }
 
     // ── Drawing a new block ──────────────────────────────────────────────────────────────────────
@@ -259,7 +296,8 @@ public partial class RealtimeEditWindow : Window
     private void AddBlock(Rect bounds, RealtimeBlockMode mode, bool notify)
     {
         var visual = new BlockVisual(
-            bounds, mode, _handleSize, _removeSize, _modeSegmentWidth, _modeInset, _uiScale);
+            bounds, mode, _handleSize, _removeSize,
+            _modeSegmentWidth, _modeHeight, _modeInset, _hintWidth, _removeGap, _uiScale);
 
         visual.Body.DragDelta += (_, e) => Move(visual, e.HorizontalChange, e.VerticalChange);
         visual.Remove.Click += (_, e) =>
@@ -371,17 +409,36 @@ public partial class RealtimeEditWindow : Window
         // content being framed, and it is the far corner from the remove button — the two are one
         // click apart otherwise, and one of them destroys the block. Tucked inside the top edge when
         // the block is against the top of the screen, which is where a subtitle strip often is.
-        double modeTop = bounds.Top - _removeSize - _removeGap;
-        if (modeTop < 0) modeTop = Math.Min(bounds.Top + _removeGap, BlockCanvas.ActualHeight - _removeSize);
+        // Above the block by preference, below it when there is no room up there, and only inside it
+        // as a last resort. The order matters more than it did when this was a single chip: the
+        // guidance makes this tall enough that putting it inside covers a good part of what the user
+        // is trying to frame, so anywhere outside the block beats anywhere inside it.
+        var mode = visual.ModeControl;
+        double modeTop = bounds.Top - mode.TotalHeight - _removeGap;
+        if (modeTop < 0)
+        {
+            double below = bounds.Bottom + _removeGap;
+            modeTop = below + mode.TotalHeight <= BlockCanvas.ActualHeight
+                ? below
+                : Math.Min(bounds.Top + _removeGap, BlockCanvas.ActualHeight - mode.TotalHeight);
+        }
 
         // Kept whole rather than allowed to run off the side: this is the control that says what the
-        // block is, and half of it off-screen says nothing.
+        // block is and how to draw it, and half of it off-screen says neither.
         double modeLeft = Math.Clamp(
-            bounds.Left, 0, Math.Max(0, BlockCanvas.ActualWidth - visual.ModeControl.TrackWidth));
+            bounds.Left, 0, Math.Max(0, BlockCanvas.ActualWidth - mode.TotalWidth));
 
-        Canvas.SetLeft(visual.ModeControl, modeLeft);
-        Canvas.SetTop(visual.ModeControl, Math.Max(0, modeTop));
+        // Snapped to whole device pixels, because this one carries text. The block itself is placed
+        // wherever the pointer left it and is right to be; a plate of 13-point CJK starting half way
+        // across a pixel is soft for the whole time it is on screen, and UseLayoutRounding inside the
+        // control cannot correct an origin that is already on a half pixel.
+        Canvas.SetLeft(visual.ModeControl, SnapToPixels(modeLeft, _dpiX));
+        Canvas.SetTop(visual.ModeControl, SnapToPixels(Math.Max(0, modeTop), _dpiY));
     }
+
+    // Canvas coordinates are this window's device-independent units; a device pixel is 1/dpi of one.
+    private static double SnapToPixels(double position, double dpi) =>
+        dpi > 0 ? Math.Round(position * dpi) / dpi : position;
 
     private void PlaceHandle(Thumb handle, double centreX, double centreY)
     {
@@ -428,7 +485,10 @@ public partial class RealtimeEditWindow : Window
             double handleSize,
             double removeSize,
             double modeSegmentWidth,
+            double modeHeight,
             double modeInset,
+            double hintWidth,
+            double gap,
             double uiScale)
         {
             Bounds = bounds;
@@ -456,7 +516,8 @@ public partial class RealtimeEditWindow : Window
                 Template = BuildRemoveTemplate(removeSize, uiScale),
             };
 
-            ModeControl = new ModeSegments(mode, removeSize, modeSegmentWidth, modeInset, uiScale);
+            ModeControl = new ModeSegments(
+                mode, modeHeight, modeSegmentWidth, modeInset, hintWidth, gap, uiScale);
         }
 
         public Rect Bounds { get; set; }
@@ -515,8 +576,10 @@ public partial class RealtimeEditWindow : Window
         }
     }
 
+
     /// <summary>
-    /// The per-block mode control: both choices always on screen, the selected one filled in.
+    /// The per-block mode control: both choices always on screen, the selected one filled in, and
+    /// under it the guidance for drawing a block of that kind.
     /// </summary>
     /// <remarks>
     /// A two-state chip that flips when clicked would be smaller, and it was tried first. It reads
@@ -526,11 +589,29 @@ public partial class RealtimeEditWindow : Window
     /// segments being visible answers "what is this block?" and "what else could it be?" at a glance,
     /// and switching is one click rather than read-then-flip.
     ///
+    /// The guidance sits under the control rather than beside it, both hard against the same left
+    /// edge, so the pair reads as one column starting at the block's corner. It lives here rather
+    /// than in the settings screen or a first-run tip because this is the one moment it can be acted
+    /// on: the user is holding the block. Issue #35 measured what its two halves are worth — a
+    /// subtitle framed against its own text lost 20 of 39 frames to the collapse filter, and one
+    /// framed too narrowly reads "bury steak!" for "Salisbury steak!" — and neither is something the
+    /// program can correct afterwards or the user can guess at.
+    ///
     /// Everything here is built in code rather than as a template because the whole edit layer is —
     /// see <see cref="BlockVisual"/> — and because the pill has to be animated by hand: the control
     /// floats over content the user is still watching, so it has to settle rather than jump.
+    ///
+    /// ON THE TEXT LOOKING SOFT. This window is layered (<c>AllowsTransparency</c>), and WPF turns
+    /// ClearType off for the whole of a layered window — every glyph here is greyscale antialiased
+    /// and no setting changes that. What is left is worth doing and is done below: the drop shadows
+    /// are drawn on their own layer rather than on an ancestor of the text, because an Effect pushes
+    /// everything beneath it through an intermediate surface; the text is formatted in Display mode,
+    /// which snaps stems to whole pixels at the small sizes used here; and the control rounds its own
+    /// layout, while the canvas rounds the position it is placed at, so the first glyph starts on the
+    /// pixel grid instead of half way across one — the same fix AboutOverlay's card carries, for the
+    /// same reason.
     /// </remarks>
-    private sealed class ModeSegments : Border
+    private sealed class ModeSegments : StackPanel
     {
         // Response, not duration, in the sense the motion is designed for: long enough to be seen
         // as one thing moving rather than two things swapping, short enough that a second click
@@ -538,16 +619,65 @@ public partial class RealtimeEditWindow : Window
         // button was pressed, and a bounce would be motion the gesture did not pay for.
         private static readonly Duration SlideDuration = new(TimeSpan.FromMilliseconds(260));
 
+        // The guidance does not move when the mode changes, it is replaced — so it crosses over
+        // rather than sliding, and faster than the pill, because a sentence that is still fading
+        // while the user starts reading it is worse than one that was simply there.
+        private static readonly Duration HintFadeDuration = new(TimeSpan.FromMilliseconds(140));
+
         // Feedback on press has to be immediate or the control feels dead, so this is short enough
         // to read as instant while still being a movement rather than a jump.
         private static readonly Duration PressDuration = new(TimeSpan.FromMilliseconds(100));
 
-        private const double PressedScale = 0.97;
+        // Pressing lights the segment rather than shrinking the control, and that is a rendering
+        // decision as much as a design one. A scale on the track is a transform over text, and WPF
+        // drops pixel snapping the moment it believes text is animating, then ramps it back over
+        // about a second — so every press would leave both labels soft for a beat afterwards (see
+        // ShellWindow.AnimateContentIn, which pays a bitmap cache to avoid exactly that). Lighting
+        // the segment also says which of the two is being pressed, which a scale of the whole
+        // control cannot.
+        private static readonly SolidColorBrush PressHighlight =
+            Freeze(Color.FromArgb(0x2E, 0xFF, 0xFF, 0xFF));
+
+        /// <summary>
+        /// One step up from regular, for the guidance — a paragraph of small text on a translucent
+        /// surface over moving picture, which needs the weight to stay readable.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not Medium, which is what "a little heavier" would normally mean. This text
+        /// is Chinese and falls back to Microsoft JhengHei UI, which ships Regular and Bold and
+        /// nothing between: measured on this sentence at 13pt, Medium renders identically to Regular
+        /// (17.47% ink) because 500 matches back to the 400 face, while SemiBold renders identically
+        /// to Bold (21.97%) because 600 matches forward to the 700 one. There is no half step to
+        /// pick, and this is the same one the rest of the application uses to emphasise (see
+        /// SectionHeader in SharedStyles).
+        ///
+        /// The two mode labels do NOT take it, and the same measurement is why. Weight buys
+        /// readability by thickening strokes, and it costs the gaps between them — which is a good
+        /// trade over a sentence of ordinary characters and a bad one over 字幕 and 遊戲介面, where
+        /// 遊, 戲 and 幕 carry twelve to seventeen strokes each and close up into a blot at this
+        /// size. Those two words are also not the ones needing help to be found: one sits in white
+        /// on a saturated pill and the other is the only other thing on the track.
+        /// </remarks>
+        private static readonly FontWeight HeavierOverPicture = FontWeights.SemiBold;
+
+        /// <summary>
+        /// How to draw a block of each kind. Named for what the user does, not for what the
+        /// recogniser then does with it: the reasons live in <see cref="RealtimeDetectorSize"/> and
+        /// <see cref="CollapsedDetection"/>, and neither is something to explain over a paused game.
+        /// </summary>
+        private const string SubtitleHint =
+            "框選時，上下約留半個至一個字的空間，避免貼齊文字；" +
+            "左右可適度放寬，但不要框入過多空白範圍，避免雜訊。";
+
+        private const string PanelHint =
+            "框選時，需翻譯的區域請保留一些空間，避免貼齊內容；" +
+            "若畫面有多個區域則建議分開框選，避免辨識速度過慢。";
 
         private readonly TranslateTransform _pillOffset = new();
-        private readonly ScaleTransform _pressScale = new(1, 1);
         private readonly Border[] _segments;
+        private readonly Border[] _highlights;
         private readonly TextBlock[] _labels;
+        private readonly TextBlock[] _hints;
         private readonly double _segmentWidth;
 
         // Which segment the pointer went down on, or -1. The click is committed on release and only
@@ -556,27 +686,26 @@ public partial class RealtimeEditWindow : Window
         private int _pressedSegment = -1;
 
         public ModeSegments(
-            RealtimeBlockMode mode, double height, double segmentWidth, double inset, double uiScale)
+            RealtimeBlockMode mode,
+            double height,
+            double segmentWidth,
+            double inset,
+            double hintWidth,
+            double gap,
+            double uiScale)
         {
             Value = mode;
             _segmentWidth = segmentWidth;
-            TrackWidth = segmentWidth * 2 + inset * 2;
 
-            Width = TrackWidth;
-            Height = height;
-            CornerRadius = new CornerRadius(height / 2);
-            Background = ModeTrack;
-            BorderBrush = ModeTrackEdge;
-            BorderThickness = new Thickness(0, 1 * uiScale, 0, 0);
-            Effect = new DropShadowEffect
-            {
-                BlurRadius = 8 * uiScale, ShadowDepth = 0, Opacity = 0.4, Color = Colors.Black
-            };
+            Orientation = System.Windows.Controls.Orientation.Vertical;
+            HorizontalAlignment = HorizontalAlignment.Left;
 
-            // Scaled about its own centre so the press reads as the control being pushed, not as it
-            // sliding towards a corner.
-            RenderTransformOrigin = new Point(0.5, 0.5);
-            RenderTransform = _pressScale;
+            // Sizes here are base units times a monitor scale, so most of them land on fractions of
+            // a pixel. Rounded, the plate edges and the text inside them start on whole pixels.
+            UseLayoutRounding = true;
+
+            var trackWidth = segmentWidth * 2 + inset * 2;
+            var radius = height / 2;
 
             var pill = new Border
             {
@@ -591,10 +720,18 @@ public partial class RealtimeEditWindow : Window
             };
 
             _labels = [BuildLabel("字幕", uiScale), BuildLabel("遊戲介面", uiScale)];
+
+            // Rounded on the outer end only, so a press on either half stays inside the capsule.
+            _highlights =
+            [
+                BuildHighlight(new CornerRadius(radius, 0, 0, radius), inset),
+                BuildHighlight(new CornerRadius(0, radius, radius, 0), inset),
+            ];
+
             _segments =
             [
-                BuildSegment(_labels[0], segmentWidth, "整條字幕、對話框——文字大，讀取時會縮小"),
-                BuildSegment(_labels[1], segmentWidth, "遊戲面板、物品說明——文字小，讀取時不縮小"),
+                BuildSegment(_labels[0], _highlights[0], segmentWidth, "整條字幕、對話框——文字大，讀取時會縮小"),
+                BuildSegment(_labels[1], _highlights[1], segmentWidth, "遊戲面板、物品說明——文字小，讀取時不縮小"),
             ];
 
             var row = new StackPanel
@@ -606,10 +743,33 @@ public partial class RealtimeEditWindow : Window
 
             // The pill goes in first so the labels sit on top of it; a label the pill slid over
             // would otherwise disappear underneath it halfway through the move.
-            var stack = new Grid();
-            stack.Children.Add(pill);
-            stack.Children.Add(row);
-            Child = stack;
+            var trackContent = new Grid();
+            trackContent.Children.Add(pill);
+            trackContent.Children.Add(row);
+
+            var track = Plate(trackWidth, new CornerRadius(radius), trackContent, uiScale);
+            track.HorizontalAlignment = HorizontalAlignment.Left;
+            track.Height = height;
+
+            _hints = [BuildHint(SubtitleHint, uiScale), BuildHint(PanelHint, uiScale)];
+
+            // Both sentences are laid out at once and only one is opaque, so the plate is as tall as
+            // the longer of them from the start and choosing a mode cannot change its size.
+            var hintContent = new Grid
+            {
+                Margin = new Thickness(14 * uiScale, 8 * uiScale, 14 * uiScale, 8 * uiScale),
+            };
+            foreach (var hint in _hints) hintContent.Children.Add(hint);
+
+            var hintPlate = Plate(hintWidth, new CornerRadius(8 * uiScale), hintContent, uiScale);
+            hintPlate.Margin = new Thickness(0, gap, 0, 0);
+
+            // Reads, never clicked. Left hit-testable it would swallow the drag that starts a new
+            // block on the picture behind it, for no gain.
+            hintPlate.IsHitTestVisible = false;
+
+            Children.Add(track);
+            Children.Add(hintPlate);
 
             for (var index = 0; index < _segments.Length; index++)
             {
@@ -623,7 +783,7 @@ public partial class RealtimeEditWindow : Window
                     e.Handled = true;
                     _pressedSegment = picked;
                     segment.CaptureMouse();
-                    SetPressed(true);
+                    SetPressed(picked, true);
                 };
                 segment.MouseLeftButtonUp += (_, e) =>
                 {
@@ -631,17 +791,24 @@ public partial class RealtimeEditWindow : Window
                     var commit = _pressedSegment == picked && segment.IsMouseOver;
                     _pressedSegment = -1;
                     segment.ReleaseMouseCapture();
-                    SetPressed(false);
+                    SetPressed(picked, false);
                     if (commit) Select(picked == 0 ? RealtimeBlockMode.Subtitle : RealtimeBlockMode.Panel);
                 };
 
                 // Dragged off and back on again while held: the press follows the pointer, so the
                 // control keeps saying what releasing right now would do.
-                segment.MouseEnter += (_, _) => { if (_pressedSegment == picked) SetPressed(true); };
-                segment.MouseLeave += (_, _) => { if (_pressedSegment == picked) SetPressed(false); };
+                segment.MouseEnter += (_, _) => { if (_pressedSegment == picked) SetPressed(picked, true); };
+                segment.MouseLeave += (_, _) => { if (_pressedSegment == picked) SetPressed(picked, false); };
             }
 
             ApplySelection(animate: false);
+
+            // Measured up front because the canvas positions this by hand and needs its size before
+            // layout has run — and it is a fixed size for the life of the block: the plate's width
+            // is given and both sentences are already laid out inside it.
+            Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+            TotalWidth = DesiredSize.Width;
+            TotalHeight = DesiredSize.Height;
         }
 
         /// <summary>Raised when the user picks the mode this block is not already on.</summary>
@@ -649,8 +816,10 @@ public partial class RealtimeEditWindow : Window
 
         public RealtimeBlockMode Value { get; private set; }
 
-        /// <summary>Full width of the control, so the caller can keep all of it on screen.</summary>
-        public double TrackWidth { get; }
+        /// <summary>Size of the control and its guidance, so the caller can keep all of it on screen.</summary>
+        public double TotalWidth { get; }
+
+        public double TotalHeight { get; }
 
         private void Select(RealtimeBlockMode mode)
         {
@@ -664,17 +833,55 @@ public partial class RealtimeEditWindow : Window
         private void ApplySelection(bool animate)
         {
             var selected = Value == RealtimeBlockMode.Subtitle ? 0 : 1;
+
             for (var index = 0; index < _labels.Length; index++)
                 _labels[index].Foreground = index == selected ? RemoveForeground : ModeIdleForeground;
 
             Move(_pillOffset, TranslateTransform.XProperty, selected * _segmentWidth, SlideDuration, animate);
+
+            for (var index = 0; index < _hints.Length; index++)
+                Fade(_hints[index], index == selected ? 1.0 : 0.0, HintFadeDuration, animate);
         }
 
-        private void SetPressed(bool pressed)
+        private void SetPressed(int segment, bool pressed) =>
+            Fade(_highlights[segment], pressed ? 1.0 : 0.0, PressDuration, animate: true);
+
+        /// <summary>
+        /// A surface with its shadow on one layer and its contents on another.
+        /// </summary>
+        /// <remarks>
+        /// The two layers exist only so the text is not a descendant of the Effect. An Effect renders
+        /// its whole subtree into an intermediate surface first, and text that has been through one
+        /// comes back softer than text drawn straight onto the window — which on a layered window,
+        /// where ClearType is already unavailable, is the difference between legible and not. The
+        /// shadow layer holds the fill and the effect and nothing else; the content layer holds the
+        /// hairline and the children, and carries no effect at all.
+        /// </remarks>
+        private static Border Plate(double width, CornerRadius corner, UIElement content, double uiScale)
         {
-            var target = pressed ? PressedScale : 1.0;
-            Move(_pressScale, ScaleTransform.ScaleXProperty, target, PressDuration, animate: true);
-            Move(_pressScale, ScaleTransform.ScaleYProperty, target, PressDuration, animate: true);
+            var shadow = new Border
+            {
+                CornerRadius = corner,
+                Background = ModeTrack,
+                Effect = new DropShadowEffect
+                {
+                    BlurRadius = 8 * uiScale, ShadowDepth = 0, Opacity = 0.4, Color = Colors.Black
+                },
+            };
+
+            var body = new Border
+            {
+                CornerRadius = corner,
+                BorderBrush = ModeTrackEdge,
+                BorderThickness = new Thickness(0, 1 * uiScale, 0, 0),
+                Child = content,
+            };
+
+            var layers = new Grid();
+            layers.Children.Add(shadow);
+            layers.Children.Add(body);
+
+            return new Border { Width = width, Child = layers };
         }
 
         /// <summary>
@@ -703,23 +910,82 @@ public partial class RealtimeEditWindow : Window
             });
         }
 
-        private static TextBlock BuildLabel(string text, double uiScale) => new()
+        /// <summary>Cross-fades a layer, from its current opacity — see <see cref="Move"/>.</summary>
+        private static void Fade(UIElement element, double to, Duration duration, bool animate)
         {
-            Text = text,
-            FontSize = 11.0 * uiScale,
-            HorizontalAlignment = HorizontalAlignment.Center,
-            VerticalAlignment = VerticalAlignment.Center,
+            if (!animate || !SystemParameters.ClientAreaAnimation)
+            {
+                element.BeginAnimation(OpacityProperty, null);
+                element.Opacity = to;
+                return;
+            }
+
+            element.BeginAnimation(OpacityProperty, new DoubleAnimation(to, duration)
+            {
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+            });
+        }
+
+        private static TextBlock BuildLabel(string text, double uiScale) =>
+            Sharpen(new TextBlock
+            {
+                Text = text,
+                FontSize = BaseModeFontSize * uiScale,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            });
+
+        // Leading a little looser than the default: this is dense CJK read once, off a translucent
+        // surface, over moving picture, and the extra air is what stops the lines running together.
+        private static TextBlock BuildHint(string text, double uiScale) =>
+            Sharpen(new TextBlock
+            {
+                Text = text,
+                FontSize = BaseHintFontSize * uiScale,
+                FontWeight = HeavierOverPicture,
+                LineHeight = BaseHintFontSize * 1.6 * uiScale,
+                LineStackingStrategy = LineStackingStrategy.BlockLineHeight,
+                TextWrapping = TextWrapping.Wrap,
+                Foreground = RemoveForeground,
+                VerticalAlignment = VerticalAlignment.Top,
+            });
+
+        // Display formatting rounds glyph widths and positions onto whole pixels, which at these
+        // sizes is the difference between a stem one pixel wide and a stem smeared across two. WPF's
+        // default (Ideal) keeps the typographic metrics instead, which is right for large text and
+        // wrong for small interface text — and this is small interface text over moving picture.
+        private static TextBlock Sharpen(TextBlock text)
+        {
+            TextOptions.SetTextFormattingMode(text, TextFormattingMode.Display);
+            TextOptions.SetTextRenderingMode(text, TextRenderingMode.ClearType);
+            return text;
+        }
+
+        private static Border BuildHighlight(CornerRadius corner, double inset) => new()
+        {
+            Background = PressHighlight,
+            CornerRadius = corner,
+            Margin = new Thickness(0, inset, 0, inset),
+            Opacity = 0,
+            IsHitTestVisible = false,
         };
 
         // Transparent rather than unset: a null background is not hit-testable, and the segment is
         // the thing being clicked.
-        private static Border BuildSegment(TextBlock label, double width, string tip) => new()
+        private static Border BuildSegment(TextBlock label, Border highlight, double width, string tip)
         {
-            Width = width,
-            Background = System.Windows.Media.Brushes.Transparent,
-            Cursor = Cursors.Hand,
-            ToolTip = tip,
-            Child = label,
-        };
+            var content = new Grid();
+            content.Children.Add(highlight);
+            content.Children.Add(label);
+
+            return new Border
+            {
+                Width = width,
+                Background = System.Windows.Media.Brushes.Transparent,
+                Cursor = Cursors.Hand,
+                ToolTip = tip,
+                Child = content,
+            };
+        }
     }
 }

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
@@ -39,8 +39,16 @@ public sealed record ScreenItem(
 /// oversight — if it turns out to confuse anyone, the fix is a line in 顯示外觀 saying its values are
 /// kept, not removing the note from 翻譯區塊.</para>
 ///
-/// Anything added later belongs to one of these two groups; if it is not obvious which, it is a
-/// preference only when the user would be annoyed to set it twice.
+/// <para><b>Kept for as long as this window is open</b> — the blocks the user drew, with the mode
+/// chosen for each. Not a preference and not a parameter: it is the answer to "where is the text",
+/// which is worth several minutes of dragging and is thrown away the moment the question changes.
+/// It lives in <see cref="RealtimeSessionController"/> rather than here, and this page tells it to
+/// forget in the two cases that change the question — the block count moving, and this window
+/// closing.</para>
+///
+/// Anything added later belongs to one of these three groups; if it is not obvious which, it is a
+/// preference only when the user would be annoyed to set it twice, and a parameter only when
+/// offering it back could be wrong rather than merely stale.
 /// </remarks>
 public partial class RealtimePage : UserControl
 {
@@ -118,7 +126,17 @@ public partial class RealtimePage : UserControl
     }
 
     /// <summary>Detaches from the controller when the shell window is destroyed.</summary>
-    public void Teardown() => RealtimeSessionController.Instance.StateChanged -= OnSessionStateChanged;
+    /// <remarks>
+    /// The kept block layout goes with the window, which is the whole of its scope: it exists so
+    /// that ending a session to change something on this page does not cost the user their blocks,
+    /// and closing the window is the end of that errand. A session already running is left alone —
+    /// it owns its own blocks, and closing this window has never been a request to stop it.
+    /// </remarks>
+    public void Teardown()
+    {
+        RealtimeSessionController.Instance.StateChanged -= OnSessionStateChanged;
+        RealtimeSessionController.Instance.ForgetBlocks();
+    }
 
     private void ProviderBox_SelectionChanged(object sender, SelectionChangedEventArgs e) =>
         RenderProviderHint();
@@ -327,6 +345,12 @@ public partial class RealtimePage : UserControl
         if (next == _blockCount) return;
 
         _blockCount = next;
+
+        // The blocks kept from the last sitting were drawn to fill a different count, so they are
+        // no longer an answer to the question being asked. Dropped as the count moves rather than
+        // checked when they are offered back, so the user sees the rule they were given.
+        RealtimeSessionController.Instance.ForgetBlocks();
+
         RenderBlockCount();
     }
 

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -55,7 +55,7 @@ internal sealed class RealtimeSessionController
     private Window? _hiddenShell;
 
     private readonly Dictionary<int, RealtimeBlockWindow> _blockWindows = [];
-    private List<System.Drawing.Rectangle> _blocks = [];
+    private List<RealtimeBlockPlacement> _blocks = [];
 
     /// <summary>
     /// Keeps the layers at the front of the topmost band — see <see cref="AlwaysOnTop"/> for why
@@ -239,7 +239,7 @@ internal sealed class RealtimeSessionController
         CloseEditWindow();
 
         var regions = _blocks
-            .Select((bounds, index) => new RealtimeRegion(index, bounds))
+            .Select((block, index) => new RealtimeRegion(index, block.Bounds, block.Mode))
             .ToList();
 
         foreach (var region in regions)

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -58,6 +58,27 @@ internal sealed class RealtimeSessionController
     private List<RealtimeBlockPlacement> _blocks = [];
 
     /// <summary>
+    /// The layout the last sitting ended with, offered back to the next one.
+    /// </summary>
+    /// <remarks>
+    /// Ending a session is not usually the user finishing — it is them going back to change the
+    /// language, the engine or a colour, all of which live on a page a running session has hidden.
+    /// Redrawing three blocks by hand every time they touch one of those is the tax that made this
+    /// worth keeping, and the modes go with the rectangles because re-answering 字幕/遊戲介面 for
+    /// each block is the same tax again.
+    ///
+    /// Held here and not written to the settings file, which is the line RealtimePage draws for
+    /// everything else about a sitting: this survives 結束即時翻譯 and nothing more. The screen it
+    /// was drawn on is kept alongside it because these are physical pixels on one monitor — offered
+    /// back for a different screen, or the same one at a different resolution, they would be blocks
+    /// the user never drew, in places nothing is.
+    /// </remarks>
+    private RememberedBlocks? _remembered;
+
+    private sealed record RememberedBlocks(
+        System.Drawing.Rectangle Screen, IReadOnlyList<RealtimeBlockPlacement> Blocks);
+
+    /// <summary>
     /// Keeps the layers at the front of the topmost band — see <see cref="AlwaysOnTop"/> for why
     /// they slide behind other topmost windows without it, and why they cannot simply activate
     /// themselves instead.
@@ -99,7 +120,9 @@ internal sealed class RealtimeSessionController
             request.ScreenBounds, request.MaxBlocks, request.SourceLanguage, request.TargetLanguage);
 
         _request = request;
-        _blocks = [];
+        _blocks = _remembered is { } kept && kept.Screen == request.ScreenBounds
+            ? [.. kept.Blocks]
+            : [];
         _hiddenShell = shellToHide;
         _hiddenShell?.Hide();
 
@@ -175,12 +198,34 @@ internal sealed class RealtimeSessionController
         CloseWindow(_control, nameof(RealtimeControlWindow));
         _control = null;
 
+        // Kept before the working copy is dropped — see RememberedBlocks for why this one thing
+        // outlives the session while everything else here is torn down.
+        _remembered = _request is { } ended && _blocks.Count > 0
+            ? new RememberedBlocks(ended.ScreenBounds, _blocks)
+            : null;
+
         _blocks = [];
         _request = null;
 
         RestoreShell();
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
+
+    /// <summary>
+    /// Drops the layout kept from the last sitting, so the next one starts on an empty screen.
+    /// </summary>
+    /// <remarks>
+    /// Called when the block count changes, and when the translation window closes. Both are the
+    /// same statement: what was drawn was drawn for a set-up that no longer exists. The count is
+    /// not checked when the blocks are offered back, deliberately — the user asked for them to go
+    /// the moment the count moved, and 2 → 3 → 2 leaving old blocks behind would be a set-up they
+    /// had told the program to forget reappearing because they changed their mind twice.
+    ///
+    /// Only the memory. A session that happens to be running keeps its own blocks and carries on:
+    /// closing the shell window has never been a request to end a session, and this does not make
+    /// it one.
+    /// </remarks>
+    public void ForgetBlocks() => _remembered = null;
 
     // ── Modes ────────────────────────────────────────────────────────────────────────────────────
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -34,6 +34,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
                         <TextBlock Grid.Row="0" Text="一般設定" Style="{StaticResource SectionHeader}"/>
@@ -49,7 +50,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="截圖快捷鍵"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="截圖翻譯"
                                        Style="{StaticResource FieldLabel}"/>
                             <TextBox   Grid.Column="1" Grid.Row="0" x:Name="HotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
@@ -63,12 +64,44 @@
                                        Height="34"
                                        Click="RecordBtn_Click"/>
                             <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
-                                       Text="按下這組快捷鍵即可框選畫面進行翻譯"
+                                       Text="按下快捷鍵即可使用截圖翻譯功能"
+                                       Style="{StaticResource FieldHint}"/>
+                        </Grid>
+
+                        <!-- Translation-window hotkey row. Same editing controls as the capture
+                             shortcut above and deliberately nothing else: this one is a shortcut to
+                             a window that is already one tray click away, so it is not announced at
+                             startup and nothing in the interface names it. -->
+                        <Grid Grid.Row="2" Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="70"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="開啟翻譯視窗"
+                                       Style="{StaticResource FieldLabel}"/>
+                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="WindowHotkeyBox"
+                                       Style="{StaticResource ModernTextBox}"
+                                       IsReadOnly="True"
+                                       Margin="0,0,8,0"
+                                       PreviewKeyDown="HotkeyBox_PreviewKeyDown"
+                                       GotFocus="HotkeyBox_GotFocus"
+                                       LostFocus="HotkeyBox_LostFocus"/>
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="WindowRecordBtn" Content="錄製"
+                                       Style="{StaticResource FlatButton}"
+                                       Height="34"
+                                       Click="RecordBtn_Click"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
+                                       Text="即時翻譯進行中時，改為將浮動視窗移至最上層"
                                        Style="{StaticResource FieldHint}"/>
                         </Grid>
 
                         <!-- Source language row -->
-                        <Grid Grid.Row="2" Margin="0,0,0,10">
+                        <Grid Grid.Row="3" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="100"/>
                                 <ColumnDefinition Width="*"/>
@@ -81,7 +114,7 @@
                         </Grid>
 
                         <!-- 框選完成自動翻譯 -->
-                        <Grid Grid.Row="3" Margin="0,10,0,0">
+                        <Grid Grid.Row="4" Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="100"/>
                                 <ColumnDefinition Width="*"/>
@@ -96,7 +129,7 @@
                         </Grid>
 
                         <!-- 開機自動啟動 -->
-                        <Grid Grid.Row="4" Margin="0,10,0,0">
+                        <Grid Grid.Row="5" Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="100"/>
                                 <ColumnDefinition Width="*"/>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -10,6 +10,8 @@ using Microsoft.Win32;
 // UseWindowsForms puts System.Windows.Forms in the implicit usings, so these names collide
 using UserControl = System.Windows.Controls.UserControl;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
+using TextBox = System.Windows.Controls.TextBox;
+using Button = System.Windows.Controls.Button;
 
 namespace OverTranslate.Views.Settings;
 
@@ -25,9 +27,27 @@ public partial class SettingsPage : UserControl
     private readonly DispatcherTimer _apiKeyDebounce;
     private readonly DispatcherTimer _statusHold;
 
-    private bool _isRecording;
-    private uint _pendingModifiers;
-    private uint _pendingVKey;
+    /// <summary>
+    /// One editable shortcut: the two controls that edit it and the settings it reads and writes.
+    /// </summary>
+    /// <param name="AdvertisedInShell">
+    /// Whether the shell's nav rail prints this combination beside a button, and so has to be told
+    /// when it changes. True for the capture shortcut, which the interface names in three places;
+    /// false for the window one, which it names nowhere.
+    /// </param>
+    private sealed record HotkeyField(
+        string Name,
+        TextBox Box,
+        Button Record,
+        Func<AppSettings, string> Display,
+        Func<AppSettings, (uint Modifiers, uint Key)> Combination,
+        Action<AppSettings, uint, uint, string> Apply,
+        bool AdvertisedInShell);
+
+    private HotkeyField[] _hotkeyFields = [];
+
+    /// <summary>The field waiting for a key, or null. At most one at a time.</summary>
+    private HotkeyField? _recording;
 
     /// <summary>True while the controls are being populated, so initialization never writes back.</summary>
     private bool _loading;
@@ -35,6 +55,34 @@ public partial class SettingsPage : UserControl
     public SettingsPage()
     {
         InitializeComponent();
+
+        _hotkeyFields =
+        [
+            new HotkeyField(
+                "截圖翻譯",
+                HotkeyBox, RecordBtn,
+                s => s.HotkeyDisplay,
+                s => (s.HotkeyModifiers, s.HotkeyVirtualKey),
+                (s, mods, vk, display) =>
+                {
+                    s.HotkeyModifiers = mods;
+                    s.HotkeyVirtualKey = vk;
+                    s.HotkeyDisplay = display;
+                },
+                AdvertisedInShell: true),
+            new HotkeyField(
+                "開啟翻譯視窗",
+                WindowHotkeyBox, WindowRecordBtn,
+                s => s.TranslationWindowHotkeyDisplay,
+                s => (s.TranslationWindowHotkeyModifiers, s.TranslationWindowHotkeyVirtualKey),
+                (s, mods, vk, display) =>
+                {
+                    s.TranslationWindowHotkeyModifiers = mods;
+                    s.TranslationWindowHotkeyVirtualKey = vk;
+                    s.TranslationWindowHotkeyDisplay = display;
+                },
+                AdvertisedInShell: false),
+        ];
 
         _apiKeyDebounce = new DispatcherTimer { Interval = ApiKeyDebounce };
         _apiKeyDebounce.Tick += (_, _) =>
@@ -71,11 +119,8 @@ public partial class SettingsPage : UserControl
             if (ProviderBox.SelectedValue == null) ProviderBox.SelectedIndex = 0;
             ProviderHint.Text = (ProviderBox.SelectedItem as ProviderItem)?.Hint ?? "";
 
-            HotkeyBox.Text = s.HotkeyDisplay;
+            foreach (var field in _hotkeyFields) field.Box.Text = field.Display(s);
             ApiKeyBox.Text = s.ApiKey;
-
-            _pendingModifiers = s.HotkeyModifiers;
-            _pendingVKey      = s.HotkeyVirtualKey;
 
             LightThemeRadio.IsChecked = s.Theme != ThemeService.Dark;
             DarkThemeRadio.IsChecked  = s.Theme == ThemeService.Dark;
@@ -270,46 +315,65 @@ public partial class SettingsPage : UserControl
 
     // ── Hotkey recording ─────────────────────────────────────────────────────
 
+    /// <summary>The field these two controls edit, or null for anything else.</summary>
+    private HotkeyField? FieldOf(object sender) =>
+        _hotkeyFields.FirstOrDefault(
+            field => ReferenceEquals(field.Box, sender) || ReferenceEquals(field.Record, sender));
+
+    private void StartRecording(HotkeyField field)
+    {
+        // Only one at a time: two boxes both saying 請按下快捷鍵 would leave the next key press
+        // ambiguous to the user long before it was ambiguous to the code.
+        StopRecording();
+
+        _recording = field;
+        field.Box.Text = "請按下快捷鍵...";
+        field.Record.Content = "取消";
+        field.Box.Focus();
+    }
+
+    /// <summary>Ends recording and puts the stored combination back in the box.</summary>
+    /// <remarks>
+    /// Reads the setting rather than remembering what was there, so this also serves as the way
+    /// back after a successful capture: the new value has been persisted by then, and restoring
+    /// from the settings shows it.
+    /// </remarks>
+    private void StopRecording()
+    {
+        if (_recording is not { } field) return;
+
+        field.Box.Text = field.Display(SettingsService.Instance.Current);
+        field.Record.Content = "錄製";
+        _recording = null;
+    }
+
     private void RecordBtn_Click(object sender, RoutedEventArgs e)
     {
-        _isRecording = !_isRecording;
-        if (_isRecording)
-        {
-            HotkeyBox.Text = "請按下快捷鍵...";
-            RecordBtn.Content = "取消";
-            HotkeyBox.Focus();
-        }
-        else
-        {
-            HotkeyBox.Text = SettingsService.Instance.Current.HotkeyDisplay;
-            RecordBtn.Content = "錄製";
-        }
+        if (FieldOf(sender) is not { } field) return;
+
+        if (ReferenceEquals(_recording, field)) StopRecording();
+        else StartRecording(field);
     }
 
     private void HotkeyBox_GotFocus(object sender, RoutedEventArgs e)
     {
-        if (!_isRecording)
-        {
-            _isRecording = true;
-            HotkeyBox.Text = "請按下快捷鍵...";
-            RecordBtn.Content = "取消";
-        }
+        if (FieldOf(sender) is { } field && !ReferenceEquals(_recording, field))
+            StartRecording(field);
     }
 
     private void HotkeyBox_LostFocus(object sender, RoutedEventArgs e)
     {
-        if (!_isRecording) return;
-        // 焦點移到 RecordBtn 時由 Click 事件處理，這裡不介入
-        if (Keyboard.FocusedElement == RecordBtn) return;
+        if (FieldOf(sender) is not { } field || !ReferenceEquals(_recording, field)) return;
 
-        _isRecording = false;
-        HotkeyBox.Text = SettingsService.Instance.Current.HotkeyDisplay;
-        RecordBtn.Content = "錄製";
+        // 焦點移到該欄位的錄製鈕時由 Click 事件處理，這裡不介入
+        if (Keyboard.FocusedElement == field.Record) return;
+
+        StopRecording();
     }
 
     private void HotkeyBox_PreviewKeyDown(object sender, KeyEventArgs e)
     {
-        if (!_isRecording) return;
+        if (_recording is not { } recording || !ReferenceEquals(recording.Box, sender)) return;
         e.Handled = true;
 
         bool isSystemKey = e.Key == Key.System;
@@ -329,28 +393,36 @@ public partial class SettingsPage : UserControl
         if (mods == 0) return;
 
         uint vk = (uint)KeyInterop.VirtualKeyFromKey(key);
-        _pendingModifiers = mods;
-        _pendingVKey      = vk;
-
         var display = $"{GlobalHotkey.ModifiersToString(mods)}+{key}";
-        HotkeyBox.Text    = display;
-        _isRecording      = false;
-        RecordBtn.Content = "錄製";
 
-        Persist(s =>
+        // Windows keys a registration by window and combination, so the second shortcut to claim
+        // one is simply refused — RegisterHotKey returns false and nothing else happens. Left to
+        // itself that reads as a shortcut that stopped working for no reason, so the clash is
+        // refused here, where there is something to say about it.
+        var settings = SettingsService.Instance.Current;
+        var taken = _hotkeyFields.FirstOrDefault(
+            field => !ReferenceEquals(field, recording) && field.Combination(settings) == (mods, vk));
+
+        if (taken is not null)
         {
-            s.HotkeyModifiers  = _pendingModifiers;
-            s.HotkeyVirtualKey = _pendingVKey;
-            s.HotkeyDisplay    = display;
-        });
+            ShowError($"✗ {display} 已指派給「{taken.Name}」");
+            StopRecording();
+            return;
+        }
+
+        Persist(s => recording.Apply(s, mods, vk, display));
+
+        // After the write, so the box picks the new combination up out of the settings.
+        StopRecording();
 
         // The global hook holds the old combination until it is rebound
         if (System.Windows.Application.Current.MainWindow is MainWindow main)
             main.ReRegisterHotkey();
 
-        // The nav rail advertises this shortcut beside 截圖翻譯 and is on screen right now, so it
-        // has to be told; nothing else re-reads it until the shell is next shown or activated.
-        if (Window.GetWindow(this) is Shell.ShellWindow shell)
+        // The nav rail advertises the capture shortcut beside 截圖翻譯 and is on screen right now,
+        // so it has to be told; nothing else re-reads it until the shell is next shown or
+        // activated. The window shortcut is advertised nowhere, so there is nothing to refresh.
+        if (recording.AdvertisedInShell && Window.GetWindow(this) is Shell.ShellWindow shell)
             shell.RefreshHotkeyHint();
     }
 }

--- a/tests/OverTranslate.Tests/CollapsedDetectionTests.cs
+++ b/tests/OverTranslate.Tests/CollapsedDetectionTests.cs
@@ -19,7 +19,8 @@ public class CollapsedDetectionTests
     [InlineData(343)]
     public void ABoxThrownAcrossTheWholeBlockIsACollapse(double height)
     {
-        Assert.True(CollapsedDetection.IsCollapsed(height, Block));
+        // "A" and "M" are what the recogniser actually returned out of those boxes.
+        Assert.True(CollapsedDetection.IsCollapsed(height, Block, "A"));
     }
 
     [Theory]
@@ -29,7 +30,7 @@ public class CollapsedDetectionTests
     [InlineData(150)]
     public void RealLinesLeaveRoomAboveAndBelowThem(double height)
     {
-        Assert.False(CollapsedDetection.IsCollapsed(height, Block));
+        Assert.False(CollapsedDetection.IsCollapsed(height, Block, "It's so relaxing."));
     }
 
     [Fact]
@@ -39,14 +40,35 @@ public class CollapsedDetectionTests
         // home." in a 190px block, thrown away by the old 0.9 threshold. The new detector draws
         // looser boxes than the one this rule was calibrated on, and a sentence lost this way never
         // reaches the screen at all.
-        Assert.False(CollapsedDetection.IsCollapsed(171, 190));
+        Assert.False(
+            CollapsedDetection.IsCollapsed(171, 190, "Let's pay CiRcLE visit on the way home."));
     }
 
     [Fact]
     public void ABoxOverrunningTheBlockIsStillACollapse()
     {
         // From the same session: 214px in a 191px block, out of which the recogniser read "Yay!".
-        Assert.True(CollapsedDetection.IsCollapsed(214, 191));
+        Assert.True(CollapsedDetection.IsCollapsed(214, 191, "Yay!"));
+    }
+
+    [Fact]
+    public void ASentenceFillingTheBlockTheUserDrewSurvives()
+    {
+        // The case issue #35 opens with: a block drawn tight around one line, so the line is 100%
+        // of it. Under the height test alone this was a collapse, and 22 of 45 measured frames read
+        // as nothing because of it. What the box holds is a complete sentence, and that is the half
+        // of the question the block's height cannot answer.
+        Assert.False(
+            CollapsedDetection.IsCollapsed(190, 190, "The news did say they were building"));
+    }
+
+    [Fact]
+    public void ABlockSpanningBoxThatReadNothingIsStillACollapse()
+    {
+        // The same event arriving without any text to judge: the box is the evidence, and there is
+        // nothing here worth putting on screen either way.
+        Assert.True(CollapsedDetection.IsCollapsed(200, 196, null));
+        Assert.True(CollapsedDetection.IsCollapsed(200, 196, "   "));
     }
 
     [Theory]
@@ -59,12 +81,12 @@ public class CollapsedDetectionTests
     [InlineData(78)]
     public void TextOfEverySizeInAMixedBlockSurvives(double height)
     {
-        Assert.False(CollapsedDetection.IsCollapsed(height, 400));
+        Assert.False(CollapsedDetection.IsCollapsed(height, 400, "M"));
     }
 
     [Fact]
     public void ABlockOfNoHeightIsNotJudged()
     {
-        Assert.False(CollapsedDetection.IsCollapsed(200, 0));
+        Assert.False(CollapsedDetection.IsCollapsed(200, 0, "A"));
     }
 }

--- a/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
@@ -11,9 +11,9 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     [Fact]
     public void ASubtitleStripIsReadAtHalfScale()
     {
-        // Wide and short: the text fills the height, so the glyphs are large and halving lands them
-        // near the size the model was trained on.
-        var (primary, _) = RealtimeDetectorSize.For(1226, 196);   // ratio 6.3
+        // The text fills a strip's height, so the glyphs are large and halving lands them near the
+        // size the model was trained on.
+        var (primary, _) = RealtimeDetectorSize.For(1226, 196, RealtimeBlockMode.Subtitle);
 
         Assert.Equal(640, primary); // 1226 * 0.5, rounded up onto the detector's grid
     }
@@ -21,36 +21,40 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     [Fact]
     public void AnInterfacePanelIsReadAtTheLargerFraction()
     {
-        // Chunky: the text is a small part of the height, so halving takes it below what the
-        // detector finds. Measured on this shape, 0.5 read 3 of 9 boxes and 0.68 read 7.
-        var (primary, _) = RealtimeDetectorSize.For(1380, 750);   // ratio 1.8
+        // The text is a small part of a panel's height, so halving takes it below what the detector
+        // finds. Measured on this shape, 0.5 read 3 of 9 boxes and 0.68 read 7.
+        var (primary, _) = RealtimeDetectorSize.For(1380, 750, RealtimeBlockMode.Panel);
 
         Assert.Equal(960, primary); // 1380 * 0.68
     }
 
     [Theory]
-    [InlineData(1432, 224)]   // the strips from a measured session, ratio 5.8 and up
-    [InlineData(1549, 203)]
-    [InlineData(1856, 152)]
-    [InlineData(1361, 139)]
-    public void TheShapesUsersActuallyDrawAreClassifiedAsStrips(int width, int height)
+    // The same rectangle, read both ways. These are the shapes the removed StripAspectRatio rule
+    // classified — a strip at 6.4 and a panel at 2.1 — and the point of issue #35 is that the shape
+    // no longer decides anything: the user does, and either answer is available for either shape.
+    [InlineData(1432, 224)]
+    [InlineData(1380, 657)]
+    public void TheModeDecidesTheScaleAndTheShapeNoLongerDoes(int width, int height)
     {
-        var (primary, _) = RealtimeDetectorSize.For(width, height);
-
-        Assert.Equal(RealtimeDetectorSize.For(width, height).Primary, primary);
-        Assert.True(primary <= width * 0.55, $"{width}x{height} should be read at strip scale");
-    }
-
-    [Theory]
-    [InlineData(1273, 647)]   // the panels from the same session, ratio 2.9 and below
-    [InlineData(1395, 636)]
-    [InlineData(1865, 1050)]
-    public void TheShapesUsersActuallyDrawAreClassifiedAsPanels(int width, int height)
-    {
-        var (primary, _) = RealtimeDetectorSize.For(width, height);
         var native = Math.Max(width, height);
 
-        Assert.True(primary >= native * 0.6, $"{width}x{height} should be read at panel scale");
+        var strip = RealtimeDetectorSize.For(width, height, RealtimeBlockMode.Subtitle).Primary;
+        var panel = RealtimeDetectorSize.For(width, height, RealtimeBlockMode.Panel).Primary;
+
+        Assert.True(strip <= native * 0.55, $"{width}x{height} as 字幕 should read at strip scale");
+        Assert.True(panel >= native * 0.6, $"{width}x{height} as 面板 should read at panel scale");
+    }
+
+    [Fact]
+    public void TheUsersDraggingCannotChangeTheScaleAnyMore()
+    {
+        // What the user actually varies: the same subtitle framed tightly and framed loosely. Under
+        // the aspect-ratio guess these landed on opposite sides of 4.0 and got two different scales
+        // from the same content — the complaint issue #35 opens with.
+        var tight = RealtimeDetectorSize.For(1432, 180, RealtimeBlockMode.Subtitle);   // ratio 8.0
+        var loose = RealtimeDetectorSize.For(1432, 480, RealtimeBlockMode.Subtitle);   // ratio 3.0
+
+        Assert.Equal(tight.Primary, loose.Primary);
     }
 
     [Fact]
@@ -65,12 +69,12 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void TheRejectedShapeFractionIsTriedFirstThenNativeSize()
+    public void TheOtherModesFractionIsTriedFirstThenNativeSize()
     {
-        // The two fail on opposite content, so when the shape rule was wrong the fraction it turned
-        // down is the best next answer. Native goes last: the only size that can read text too small
-        // to survive any downscale.
-        var (_, fallbacks) = RealtimeDetectorSize.For(1415, 169);  // a strip, so primary is 0.5
+        // The two fail on opposite content, so the fraction the mode turned down is the best next
+        // answer when the mode was not the whole story. Native goes last: the only size that can
+        // read text too small to survive any downscale.
+        var (_, fallbacks) = RealtimeDetectorSize.For(1415, 169, RealtimeBlockMode.Subtitle);
 
         Assert.Equal([992, 1415], fallbacks); // 1415 * 0.68, then native
     }
@@ -78,7 +82,7 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     [Fact]
     public void ASizeThatWouldRepeatTheFirstAttemptIsNotTriedAgain()
     {
-        var (primary, fallbacks) = RealtimeDetectorSize.For(1226, 196);
+        var (primary, fallbacks) = RealtimeDetectorSize.For(1226, 196, RealtimeBlockMode.Subtitle);
 
         Assert.DoesNotContain(primary, fallbacks);
     }
@@ -88,7 +92,7 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     {
         // 60px subtitles do not fit in a region this size, so halving could only take small text
         // further out of range.
-        var (primary, fallbacks) = RealtimeDetectorSize.For(400, 120);
+        var (primary, fallbacks) = RealtimeDetectorSize.For(400, 120, RealtimeBlockMode.Subtitle);
 
         Assert.Equal(400, primary);
         Assert.Empty(fallbacks);
@@ -97,9 +101,9 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     [Fact]
     public void TheLongestSideDecidesTheSize()
     {
-        // Tall and narrow is not a strip, so it reads at panel scale — and the size comes from the
-        // long side whichever way round the block is.
-        var (primary, _) = RealtimeDetectorSize.For(300, 1000);
+        // The size comes from the long side whichever way round the block is — a tall, narrow panel
+        // is measured on its height.
+        var (primary, _) = RealtimeDetectorSize.For(300, 1000, RealtimeBlockMode.Panel);
         Assert.Equal(704, primary); // 1000 * 0.68, rounded up onto the detector's grid
     }
 
@@ -115,7 +119,7 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
         using var engine = new OcrService();
         using var frame = new Bitmap(Path.Combine(AppContext.BaseDirectory, "Fixtures", fixture));
 
-        var (primary, _) = RealtimeDetectorSize.For(frame.Width, frame.Height);
+        var (primary, _) = RealtimeDetectorSize.For(frame.Width, frame.Height, RealtimeBlockMode.Subtitle);
         var blocks = await engine.TryRecognizeAsync(frame, "EN", primary);
 
         var text = string.Join(" ", blocks?.Select(b => b.Text) ?? []).ToLowerInvariant();
@@ -127,9 +131,9 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     [Fact]
     public void ABlankRegionStopsPayingForTheNativeRetry()
     {
-        // The expensive one goes; the shape rule's other fraction, which rescued 17 of the 23
+        // The expensive one goes; the other mode's fraction, which rescued 17 of the 23
         // blank-state rescues on record against native's 6, stays.
-        var (_, fallbacks) = RealtimeDetectorSize.For(1699, 242);
+        var (_, fallbacks) = RealtimeDetectorSize.For(1699, 242, RealtimeBlockMode.Subtitle);
         var whileBlank = RealtimeDetectorSize.WhileNothingIsShown(fallbacks, 1699, 242);
 
         Assert.Contains(1699, fallbacks);
@@ -142,7 +146,7 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     {
         // Below HalfScaleMinSide there are no fallbacks at all, so there is nothing here to save
         // and nothing to lose either.
-        var (_, fallbacks) = RealtimeDetectorSize.For(400, 120);
+        var (_, fallbacks) = RealtimeDetectorSize.For(400, 120, RealtimeBlockMode.Subtitle);
 
         Assert.Empty(RealtimeDetectorSize.WhileNothingIsShown(fallbacks, 400, 120));
     }

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -23,8 +23,16 @@ if (args.Length == 0)
     Console.Error.WriteLine("       OcrHarness --margin-sweep <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (same text, blocks cropped tight around it vs left loose)");
     Console.Error.WriteLine("       OcrHarness --xlate-test   (network translation/resilience check, no OCR)");
+    Console.Error.WriteLine("       (add --panel to any sweep to read as a game panel rather than a subtitle)");
     return 1;
 }
+
+// Which mode to read as. The application asks the user this (see RealtimeBlockMode) because the
+// answer is about what is on screen and not about the picture's shape; offline there is nobody to
+// ask, so it is a flag. Subtitle by default: every dump kept so far is one, and reading a subtitle
+// dump as a panel would report the wrong half of RealtimeDetectorSize.
+var harnessMode = args.Contains("--panel") ? RealtimeBlockMode.Panel : RealtimeBlockMode.Subtitle;
+args = [.. args.Where(argument => argument != "--panel")];
 
 // Forced-fallback check: the primary engine gets a 1ms-timeout HttpClient so it always fails,
 // proving the hedge falls back to a backup engine and that the badge data (FallbackUsed/Dominant)
@@ -140,7 +148,7 @@ if (args[0] == "--compare-models")
 
         using var image = new Bitmap(path);
         var native = Math.Max(image.Width, image.Height);
-        var (primary, _) = RealtimeDetectorSize.For(image.Width, image.Height);
+        var (primary, _) = RealtimeDetectorSize.For(image.Width, image.Height, harnessMode);
 
         Console.WriteLine(new string('=', 78));
         Console.WriteLine($"{Path.GetFileName(path)}  {image.Width}x{image.Height}");
@@ -188,7 +196,7 @@ if (args[0] == "--pad-sweep")
         if (!File.Exists(path)) { Console.WriteLine($"(missing) {path}"); continue; }
 
         using var image = new Bitmap(path);
-        var (primary, _) = RealtimeDetectorSize.For(image.Width, image.Height);
+        var (primary, _) = RealtimeDetectorSize.For(image.Width, image.Height, harnessMode);
 
         Console.WriteLine(new string('=', 78));
         Console.WriteLine($"{Path.GetFileName(path)}  {image.Width}x{image.Height}  detect={primary}");
@@ -256,7 +264,7 @@ if (args[0] == "--margin-sweep")
 
     async Task<List<OcrTextBlock>> ReadAsync(Bitmap image)
     {
-        var (primary, fallbacks) = RealtimeDetectorSize.For(image.Width, image.Height);
+        var (primary, fallbacks) = RealtimeDetectorSize.For(image.Width, image.Height, harnessMode);
 
         foreach (var size in new[] { primary }.Concat(fallbacks))
         {
@@ -314,7 +322,7 @@ if (args[0] == "--margin-sweep")
                 Math.Min(image.Height, (int)Math.Ceiling(bottom + pad)));
 
             using var cropped = image.Clone(crop, image.PixelFormat);
-            var (primary, _) = RealtimeDetectorSize.For(cropped.Width, cropped.Height);
+            var (primary, _) = RealtimeDetectorSize.For(cropped.Width, cropped.Height, harnessMode);
 
             var elapsed = System.Diagnostics.Stopwatch.StartNew();
             var kept = await ReadAsync(cropped);
@@ -425,7 +433,7 @@ if (args[0] == "--scale-sweep")
             $"{Path.GetFileName(path)}  {image.Width}x{image.Height}  ratio={aspect:0.00}");
 
         // What the app itself would pick for this block, so the sweep can be read against it.
-        var (primary, fallbacks) = RealtimeDetectorSize.For(image.Width, image.Height);
+        var (primary, fallbacks) = RealtimeDetectorSize.For(image.Width, image.Height, harnessMode);
         Console.WriteLine($"  app picks: primary={primary} fallbacks=[{string.Join(",", fallbacks)}]");
 
         // Stepped in whole percent, not by adding 0.05 to a double: the accumulated error moved

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -219,7 +219,7 @@ if (args[0] == "--pad-sweep")
             // scale sweep: a reading it would have thrown away is not a reading.
             var kept = blocks?
                 .Where(block =>
-                    !CollapsedDetection.IsCollapsed(block.Bounds.Height, image.Height) &&
+                    !CollapsedDetection.IsCollapsed(block.Bounds.Height, image.Height, block.Text) &&
                     !ShortReadingDetection.IsTooShort(block.Text) &&
                     !ShortReadingDetection.IsUnconvincingShortText(block.Text, block.Confidence))
                 .ToList();
@@ -275,7 +275,7 @@ if (args[0] == "--margin-sweep")
             // which is exactly what this sweep is changing.
             var kept = blocks?
                 .Where(block =>
-                    !CollapsedDetection.IsCollapsed(block.Bounds.Height, image.Height) &&
+                    !CollapsedDetection.IsCollapsed(block.Bounds.Height, image.Height, block.Text) &&
                     !ShortReadingDetection.IsTooShort(block.Text) &&
                     !ShortReadingDetection.IsUnconvincingShortText(block.Text, block.Confidence))
                 .ToList() ?? [];
@@ -463,7 +463,7 @@ if (args[0] == "--scale-sweep")
             // application had recorded as reading nothing.
             var kept = blocks?
                 .Where(block =>
-                    !CollapsedDetection.IsCollapsed(block.Bounds.Height, image.Height) &&
+                    !CollapsedDetection.IsCollapsed(block.Bounds.Height, image.Height, block.Text) &&
                     !ShortReadingDetection.IsTooShort(block.Text) &&
                     !ShortReadingDetection.IsUnconvincingShortText(block.Text, block.Confidence))
                 .ToList();


### PR DESCRIPTION
拿掉「這個框是字幕還是遊戲面板」的長寬比猜測，改由使用者在拉框時逐框選擇；並用零成本的方式把「框貼著字拉」的懸崖砍掉一半。

Closes #35 —— **兩條驗收條件未達成，其中一條是刻意結案、另一條移交新單，詳見文末**。

## 這條分支做了什麼

### 1. 模式由使用者選，不再用形狀猜（issue 的方向 D）

`RealtimeDetectorSize.StripAspectRatio` 移除。`For(w, h, mode)` 改由模式決定偵測尺度的起點，另一個模式的比例仍然是第一個 fallback。

拉框面板上每個框帶一個分段控制（字幕 / 遊戲介面），兩段永遠都在。不用單顆切換 chip：只標著現況的兩態按鈕，讀起來同時像狀態也像動作，而且多個框並存時看不出「有得選」這件事存在。

**為什麼非做不可**：同一段字幕，框拉成 8:1 跟拉成 3:1 會落在門檻兩側，拿到兩套完全不同的行為。而 `RealtimeDetectorSize` 自己的註解早就量過，0.68 套在字幕上有三分之一的 pass 讀不到東西。實測 session 裡使用者的框已經出現過 3.33 的比例。

**猜錯的代價（實測）**：把一個 1604x784 的遊戲面板改用字幕模式讀，detect 從 0.70 掉到 0.52，圖被縮到 74%，大字都在但**小字整批消失**。log 顯示那些字沒有出現在任何偵測結果裡——不是被後處理丟掉，是根本沒被偵測到。而且 fallback 救不了：fallback 只在整個 pass 讀到零字時才跑，大字讀得到就永遠不會升級。

### 2. 塌陷判斷加上「而且讀出來很短」（方向 B 的零成本版）

`IsCollapsed(boxHeight, blockHeight, text)`：高度佔框高 ≥95% **而且** 讀出來 ≤10 字才算塌陷。

原本的規則拿使用者畫的框當尺，所以框貼著字拉時，一行**正確**的字就是框高的 100%，整句被丟掉——而且每個 pass 都會再被丟一次，因為原因是框的形狀而框不會變。

兩群不重疊：所有記錄在案的塌陷都是 `"A"` `"M"` `"Yay!"`（≤4 字），被誤殺的是 `"Let's pay CiRcLE visit on the way home."`（39 字）。文字在判斷當下早就在手上，不多花任何一次推論。

`OcrHarness --margin-sweep`，39 張真實 dump：

```
  留白          只看高度    加上短讀     讀到 0 字
  0（貼邊）      47.8%       75.3%       20/39 -> 9/39
  0.15 行高      70.8%       77.6%       11/39 -> 8/39
  0.50 行高      86.4%       85.2%        5/39     5/39
  1.50 行高      97.2%       96.9%        1/39     1/39
```

貼邊那端的懸崖少掉一半，寬鬆那端沒動（0.3pp 是同一支 sweep 的跑動雜訊）。

**換進來的新失敗**：塌陷若讀出長亂碼（>10 字）現在會被放行。這是便宜得多的失敗——壞句子只存在一個 pass，下一個 pass 就蓋掉；誤殺一句正確的則是那句從頭到尾都不出現。真實貼緊 session（1435x146）驗過，新失敗沒有出現。

### 3. 拉框當下的引導

模式控制下方帶一句該模式的框選建議，跟著模式切換。放在這裡而不是設定頁或首次啟動提示，是因為這是唯一能被執行的時刻——使用者正握著那個框。

順帶修掉浮動層上文字糊掉的四個成因：陰影改畫在自己的圖層而不是文字的祖先（Effect 會把整個子樹推進中介表面）、`TextFormattingMode.Display`、控制項自身與 canvas 擺放座標都對齊實體像素、字級調大。**ClearType 本身無解**——這是 `AllowsTransparency` 的分層視窗，WPF 一律關掉它。

按壓回饋從「整個膠囊縮放」改成「按到的那一段亮起」，也是同一件事的一部分：縮放是對文字做 transform，WPF 會因此關掉 pixel snapping 並花約一秒才加回來（`ShellWindow.AnimateContentIn` 為了這件事付了一層 BitmapCache）。亮起單段不碰文字 render，而且還多說了是哪一段被按到。

### 4. 結束後保留框與模式

按 X 離開即時翻譯通常不是使用者做完了，而是要回去改語言、引擎或顏色——那些都在被 session 隱藏的頁面上。所以框與每個框的模式會留著，其他照舊全部拆掉。

釋放的條件：**改動區塊數量**、**關掉翻譯視窗**，以及**換螢幕或解析度變了**（第三項未被要求，但框存的是某台螢幕的實體像素，帶回去會是使用者從沒畫過、可能整個在畫面外的框）。

## 不在 #35 範圍內的一個 commit

`18a7417` 新增「開啟翻譯視窗」的快捷鍵（預設 `Ctrl+Alt+S`），設定頁可改，編輯方式與截圖快捷鍵相同。刻意低調：不進開機通知、介面不宣傳。即時翻譯進行中改為把浮動層移到最上層（同右下選單）；截圖翻譯進行中則安靜地不動作。

順帶擋掉一個這次改動自己製造的洞：`GlobalHotkey` 原本 id 寫死，兩支快捷鍵設成同一組時第二個註冊會被 Windows 靜默拒絕，現在錄製階段就會擋下並說明。

與 #35 無關，只是不想為它另開分支。要拆的話單獨 revert 這一個 commit 即可。

## 驗收條件現況

| 條件 | 狀態 |
|---|---|
| 長寬比猜測移除 | ✅ |
| 遊戲面板既有表現不得退步 | ✅（反證亦成立：選錯模式小字整批消失） |
| 貼邊分數要接近寬鬆 | ⚠️ 未達成，**刻意結案**。20/39 → 9/39 |
| 留白過大不得有懲罰 | ⚠️ 未達成，**移交後續單**。辨識率通過，耗時 +46% |
| 框外文字不得被翻出 | n/a（方向 A 未採用，已於 #35 記錄放棄原因） |

兩條都不是這條分支能收掉的，但性質不同：

- **貼邊剩下的 9/39 沒有程式解，所以這條到此為止。** 那是根因 2——左右超出框的筆畫在截圖階段就被切掉了（實測讀到 `bury steak!`、`paghetti peperoncin`、`Hard-boile`，原文是 Salisbury steak / Spaghetti peperoncino / Hard-boiled）。任何過濾器都救不回沒被截到的像素，唯一的答案是在拉框當下引導，也就是本 PR 的第 3 項。繼續壓這條曲線的邊際效益已經很低。

- **耗時 +46% 有解，但不在這批。** 正解是方向 C：偵測尺度改由上一個 pass 量到的字高推導，框拉多大都不影響送進偵測器的尺度。那會影響每一個 pass、尚未量測，混進這批已驗證的改動裡會把整批的可信度拉到最低的那一項。另開一單處理。

## 測試

- 277 個單元測試通過
- `OcrHarness --margin-sweep` 前後對照（表在上方）
- 真實 session 實測：純字幕（寬鬆／貼緊各一輪）、遊戲場景（上字幕模式＋下面板模式）、以及刻意把面板改成字幕模式的對照
