### PR TITLE
feat: 設定頁 API Key 改為遮蔽輸入並提供眼睛按鈕切換顯示

### DIFF
--- a/src/OverTranslate/Views/Controls/SecretBox.xaml
+++ b/src/OverTranslate/Views/Controls/SecretBox.xaml
@@ -1,0 +1,94 @@
+<UserControl x:Class="OverTranslate.Views.Controls.SecretBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <UserControl.Resources>
+        <!-- The frame lives on the outer Border so the editor and the reveal button sit inside
+             one input box; the inner editors are stripped of their own chrome. -->
+        <Style x:Key="SecretEditorChrome" TargetType="Control">
+            <Setter Property="FontFamily"               Value="{StaticResource AppFont}"/>
+            <Setter Property="FontSize"                 Value="{StaticResource AppFontSize}"/>
+            <Setter Property="Foreground"               Value="{DynamicResource AppTextPrimary}"/>
+            <Setter Property="Background"               Value="Transparent"/>
+            <Setter Property="BorderThickness"          Value="0"/>
+            <Setter Property="Padding"                  Value="9,0,0,0"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+        </Style>
+
+        <Style x:Key="RevealButton" TargetType="Button">
+            <Setter Property="Width"      Value="34"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppTextSecondary}"/>
+            <Setter Property="Cursor"     Value="Hand"/>
+            <Setter Property="Focusable"  Value="False"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Root" Background="{TemplateBinding Background}"
+                                CornerRadius="6">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Foreground"
+                                        Value="{DynamicResource AppTextPrimary}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Border x:Name="Root"
+            Background="{DynamicResource AppInputBg}"
+            CornerRadius="6"
+            Height="34">
+        <Border.Style>
+            <Style TargetType="Border">
+                <Setter Property="BorderBrush"     Value="{DynamicResource AppInputBorder}"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Style.Triggers>
+                    <DataTrigger Value="True"
+                                 Binding="{Binding IsKeyboardFocusWithin,
+                                           RelativeSource={RelativeSource AncestorType=UserControl}}">
+                        <Setter Property="BorderBrush"
+                                Value="{DynamicResource AppInputFocusBorder}"/>
+                        <Setter Property="BorderThickness" Value="1.5"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Border.Style>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <PasswordBox x:Name="MaskedBox" Grid.Column="0"
+                         Style="{StaticResource SecretEditorChrome}"
+                         CaretBrush="{DynamicResource AppTextPrimary}"
+                         SelectionBrush="{DynamicResource AppAccent}"
+                         PasswordChanged="MaskedBox_PasswordChanged"/>
+
+            <TextBox x:Name="PlainBox" Grid.Column="0"
+                     Visibility="Collapsed"
+                     Style="{StaticResource SecretEditorChrome}"
+                     CaretBrush="{DynamicResource AppTextPrimary}"
+                     SelectionBrush="{DynamicResource AppAccent}"
+                     TextChanged="PlainBox_TextChanged"/>
+
+            <Button x:Name="RevealToggle" Grid.Column="1"
+                    Style="{StaticResource RevealButton}"
+                    ToolTip="顯示內容"
+                    Click="RevealToggle_Click">
+                <TextBlock x:Name="RevealIcon"
+                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                           FontSize="15"
+                           Text="&#xE7B3;"/>
+            </Button>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/OverTranslate/Views/Controls/SecretBox.xaml.cs
+++ b/src/OverTranslate/Views/Controls/SecretBox.xaml.cs
@@ -1,0 +1,84 @@
+using System.Windows;
+using System.Windows.Controls;
+// UseWindowsForms puts System.Windows.Forms in the implicit usings, so this name collides
+using UserControl = System.Windows.Controls.UserControl;
+
+namespace OverTranslate.Views.Controls;
+
+/// <summary>
+/// A single-line editor for secrets (API keys): masked by default, with an eye button that
+/// reveals the value. WPF's PasswordBox cannot show its own text, so the control keeps a
+/// PasswordBox and a TextBox in step and swaps which one is visible.
+/// </summary>
+public partial class SecretBox : UserControl
+{
+    // Copying the value into the twin control raises its change event; the flag stops that
+    // echo from being reported as a user edit.
+    private bool _syncing;
+    private bool _revealed;
+
+    public SecretBox()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>Raised when the user edits the value, in either display mode.</summary>
+    public event EventHandler? SecretChanged;
+
+    /// <summary>The value being edited. Setting it does not raise <see cref="SecretChanged"/>.</summary>
+    public string Secret
+    {
+        get => MaskedBox.Password;
+        set
+        {
+            var text = value ?? "";
+            if (MaskedBox.Password == text && PlainBox.Text == text) return;
+
+            _syncing = true;
+            MaskedBox.Password = text;
+            PlainBox.Text = text;
+            _syncing = false;
+        }
+    }
+
+    private void MaskedBox_PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (_syncing) return;
+        _syncing = true;
+        PlainBox.Text = MaskedBox.Password;
+        _syncing = false;
+        SecretChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void PlainBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_syncing) return;
+        _syncing = true;
+        MaskedBox.Password = PlainBox.Text;
+        _syncing = false;
+        SecretChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void RevealToggle_Click(object sender, RoutedEventArgs e)
+    {
+        _revealed = !_revealed;
+
+        PlainBox.Visibility = _revealed ? Visibility.Visible : Visibility.Collapsed;
+        MaskedBox.Visibility = _revealed ? Visibility.Collapsed : Visibility.Visible;
+
+        // Segoe Fluent Icons: Hide (crossed-out eye) while revealed, RedEye while masked.
+        RevealIcon.Text = _revealed ? "" : "";
+        RevealToggle.ToolTip = _revealed ? "隱藏內容" : "顯示內容";
+
+        // Keep the caret where the user was typing instead of dropping focus on the button.
+        if (_revealed)
+        {
+            PlainBox.Focus();
+            PlainBox.CaretIndex = PlainBox.Text.Length;
+        }
+        else
+        {
+            MaskedBox.Focus();
+        }
+    }
+}

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="OverTranslate.Views.Settings.SettingsPage"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:OverTranslate.Views.Controls">
 
     <Grid Margin="28,22,28,20">
         <Grid.RowDefinitions>
@@ -184,9 +185,8 @@
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0" x:Name="ApiKeyLabel"
                                        Text="API Key" Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="1" x:Name="ApiKeyBox"
-                                       Style="{StaticResource ModernTextBox}"
-                                       TextChanged="ApiKeyBox_TextChanged"/>
+                            <controls:SecretBox Grid.Column="1" x:Name="ApiKeyBox"
+                                                SecretChanged="ApiKeyBox_SecretChanged"/>
                         </Grid>
 
                         <!-- OpenAI Compatible settings (conditionally visible) -->
@@ -211,10 +211,9 @@
                             <TextBlock Grid.Column="0" Grid.Row="1" Text="API Key"
                                        Margin="0,10,0,0"
                                        Style="{StaticResource FieldLabel}"/>
-                            <TextBox Grid.Column="1" Grid.Row="1" x:Name="OpenAiApiKeyBox"
-                                     Margin="0,10,0,0"
-                                     Style="{StaticResource ModernTextBox}"
-                                     TextChanged="OpenAiSetting_TextChanged"/>
+                            <controls:SecretBox Grid.Column="1" Grid.Row="1" x:Name="OpenAiApiKeyBox"
+                                                Margin="0,10,0,0"
+                                                SecretChanged="OpenAiSecret_SecretChanged"/>
 
                             <TextBlock Grid.Column="0" Grid.Row="2" Text="模型名稱"
                                        Margin="0,10,0,0"

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -91,7 +91,7 @@ public partial class SettingsPage : UserControl
         _apiKeyDebounce.Tick += (_, _) =>
         {
             _apiKeyDebounce.Stop();
-            Persist(s => s.ApiKey = ApiKeyBox.Text.Trim());
+            Persist(s => s.ApiKey = ApiKeyBox.Secret.Trim());
         };
 
         _openAiSettingsDebounce = new DispatcherTimer { Interval = ApiKeyDebounce };
@@ -101,7 +101,7 @@ public partial class SettingsPage : UserControl
             Persist(s =>
             {
                 s.OpenAiBaseUrl = OpenAiBaseUrlBox.Text.Trim();
-                s.OpenAiApiKey = OpenAiApiKeyBox.Text.Trim();
+                s.OpenAiApiKey = OpenAiApiKeyBox.Secret.Trim();
                 s.OpenAiModel = OpenAiModelBox.Text.Trim();
             });
         };
@@ -135,9 +135,9 @@ public partial class SettingsPage : UserControl
             ProviderHint.Text = (ProviderBox.SelectedItem as ProviderItem)?.Hint ?? "";
 
             foreach (var field in _hotkeyFields) field.Box.Text = field.Display(s);
-            ApiKeyBox.Text = s.ApiKey;
+            ApiKeyBox.Secret = s.ApiKey;
             OpenAiBaseUrlBox.Text = s.OpenAiBaseUrl;
-            OpenAiApiKeyBox.Text = s.OpenAiApiKey;
+            OpenAiApiKeyBox.Secret = s.OpenAiApiKey;
             OpenAiModelBox.Text = s.OpenAiModel;
 
             LightThemeRadio.IsChecked = s.Theme != ThemeService.Dark;
@@ -220,7 +220,7 @@ public partial class SettingsPage : UserControl
             : TranslationProvider.Microsoft);
     }
 
-    private void ApiKeyBox_TextChanged(object sender, TextChangedEventArgs e)
+    private void ApiKeyBox_SecretChanged(object? sender, EventArgs e)
     {
         if (_loading) return;
         _apiKeyDebounce.Stop();
@@ -228,6 +228,13 @@ public partial class SettingsPage : UserControl
     }
 
     private void OpenAiSetting_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (_loading) return;
+        _openAiSettingsDebounce.Stop();
+        _openAiSettingsDebounce.Start();
+    }
+
+    private void OpenAiSecret_SecretChanged(object? sender, EventArgs e)
     {
         if (_loading) return;
         _openAiSettingsDebounce.Stop();


### PR DESCRIPTION
## 變更內容

設定頁的 DeepL / OpenAI API Key 原本是一般 TextBox，內容直接明文顯示。改為預設遮蔽（`••••••`），右側加上眼睛按鈕，點擊才顯示原內容。

新增共用控制項 `Views/Controls/SecretBox`：

- WPF 的 `PasswordBox` 無法讀寫顯示自身文字，因此控制項內部同時放 `PasswordBox` 與 `TextBox`，兩者互相同步、切換誰可見。
- 外框只有一個 Border，外觀與 `ModernTextBox` 一致（含 focus 邊框），避免兩種輸入框長得不一樣。
- 眼睛圖示使用 Segoe Fluent Icons（遮蔽時 RedEye、顯示時 Hide），切換時焦點與游標會跟著移到目前的輸入框。
- 對外只有 `Secret` 屬性與 `SecretChanged` 事件；`SettingsPage` 既有的 600ms debounce 儲存邏輯不變。

## 驗證

- 實機啟動走到設定頁：預設顯示遮蔽字元，點眼睛後正確顯示原文，再點一次回到遮蔽。
- 無障礙樹上 `PasswordBox` 的值顯示為 `[redacted]`，UI Automation 也讀不到內容。
- `dotnet test`：344 通過、0 失敗。

## 附帶確認

順道檢查了 API Key 是否會寫進 log，結論是不會，即使勾選「記錄詳細資訊」也不會：

- 全專案的 log 呼叫沒有任何一個帶入 API Key 變數；`SettingsService` 只記錄檔案路徑與例外，不會 dump 設定內容。
- 金鑰只走 HTTP header（DeepL 的 `DeepL-Auth-Key`、OpenAI 相容的 `Bearer`），不進 URL，所以例外訊息也不會帶出金鑰。