### PR TITLE
feat: 更新提醒改為可跳過版本並常駐側邊欄入口，新增每小時背景檢查

### DIFF
--- a/src/OverTranslate/App.xaml.cs
+++ b/src/OverTranslate/App.xaml.cs
@@ -89,14 +89,25 @@ public partial class App
         MainWindow = mainWindow;
         mainWindow.InitializeApp();
 
-        _ = CheckForUpdateAsync();
+        UpdateNotifier.StartPolling();
+        _ = PromptForUpdateAsync();
     }
 
-    private static async Task CheckForUpdateAsync()
+    /// <summary>
+    /// The one update check allowed to put a window on the screen.
+    /// </summary>
+    /// <remarks>
+    /// Every later check — see <see cref="UpdateNotifier.StartPolling"/> — only lights up the nav
+    /// rail. This used to be the only check there was, which meant the dialog was the sole way an
+    /// update could ever be announced, which in turn meant it had to reappear on every single launch
+    /// until the user gave in. It no longer has to carry that alone: 跳過此版本 turns it off for a
+    /// release without taking the rail's entry with it.
+    /// </remarks>
+    private static async Task PromptForUpdateAsync()
     {
-        var info = await UpdateService.CheckAsync();
-        if (info is null) return;
-        Current.Dispatcher.Invoke(() => new UpdateWindow(info).Show());
+        var info = await UpdateNotifier.CheckAsync();
+        if (info is null || UpdateNotifier.IsSkipped(info)) return;
+        Current.Dispatcher.Invoke(() => UpdateWindow.ShowOrActivate(info));
     }
 
     private void MonitorActivationRequests()

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -49,4 +49,15 @@ public class AppSettings
     public string RealtimeTextColor { get; set; } = Services.Realtime.RealtimeSubtitleColors.DefaultText;
     /// <inheritdoc cref="RealtimeTextColor"/>
     public string RealtimeScrimColor { get; set; } = Services.Realtime.RealtimeSubtitleColors.DefaultScrim;
+
+    /// <summary>
+    /// The newest version the user has told us to stop interrupting them about, or empty for none.
+    /// </summary>
+    /// <remarks>
+    /// Compared as a version rather than for equality, so it silences that release and nothing later:
+    /// skipping 1.9.0 leaves 1.9.1 free to prompt again. It suppresses only the startup dialog — the
+    /// nav rail still offers the update — because what the user declined was being interrupted, not
+    /// the update itself. See <see cref="Services.UpdateNotifier"/>.
+    /// </remarks>
+    public string SkippedUpdateVersion { get; set; } = "";
 }

--- a/src/OverTranslate/Services/UpdateNotifier.cs
+++ b/src/OverTranslate/Services/UpdateNotifier.cs
@@ -1,0 +1,140 @@
+using System.Windows.Threading;
+using NLog;
+using Velopack;
+
+namespace OverTranslate.Services;
+
+/// <summary>
+/// The application's single source of truth for "is there a newer version", and the only thing that
+/// goes looking for one.
+/// </summary>
+/// <remarks>
+/// It exists because the nav rail cannot own this state. <see cref="Views.Shell.ShellWindow"/> is
+/// created on demand and destroyed on close, while the application itself lives in the tray for
+/// days, so a result found at startup — or four hours into a session with no window open — has
+/// nowhere to live unless something outside the window holds it.
+///
+/// Nothing here shows anything. It answers a question and raises
+/// <see cref="AvailabilityChanged"/>; deciding whether that warrants putting something on screen
+/// belongs to the callers, and only one of them ever does — the startup check in App. Every
+/// subsequent check is deliberately silent, which is the whole point of the periodic one: an
+/// application that is left running for a week used to have exactly one chance to notice a release,
+/// and taking that chance meant a dialog on every launch.
+/// </remarks>
+public static class UpdateNotifier
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    /// <remarks>
+    /// Paced for the user who never closes the application rather than for the release schedule.
+    /// The cost is not a consideration here: one check is a request or two against GitHub's
+    /// unauthenticated limit of 60 an hour, and the release listing it reads is tens of kilobytes.
+    /// </remarks>
+    private static readonly TimeSpan PollInterval = ResolvePollInterval();
+
+    private static DispatcherTimer? _timer;
+
+    /// <summary>
+    /// The interval, or whatever OVERTRANSLATE_UPDATE_POLL_SECONDS overrides it to.
+    /// </summary>
+    /// <remarks>
+    /// An hour is not a thing anyone can sit and verify, and the periodic check is the whole reason
+    /// this class exists — so it gets the same treatment as the release itself (see
+    /// <see cref="UpdateService"/>'s OVERTRANSLATE_FAKE_UPDATE): unset it behaves exactly as
+    /// shipped, set it turns "wait an hour" into a few seconds.
+    /// </remarks>
+    private static TimeSpan ResolvePollInterval()
+    {
+        var raw = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_POLL_SECONDS");
+        if (double.TryParse(raw, out var seconds) && seconds > 0)
+            return TimeSpan.FromSeconds(seconds);
+
+        return TimeSpan.FromHours(1);
+    }
+
+    /// <summary>The newest release found so far, or null while none has been seen.</summary>
+    public static UpdateInfo? Available { get; private set; }
+
+    /// <summary>
+    /// Raised on the UI thread when <see cref="Available"/> starts pointing at a different version.
+    /// </summary>
+    public static event EventHandler? AvailabilityChanged;
+
+    /// <summary>
+    /// Begins checking every few hours. Does not check immediately — the caller's own startup check
+    /// covers that moment and is the one allowed to prompt.
+    /// </summary>
+    public static void StartPolling()
+    {
+        if (_timer is not null) return;
+
+        // Background priority: this is never what the user is waiting on, and the tick fires while
+        // they may be mid-capture.
+        _timer = new DispatcherTimer(DispatcherPriority.Background) { Interval = PollInterval };
+        _timer.Tick += async (_, _) => await CheckAsync();
+        _timer.Start();
+    }
+
+    /// <summary>
+    /// Asks for the latest release and records it. Returns it, or null when there is nothing newer.
+    /// </summary>
+    public static async Task<UpdateInfo?> CheckAsync()
+    {
+        UpdateInfo? info;
+        try
+        {
+            info = await UpdateService.CheckAsync();
+        }
+        catch (Exception ex)
+        {
+            // Nothing awaits the timer's call, so an escaping exception would otherwise be silent.
+            Log.Warn(ex, "Update check failed");
+            return null;
+        }
+
+        // A null answer means one of three things — up to date, not an installed build, or the check
+        // failed — and CheckAsync flattens all three, so the only safe reading is "learned nothing".
+        // Clearing Available on it would let one dropped connection take an update the user has
+        // already been told about back off the nav rail. Nothing is lost by keeping it: applying an
+        // update restarts the process, so a stale Available cannot outlive the version it refers to.
+        if (info is null) return null;
+
+        if (Available?.LatestVersion != info.LatestVersion)
+        {
+            Available = info;
+            AvailabilityChanged?.Invoke(null, EventArgs.Empty);
+        }
+
+        return info;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="info"/> is covered by the user's 跳過此版本 choice.
+    /// </summary>
+    public static bool IsSkipped(UpdateInfo info)
+    {
+        var skipped = SettingsService.Instance.Current.SkippedUpdateVersion;
+        if (string.IsNullOrWhiteSpace(skipped)) return false;
+
+        // A stored value we cannot read is treated as no choice at all, so a hand-edited settings
+        // file cannot silence updates permanently.
+        if (!SemanticVersion.TryParse(skipped, out var skippedVersion))
+        {
+            Log.Warn("Ignoring unreadable SkippedUpdateVersion '{0}'", skipped);
+            return false;
+        }
+
+        return info.VelopackInfo.TargetFullRelease.Version <= skippedVersion;
+    }
+
+    /// <summary>
+    /// Records that the startup dialog should stay quiet until something newer than
+    /// <paramref name="info"/> is released.
+    /// </summary>
+    public static void Skip(UpdateInfo info)
+    {
+        SettingsService.Instance.Current.SkippedUpdateVersion =
+            info.VelopackInfo.TargetFullRelease.Version.ToString();
+        SettingsService.Instance.Save();
+    }
+}

--- a/src/OverTranslate/Services/UpdateService.cs
+++ b/src/OverTranslate/Services/UpdateService.cs
@@ -15,8 +15,15 @@ public static class UpdateService
     private const string StableChannel = "win";
     private const string BetaChannel = "beta";
 
+    // How many times the faked check has been asked; see OVERTRANSLATE_FAKE_UPDATE_AFTER.
+    private static int _fakeCheckCount;
+
     public static async Task<UpdateInfo?> CheckAsync()
     {
+        var fake = CreateFakeUpdate();
+        if (fake is not null)
+            return fake;
+
         try
         {
             var manager = CreateManager();
@@ -56,6 +63,60 @@ public static class UpdateService
             await onApplying();
 
         info.Manager.ApplyUpdatesAndRestart(info.VelopackInfo);
+    }
+
+    /// <summary>
+    /// Pretends a release exists, when OVERTRANSLATE_FAKE_UPDATE names a version. Returns null —
+    /// meaning "check for real" — when it does not.
+    /// </summary>
+    /// <remarks>
+    /// Everything the update notification does now — the startup dialog, 跳過此版本, the nav rail's
+    /// row, the periodic re-check — is decided before a single byte is downloaded, and none of it
+    /// can be exercised without a release to react to. Without this hook the only ways to see any of
+    /// it are publishing to GitHub, which pushes the release at real users, or installing a private
+    /// build, which cannot show the "no update yet" side at all. It also unblocks running from the
+    /// IDE, where <see cref="UpdateManager.IsInstalled"/> is false and the real check therefore
+    /// always answers null.
+    ///
+    /// An environment variable rather than a setting or a #if, matching OVERTRANSLATE_CHANNEL below:
+    /// it does nothing whatsoever unless deliberately set, it needs no build of its own, and it can
+    /// be pointed at a Release build. Downloading is the one thing it cannot fake — there is no
+    /// package behind the version it invents, so 立即更新 will fail and report so. That path is
+    /// unchanged by this work; test it against a real release.
+    ///
+    /// OVERTRANSLATE_FAKE_UPDATE_AFTER holds the release back for that many checks, which is the
+    /// only way to see the half that matters most: a release that did not exist at launch has to
+    /// reach the nav rail of an already-open window without a dialog appearing. Left unset, the
+    /// release is there from the first check and the startup dialog is what you get.
+    /// </remarks>
+    private static UpdateInfo? CreateFakeUpdate()
+    {
+        var version = Environment.GetEnvironmentVariable("OVERTRANSLATE_FAKE_UPDATE");
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+
+        if (!SemanticVersion.TryParse(version, out var parsed))
+            return null;
+
+        var checksSoFar = Interlocked.Increment(ref _fakeCheckCount);
+        if (int.TryParse(Environment.GetEnvironmentVariable("OVERTRANSLATE_FAKE_UPDATE_AFTER"), out var after)
+            && checksSoFar <= after)
+        {
+            return null;
+        }
+
+        var asset = new VelopackAsset
+        {
+            PackageId = "OverTranslate",
+            Version = parsed,
+            Type = VelopackAssetType.Full,
+            FileName = $"OverTranslate-{parsed}-full.nupkg"
+        };
+
+        return new UpdateInfo(
+            parsed.ToString(),
+            CreateManager(),
+            new VelopackUpdateInfo(asset, false, null!, []));
     }
 
     private static UpdateManager CreateManager()

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -857,6 +857,59 @@
         </Setter>
     </Style>
 
+    <!-- The rail's "there is a newer version" badge, under the version number it contradicts.
+         A badge rather than a nav row: it states a fact about this copy of the application, which
+         is what that corner of the rail is already for, and it is absent whenever the fact is not
+         true. Sizing follows the version label it hangs off (11px) rather than the nav items, so it
+         reads as an annotation on the brand block instead of a fourth destination.
+
+         Tonal fill with no accent outline. NavPrimaryAction's outlined treatment is what 截圖翻譯
+         uses to claim the rail's primary action, and repeating it here would have news out-shouting
+         the button the user actually came for. The border is one step up the same tonal ramp — just
+         enough to give the fill an edge on the sidebar's own background.
+
+         Fully rounded, unlike every other surface in the app at 6. That is the point: a pill is the
+         shape of a label, a 6px rectangle is the shape of a button, and this is a statement about
+         the application that happens to be clickable rather than a control the rail is offering.
+
+         Hover and press walk AppAccentSubtle's own steps rather than the neutral button greys: a
+         tinted surface that turns grey under the pointer reads as a different control appearing. -->
+    <Style x:Key="RailUpdateChip" TargetType="Button">
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"        Value="10"/>
+        <Setter Property="Foreground"      Value="{DynamicResource AppAccent}"/>
+        <Setter Property="Background"      Value="{DynamicResource AppAccentSubtle}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource AppAccentSubtleHover}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Cursor"          Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="9.5"
+                            Padding="9,0"
+                            Height="19">
+                        <ContentPresenter VerticalAlignment="Center"
+                                          HorizontalAlignment="Left"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppAccentSubtleHover}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppAccentSubtlePressed}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Same visuals, no selected state — for actions that open a dialog
          rather than switching pages (關於) -->
     <Style x:Key="NavActionItem" TargetType="Button">

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -56,6 +56,30 @@
                     </StackPanel>
                 </Button>
 
+                <!-- The application's only lasting way of saying a new version exists. It is absent
+                     entirely until one does — an always-present row reading "已是最新版本" would be
+                     a permanent fixture that is right about nothing the user needs to act on.
+
+                     Docked after 關於 so it lands above it, and carrying the accent colour so it
+                     reads as news rather than as another destination. Whether it appears is driven
+                     by UpdateNotifier rather than by anything this window knows: the shell is built
+                     on demand and destroyed on close, while the check that found the release may
+                     have run hours before this window existed. -->
+                <Button x:Name="UpdateBtn"
+                        DockPanel.Dock="Bottom"
+                        Style="{StaticResource NavActionItem}"
+                        Foreground="{DynamicResource AppAccent}"
+                        Margin="8,0,8,0"
+                        Visibility="Collapsed"
+                        Click="UpdateBtn_Click">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="14" Text="&#xE896;"
+                                   Width="24" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="UpdateBtnText" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
                 <!-- 截圖翻譯 — the app's primary action, and since the tray menu no longer
                      offers it, the only place other than the shortcut itself. It sits above the
                      nav list rather than inside it because it performs an action instead of

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -22,13 +22,46 @@
                 BorderThickness="0,0,1,0">
             <DockPanel>
 
-                <!-- Brand -->
-                <StackPanel DockPanel.Dock="Top"
-                            Orientation="Horizontal"
-                            Margin="18,18,16,20">
-                    <Image x:Name="BrandIcon" Width="30" Height="30"
+                <!-- Brand.
+
+                     A two-row grid rather than nested stacks, so both of the alignments here hold
+                     themselves together instead of being maintained by hand.
+
+                     The mark's height is bound to the name-and-version column beside it, which caps
+                     it to exactly the block of text it belongs to — top edge on the wordmark's
+                     ascender, bottom edge on the version's descender — and keeps it there if either
+                     type size is ever changed. Width is left free so Stretch works the aspect ratio
+                     out; the artwork is square, so it follows.
+
+                     The badge sits on the second row of the same column as the text, so it starts
+                     on the wordmark's left edge without anyone computing an indent from the mark's
+                     width. It is deliberately outside the height binding: the mark answers to the
+                     name and version, which are always there, and not to a badge that comes and
+                     goes — otherwise the mark would resize itself every time a release appeared. -->
+                <Grid DockPanel.Dock="Top" Margin="18,18,16,20">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- These are a seed, not the final size: MatchBrandIconToText replaces both the
+                         moment the text beside it has been measured, so the mark ends up exactly as
+                         tall as the wordmark and version together. Both dimensions are always set
+                         together — the column is Auto, so an Image left to work its own width out
+                         would report the source bitmap's and take the whole rail. -->
+                    <Image x:Name="BrandIcon"
+                           Grid.Row="0" Grid.Column="0"
+                           Width="34" Height="34"
+                           VerticalAlignment="Top"
                            RenderOptions.BitmapScalingMode="HighQuality"/>
-                    <StackPanel Margin="10,0,0,0" VerticalAlignment="Center">
+
+                    <StackPanel x:Name="BrandText"
+                                Grid.Row="0" Grid.Column="1"
+                                Margin="10,0,0,0">
                         <TextBlock Text="OverTranslate"
                                    FontFamily="{StaticResource AppFont}"
                                    FontSize="14"
@@ -39,7 +72,63 @@
                                    FontSize="11"
                                    Foreground="{DynamicResource AppTextSecondary}"/>
                     </StackPanel>
-                </StackPanel>
+
+                    <!-- The application's only lasting way of saying a new version exists, and
+                         absent entirely until one does — a permanent badge reading "已是最新版本"
+                         would be a fixture that is right about nothing the user needs to act on.
+                         It sits under the version it contradicts, so the claim and its subject are
+                         read together.
+
+                         Whether it appears is driven by UpdateNotifier rather than by anything this
+                         window knows: the shell is built on demand and destroyed on close, while
+                         the check that found the release may have run hours before this window
+                         existed.
+
+                         A DockPanel inside, not a StackPanel: a horizontal StackPanel measures its
+                         children against infinite width, so the label would never trim and a long
+                         beta version string would run straight out of the rail. Docking the icon
+                         gives the label the remaining width to trim against — and the grid column
+                         is what bounds that width, so no MaxWidth has to be kept in step with the
+                         rail's own. -->
+                    <Button x:Name="UpdateBtn"
+                            Grid.Row="1" Grid.Column="1"
+                            Style="{StaticResource RailUpdateChip}"
+                            HorizontalAlignment="Left"
+                            Margin="10,5,0,0"
+                            Visibility="Collapsed"
+                            Click="UpdateBtn_Click">
+                        <DockPanel>
+                            <!-- Drawn rather than set in Segoe, because Segoe has no circled arrow
+                                 and its circled glyphs (E946, E930) lose their interior below about
+                                 14px anyway — at the 11px this line is set in, the ring survives and
+                                 whatever is inside it does not. A Canvas, not a Grid: Grid centres
+                                 each child by its own bounding box, which would drop the arrowhead
+                                 to the circle's centre instead of its upper half. Canvas keeps the
+                                 literal coordinates, and the Viewbox scales the finished 24-unit
+                                 drawing down to the size the text needs. -->
+                            <Viewbox DockPanel.Dock="Left"
+                                     Width="14" Height="14"
+                                     VerticalAlignment="Center"
+                                     Margin="0,0,6,0">
+                                <Canvas Width="24" Height="24">
+                                    <Ellipse Canvas.Left="2" Canvas.Top="2"
+                                             Width="20" Height="20"
+                                             Stroke="{DynamicResource AppAccent}"
+                                             StrokeThickness="1.75"/>
+                                    <Path Stroke="{DynamicResource AppAccent}"
+                                          StrokeThickness="1.75"
+                                          StrokeStartLineCap="Round"
+                                          StrokeEndLineCap="Round"
+                                          StrokeLineJoin="Round"
+                                          Data="M16,12 L12,8 L8,12 M12,16 L12,8"/>
+                                </Canvas>
+                            </Viewbox>
+                            <TextBlock x:Name="UpdateBtnText"
+                                       VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"/>
+                        </DockPanel>
+                    </Button>
+                </Grid>
 
                 <!-- 關於 opens a modal overlay rather than switching pages, so it sits
                      apart from the nav list and never takes the selected state -->
@@ -56,29 +145,15 @@
                     </StackPanel>
                 </Button>
 
-                <!-- The application's only lasting way of saying a new version exists. It is absent
-                     entirely until one does — an always-present row reading "已是最新版本" would be
-                     a permanent fixture that is right about nothing the user needs to act on.
-
-                     Docked after 關於 so it lands above it, and carrying the accent colour so it
-                     reads as news rather than as another destination. Whether it appears is driven
-                     by UpdateNotifier rather than by anything this window knows: the shell is built
-                     on demand and destroyed on close, while the check that found the release may
-                     have run hours before this window existed. -->
-                <Button x:Name="UpdateBtn"
-                        DockPanel.Dock="Bottom"
-                        Style="{StaticResource NavActionItem}"
-                        Foreground="{DynamicResource AppAccent}"
-                        Margin="8,0,8,0"
-                        Visibility="Collapsed"
-                        Click="UpdateBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="14" Text="&#xE896;"
-                                   Width="24" VerticalAlignment="Center"/>
-                        <TextBlock x:Name="UpdateBtnText" VerticalAlignment="Center"/>
-                    </StackPanel>
-                </Button>
+                <!-- Docked after 關於 so it lands above it. 關於 is the one item down here and the
+                     nav list ends a long way above it, so without a line the two read as one list
+                     with a large accidental gap in it. Inset to 16 so it starts and ends on the
+                     same vertical as the nav rows' own edges, which is what makes it read as
+                     dividing them rather than as a stray rule. -->
+                <Border DockPanel.Dock="Bottom"
+                        Height="1"
+                        Margin="16,0,16,10"
+                        Background="{DynamicResource AppBorder}"/>
 
                 <!-- 截圖翻譯 — the app's primary action, and since the tray menu no longer
                      offers it, the only place other than the shortcut itself. It sits above the

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -86,6 +86,11 @@ public partial class ShellWindow : Window
         Realtime.RealtimeSessionController.Instance.StateChanged += OnRealtimeStateChanged;
         RefreshCaptureAvailability();
 
+        // Same reasoning, and one more: the periodic check runs whether or not this window exists,
+        // so the rail has to be able to gain the row while the user is sitting in front of it.
+        UpdateNotifier.AvailabilityChanged += OnUpdateAvailabilityChanged;
+        RefreshUpdateAvailability();
+
         // Nav_Checked drives navigation, so this also renders the initial page
         TranslationNav.IsChecked = true;
     }
@@ -125,6 +130,39 @@ public partial class ShellWindow : Window
 
         CaptureBtn.IsEnabled = !running;
         CaptureBtn.ToolTip = running ? "即時翻譯進行中，請先結束後再使用截圖翻譯" : null;
+    }
+
+    private void OnUpdateAvailabilityChanged(object? sender, EventArgs e) =>
+        Dispatcher.BeginInvoke(RefreshUpdateAvailability);
+
+    /// <summary>
+    /// Shows or hides the rail's 有新版本 row to match what <see cref="UpdateNotifier"/> has found.
+    /// </summary>
+    /// <remarks>
+    /// Unaffected by 跳過此版本 by design — that choice silences the startup dialog, and taking the
+    /// rail's entry away with it would leave a user who skipped a release with no way back to it
+    /// short of reinstalling.
+    /// </remarks>
+    private void RefreshUpdateAvailability()
+    {
+        var update = UpdateNotifier.Available;
+        if (update is null)
+        {
+            UpdateBtn.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        // The version is on the row itself rather than behind a hover: it is the one piece of
+        // information that tells the user whether this is the release they already decided about.
+        UpdateBtnText.Text = $"有新版本 {update.LatestVersion}";
+        UpdateBtn.Visibility = Visibility.Visible;
+    }
+
+    private void UpdateBtn_Click(object sender, RoutedEventArgs e)
+    {
+        var update = UpdateNotifier.Available;
+        if (update is null) return;
+        UpdateWindow.ShowOrActivate(update);
     }
 
     private void CaptureBtn_Click(object sender, RoutedEventArgs e)
@@ -279,6 +317,9 @@ public partial class ShellWindow : Window
         // on the screen, not in this window, and closing the shell is not a request to end it.
         _realtimePage.Teardown();
         Realtime.RealtimeSessionController.Instance.StateChanged -= OnRealtimeStateChanged;
+        // UpdateNotifier is static and outlives every window, so a handler left attached would keep
+        // this closed window alive for as long as the application runs.
+        UpdateNotifier.AvailabilityChanged -= OnUpdateAvailabilityChanged;
         _instance = null;
         base.OnClosed(e);
     }

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -78,6 +78,7 @@ public partial class ShellWindow : Window
         VersionText.Text = $"v{Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0"}";
 
         _instance = this;
+        MatchBrandIconToText();
         RefreshHotkeyHint();
 
         // Subscribed rather than refreshed on show: a session ending brings this window back with
@@ -93,6 +94,30 @@ public partial class ShellWindow : Window
 
         // Nav_Checked drives navigation, so this also renders the initial page
         TranslationNav.IsChecked = true;
+    }
+
+    /// <summary>
+    /// Caps the brand mark to the height of the wordmark and version beside it.
+    /// </summary>
+    /// <remarks>
+    /// A size-changed handler rather than a binding on ActualHeight. The grid's first column is
+    /// Auto, so its width comes from the image's desired width, which under a binding is still the
+    /// source bitmap's own until the binding has resolved — by which point the column has claimed
+    /// the whole rail and squeezed out the text the height was to be measured from. Measuring after
+    /// the text has been laid out has no such ordering to lose.
+    ///
+    /// Only on a height change. Setting the image's width resizes the Auto column, which resizes
+    /// the starred column beside it, which raises this event again — reacting to that would loop.
+    /// The badge is deliberately not part of the measurement: it is on its own row, so a release
+    /// appearing never resizes the mark.
+    /// </remarks>
+    private void MatchBrandIconToText()
+    {
+        BrandText.SizeChanged += (_, e) =>
+        {
+            if (!e.HeightChanged) return;
+            BrandIcon.Width = BrandIcon.Height = e.NewSize.Height;
+        };
     }
 
     /// <summary>
@@ -136,12 +161,12 @@ public partial class ShellWindow : Window
         Dispatcher.BeginInvoke(RefreshUpdateAvailability);
 
     /// <summary>
-    /// Shows or hides the rail's 有新版本 row to match what <see cref="UpdateNotifier"/> has found.
+    /// Shows or hides the rail's update badge to match what <see cref="UpdateNotifier"/> has found.
     /// </summary>
     /// <remarks>
     /// Unaffected by 跳過此版本 by design — that choice silences the startup dialog, and taking the
-    /// rail's entry away with it would leave a user who skipped a release with no way back to it
-    /// short of reinstalling.
+    /// badge away with it would leave a user who skipped a release with no way back to it short of
+    /// reinstalling.
     /// </remarks>
     private void RefreshUpdateAvailability()
     {
@@ -152,9 +177,11 @@ public partial class ShellWindow : Window
             return;
         }
 
-        // The version is on the row itself rather than behind a hover: it is the one piece of
+        // The version is on the badge itself rather than behind a hover: it is the one piece of
         // information that tells the user whether this is the release they already decided about.
-        UpdateBtnText.Text = $"有新版本 {update.LatestVersion}";
+        // 「至」carries the relationship to the version directly above — this is where that number
+        // goes, not merely that a number exists. "v" matches that label's own formatting.
+        UpdateBtnText.Text = $"可更新至 v{update.LatestVersion}";
         UpdateBtn.Visibility = Visibility.Visible;
     }
 

--- a/src/OverTranslate/Views/Shell/UpdateWindow.xaml
+++ b/src/OverTranslate/Views/Shell/UpdateWindow.xaml
@@ -97,30 +97,48 @@
         </Border>
 
         <!-- 按鈕列 -->
-        <Grid Grid.Row="2" Margin="0,12,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <Button x:Name="DismissBtn" Grid.Column="0" Content="稍後再說"
-                    Style="{StaticResource FlatButton}"
-                    Height="36"
-                    Click="DismissBtn_Click"/>
-            <Button x:Name="DownloadBtn" Grid.Column="2"
-                    Style="{StaticResource AccentButton}"
-                    Height="36"
-                    Click="DownloadBtn_Click">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                               FontSize="13" Text="&#xE896;"
-                               VerticalAlignment="Center"
-                               Margin="0,0,6,0"/>
-                    <TextBlock x:Name="DownloadBtnText" Text="立即更新"
-                               FontFamily="{StaticResource AppFont}"
-                               VerticalAlignment="Center"/>
-                </StackPanel>
-            </Button>
-        </Grid>
+        <StackPanel Grid.Row="2" Margin="0,12,0,0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="8"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Button x:Name="DismissBtn" Grid.Column="0" Content="稍後再說"
+                        Style="{StaticResource FlatButton}"
+                        Height="36"
+                        Click="DismissBtn_Click"/>
+                <Button x:Name="DownloadBtn" Grid.Column="2"
+                        Style="{StaticResource AccentButton}"
+                        Height="36"
+                        Click="DownloadBtn_Click">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="13" Text="&#xE896;"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,6,0"/>
+                        <TextBlock x:Name="DownloadBtnText" Text="立即更新"
+                                   FontFamily="{StaticResource AppFont}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+            </Grid>
+
+            <!-- Below the pair rather than beside it, and unstyled as a link rather than a third
+                 button: 稍後再說 and 立即更新 are the two answers to the question being asked, while
+                 this one changes what the application does in future. Giving it equal weight in the
+                 row would put a lasting choice one mis-click away from the dismiss button it would
+                 sit next to. -->
+            <TextBlock HorizontalAlignment="Center"
+                       Margin="0,10,0,0"
+                       FontFamily="{StaticResource AppFont}"
+                       FontSize="12"
+                       Foreground="{DynamicResource AppTextSecondary}">
+                <Hyperlink x:Name="SkipVersionLink"
+                           Foreground="{DynamicResource AppTextSecondary}"
+                           TextDecorations="None"
+                           Click="SkipVersionLink_Click">跳過此版本，不要再提醒我</Hyperlink>
+            </TextBlock>
+        </StackPanel>
     </Grid>
 </Window>

--- a/src/OverTranslate/Views/Shell/UpdateWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/UpdateWindow.xaml.cs
@@ -10,8 +10,32 @@ namespace OverTranslate.Views.Shell;
 
 public partial class UpdateWindow : Window
 {
+    private static UpdateWindow? _instance;
+
     private readonly UpdateInfo _updateInfo;
     private bool _isUpdating;
+
+    /// <summary>
+    /// Opens the update window, or brings the open one forward.
+    /// </summary>
+    /// <remarks>
+    /// Two entry points reach this now — the startup check and the nav rail's 有新版本 — and the
+    /// rail's is a button the user can press while the window it opens is already on screen behind
+    /// the shell. A second instance would be a second download button for the same release.
+    /// </remarks>
+    public static void ShowOrActivate(UpdateInfo info)
+    {
+        if (_instance is not null)
+        {
+            _instance.Activate();
+            return;
+        }
+
+        var window = new UpdateWindow(info);
+        _instance = window;
+        window.Closed += (_, _) => _instance = null;
+        window.Show();
+    }
 
     public UpdateWindow(UpdateInfo info)
     {
@@ -30,6 +54,7 @@ public partial class UpdateWindow : Window
             _isUpdating = true;
             DismissBtn.IsEnabled = false;
             DownloadBtn.IsEnabled = false;
+            SkipVersionLink.IsEnabled = false;
             ErrorText.Visibility = Visibility.Collapsed;
             DownloadBtnText.Text = "下載中 0%";
             DownloadProgress.IsIndeterminate = false;
@@ -43,6 +68,7 @@ public partial class UpdateWindow : Window
             _isUpdating = false;
             DismissBtn.IsEnabled = true;
             DownloadBtn.IsEnabled = true;
+            SkipVersionLink.IsEnabled = true;
             DownloadBtnText.Text = "重試";
             DownloadProgress.BeginAnimation(System.Windows.Controls.ProgressBar.ValueProperty, null);
             DownloadProgress.IsIndeterminate = false;
@@ -108,6 +134,20 @@ public partial class UpdateWindow : Window
     }
 
     private void DismissBtn_Click(object sender, RoutedEventArgs e) => Close();
+
+    /// <summary>
+    /// Silences the startup dialog for this release and anything older, then closes.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not a refusal of the update: the nav rail keeps offering it, so a user who
+    /// skips a release in the morning and changes their mind that evening has somewhere to go. What
+    /// this turns off is the interruption, which is the part they actually objected to.
+    /// </remarks>
+    private void SkipVersionLink_Click(object sender, RoutedEventArgs e)
+    {
+        UpdateNotifier.Skip(_updateInfo);
+        Close();
+    }
 
     private void ReleaseNotesLink_RequestNavigate(object sender, RequestNavigateEventArgs e)
     {


### PR DESCRIPTION
## 問題

更新頁只要版本有落差，使用者每次開啟應用都會被彈一次，直到他更新為止。

根因是「告知」和「打斷」被綁成同一件事：彈窗是唯一的通知管道，所以它必須重複出現才能確保被看到，而重複出現正是最惹人厭的地方。

## 作法

把兩者拆開。用一個常駐但安靜的入口承擔「告知」，把「打斷」降到最低。

- **啟動時**仍會檢查並彈窗，但多了「跳過此版本」。跳過後記下版本號，只有**更新的**版本才會再提醒（跳過 1.9.0 之後，1.9.1 一出來仍會提醒）。「稍後再說」維持原行為，下次啟動照樣彈。
- **常駐計時器**每小時背景檢查一次。這次檢查**不彈窗、不跳提示**，只點亮側邊欄的徽章——長期不關機的使用者原本完全沒有機會收到更新資訊，因為檢查只在程式啟動時跑。
- **側邊欄徽章**顯示在品牌區版本號下方，只在有新版時出現。**不受「跳過此版本」影響**：跳過關掉的是打擾，不是更新本身，使用者改變主意時還有路可走。

## 主要變更

| 檔案 | 內容 |
|---|---|
| `Services/UpdateNotifier.cs` | 新增。全應用程式唯一的「有無新版」狀態來源、每小時輪詢、跳過版本的判定與寫入 |
| `Models/AppSettings.cs` | 新增 `SkippedUpdateVersion` |
| `App.xaml.cs` | 啟動流程改為 `StartPolling()` + 會尊重跳過設定的 `PromptForUpdateAsync()` |
| `Views/Shell/UpdateWindow.xaml(.cs)` | 新增「跳過此版本」連結、`ShowOrActivate` 單例入口 |
| `Views/Shell/ShellWindow.xaml(.cs)` | 品牌區徽章、「關於」上方的分隔線 |
| `Themes/SharedStyles.xaml` | 新增 `RailUpdateChip` 樣式 |
| `Services/UpdateService.cs` | 新增測試鉤子（見下） |

## 設計上的取捨

**`UpdateNotifier` 為什麼是獨立的靜態服務**：`ShellWindow` 是用時才建、關閉即銷毀，而程式本體在系統匣一待就是好幾天。輪詢在沒有任何視窗存在時也要能記住結果，狀態不能放在視窗裡。

**收到 `null` 時不清除已知的新版**：`UpdateService.CheckAsync()` 把「已是最新」「非安裝版」「檢查失敗」都回傳 `null`，分不出來。清除的話，網路斷一次就會讓徽章消失。不會殘留，因為套用更新必定重啟程式。

**徽章的高度綁定文字欄**：logo 尺寸跟著「名稱＋版本」那一欄走，字級調整時不需要同步改數字。

## 測試

開發環境下 `CheckAsync()` 第一件事是 `if (!manager.IsInstalled) return null`，而 `dotnet run` 跑出來的永遠不是 Velopack 安裝版，因此原本連彈窗都看不到。新增兩個環境變數鉤子，未設時完全不生效：

- `OVERTRANSLATE_FAKE_UPDATE` — 假裝找到指定版本，完全不連網
- `OVERTRANSLATE_FAKE_UPDATE_AFTER` — 前 N 次檢查裝作沒有，用來驗證「輪詢時徽章自己出現且不打擾」
- `OVERTRANSLATE_UPDATE_POLL_SECONDS` — 縮短輪詢間隔

完整步驟與清除指令見 `.ai/TEST-UPDATE-NOTIFICATION.md`。

實際下載與套用無法用這套方法驗證（假版本背後沒有真的 package），但那段流程本次完全沒有更動。

測試套件 344 通過、0 失敗。
