### PR TITLE
壓 tag 自動打包發布 pre-release，並一併產出 portable 版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+# 壓 tag 後自動打包並發成 pre-release。
+#
+# 只發 pre-release，永遠不會直接成為正式版 —— 一般使用者的更新來源是
+# GithubSource(prerelease: false)，看不到標成 pre-release 的 release。
+# 要正式發布時，由人到 GitHub 上手動取消勾選 pre-release。
+#
+# 版號來自 src/OverTranslate/OverTranslate.csproj 的 <Version>，tag 只是觸發器。
+# 所以正常流程是：先發一個調整版號的 commit 到 main，再壓 tag。
+name: 打包並發布 pre-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 覆寫版號（留空則用 csproj 的 <Version>）
+        required: false
+        type: string
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  pack:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: 安裝 Velopack CLI
+        shell: pwsh
+        run: |
+          # 版本鎖死，與 OverTranslate.csproj 的 Velopack 套件一致。
+          # CLI 與 runtime 版本不一致時產出的 delta 可能無法套用。
+          dotnet tool install -g vpk --version 1.2.0
+          "$env:USERPROFILE\.dotnet\tools" | Out-File -Append -Encoding utf8 $env:GITHUB_PATH
+
+      - name: 決定版號
+        id: ver
+        shell: pwsh
+        run: |
+          $version = '${{ inputs.version }}'
+          if ([string]::IsNullOrWhiteSpace($version)) {
+              [xml]$csproj = Get-Content .\src\OverTranslate\OverTranslate.csproj
+              $version = ($csproj.Project.PropertyGroup.Version | Select-Object -First 1).Trim()
+          }
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "找不到版號。" }
+
+          Write-Host "版號：$version"
+          "version=$version" | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
+          "tag=v$version"    | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
+
+      - name: 防呆——這個版號是否已經發布過
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # 忘記調 csproj 版號時，包出來的東西會跟線上某一版同號但內容不同。
+          # 那會讓已經更新過的使用者永遠收不到這一版（版號沒變大），而且不會有任何錯誤。
+          # 寧可在這裡失敗。
+          $target = "OverTranslate-${{ steps.ver.outputs.version }}-full.nupkg"
+          $existing = gh api --paginate repos/${{ github.repository }}/releases `
+              --jq '.[].assets[].name' 2>$null
+          if ($existing -contains $target) {
+              throw "版號 ${{ steps.ver.outputs.version }} 已經發布過（找到 $target）。請先調整 csproj 的 <Version>。"
+          }
+          Write-Host "版號未被使用，繼續。"
+
+      - name: 抓上一版 full 包（產生 delta 用）
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # vpk 需要上一版的 full 包在本地才算得出 delta，而 runner 每次都是全新的。
+          # 抓不到就只出 full 包，使用者這一次要下載整包 —— 會變慢，但不該擋住發布，
+          # 所以這一步失敗不影響後續。
+          New-Item -ItemType Directory -Force -Path .\artifacts\releases | Out-Null
+          vpk download github `
+              --repoUrl https://github.com/${{ github.repository }} `
+              --channel win `
+              --outputDir .\artifacts\releases `
+              --token $env:GH_TOKEN
+
+      - name: 打包
+        shell: pwsh
+        run: |
+          .\publish-velopack.ps1 -Version ${{ steps.ver.outputs.version }}
+
+      - name: 發布 pre-release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $v = '${{ steps.ver.outputs.version }}'
+          $dir = '.\artifacts\releases'
+
+          # 逐一指定，不要整個資料夾丟上去 —— 上一步抓下來的「上一版 full 包」也在裡面，
+          # 那個線上已經有了，重傳只是浪費 100+ MB。
+          $assets = @(
+              "$dir\releases.win.json"
+              "$dir\OverTranslate-$v-full.nupkg"
+              "$dir\OverTranslate-win-Setup.exe"
+              "$dir\OverTranslate-win-Portable.zip"
+          )
+          $delta = "$dir\OverTranslate-$v-delta.nupkg"
+          if (Test-Path $delta) { $assets += $delta } else { Write-Warning "沒有 delta，使用者這一版要下載完整包。" }
+
+          foreach ($a in $assets) {
+              if (-not (Test-Path $a)) { throw "缺少產物：$a" }
+          }
+
+          $notes = @"
+自動打包產出，尚未正式發布。
+
+確認無誤後，到本頁按 **Edit release** 取消勾選 *Set as a pre-release*，
+使用者才會收到這一版。
+
+- commit: ${{ github.sha }}
+- 觸發：${{ github.event_name }}
+"@
+
+          gh release create '${{ steps.ver.outputs.tag }}' `
+              --repo ${{ github.repository }} `
+              --target ${{ github.sha }} `
+              --title $v `
+              --notes $notes `
+              --prerelease `
+              @assets
+
+      - name: 產出清單
+        if: always()
+        shell: pwsh
+        run: Get-ChildItem .\artifacts\releases | Select-Object Name, Length

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,17 @@
 # GithubSource(prerelease: false)，看不到標成 pre-release 的 release。
 # 要正式發布時，由人到 GitHub 上手動取消勾選 pre-release。
 #
-# 版號來自 src/OverTranslate/OverTranslate.csproj 的 <Version>，tag 只是觸發器。
-# 所以正常流程是：先發一個調整版號的 commit 到 main，再壓 tag。
+# 版號**以 tag 為準**（v2.0.0-beta.1 → 2.0.0-beta.1），csproj 的 <Version> 不參與。
+# 這是刻意的：測試時常常只想壓一個不同版號的 tag 看打包結果，不該被迫先發一個
+# 改版號的 commit。csproj 與 tag 不一致時只警告，不擋。
 name: 打包並發布 pre-release
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 覆寫版號（留空則用 csproj 的 <Version>）
-        required: false
+        description: 版號，不含 v（例如 2.0.0-beta.1）
+        required: true
         type: string
   push:
     tags:
@@ -45,23 +46,34 @@ jobs:
         id: ver
         shell: pwsh
         run: |
-          $version = '${{ inputs.version }}'
-          if ([string]::IsNullOrWhiteSpace($version)) {
-              [xml]$csproj = Get-Content .\src\OverTranslate\OverTranslate.csproj
-              $version = ($csproj.Project.PropertyGroup.Version | Select-Object -First 1).Trim()
-          }
-          if ([string]::IsNullOrWhiteSpace($version)) { throw "找不到版號。" }
+          # tag 觸發時用 tag 名，手動觸發時用輸入值。兩條路都不看 csproj。
+          $tag = if ('${{ github.ref_type }}' -eq 'tag') { '${{ github.ref_name }}' } else { 'v${{ inputs.version }}' }
+          $version = $tag -replace '^v', ''
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "版號是空的（tag='$tag'）。" }
 
-          Write-Host "版號：$version"
+          # 不是 semver 的話 vpk 會在打包中途才失敗，那時已經燒掉好幾分鐘的 build。
+          if ($version -notmatch '^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$') {
+              throw "版號 '$version' 不是合法的 semver。tag 請用 v2.0.0 或 v2.0.0-beta.1 的形式。"
+          }
+
+          # 只是提醒。tag 與 csproj 不一致完全不影響更新流程（Velopack 認的是 packVersion），
+          # 但正式要發的那一版通常會希望兩者一致。
+          [xml]$csproj = Get-Content .\src\OverTranslate\OverTranslate.csproj
+          $csprojVersion = ($csproj.Project.PropertyGroup.Version | Select-Object -First 1).Trim()
+          if ($csprojVersion -ne $version) {
+              Write-Warning "tag 版號 '$version' 與 csproj 的 '$csprojVersion' 不一致。打包用 tag 的版號。"
+          }
+
+          Write-Host "版號：$version（tag: $tag）"
           "version=$version" | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
-          "tag=v$version"    | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
+          "tag=$tag"         | Out-File -Append -Encoding utf8 $env:GITHUB_OUTPUT
 
       - name: 防呆——這個版號是否已經發布過
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # 忘記調 csproj 版號時，包出來的東西會跟線上某一版同號但內容不同。
+          # 同一個版號重壓一次 tag 時，包出來的東西會跟線上某一版同號但內容不同。
           # 那會讓已經更新過的使用者永遠收不到這一版（版號沒變大），而且不會有任何錯誤。
           # 寧可在這裡失敗。
           $target = "OverTranslate-${{ steps.ver.outputs.version }}-full.nupkg"

--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,6 @@ Desktop.ini
 launchSettings.json
 
 # publish
+# publish-velopack.ps1 已納入版控 —— CI 在本倉打包，腳本必須跟著程式碼走。
+# 發版步驟文件仍放在 OverTranslate-Ops（私有倉）。
 PUBLISH.md
-publish-velopack.ps1

--- a/publish-velopack.ps1
+++ b/publish-velopack.ps1
@@ -1,0 +1,166 @@
+param(
+    # 相對路徑一律以 $PSScriptRoot（本腳本所在的專案根目錄）為基準，不是當前工作目錄，
+    # 所以從哪裡呼叫都可以——CI 的工作目錄與人在本機的習慣不一定相同。
+    [string]$ProjectPath = ".\src\OverTranslate\OverTranslate.csproj",
+    [string]$PublishDir = ".\src\OverTranslate\bin\Publish",
+    [string]$OutputDir = ".\artifacts\releases",
+    [string]$PackId = "OverTranslate",
+    [string]$PackTitle = "OverTranslate",
+    [string]$PackAuthors = "Hon.Lu",
+    [string]$MainExe = "OverTranslate.exe",
+    [string]$IconPath = ".\src\OverTranslate\icons\icon_256.ico",
+    [string]$Channel = "win",
+    [string]$PublishProfile = "FolderProfile",
+    [string]$Configuration = "Release",
+    [switch]$SkipPublish,
+    [string]$Version
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-FullPath {
+    param([string]$PathValue)
+    if ([System.IO.Path]::IsPathRooted($PathValue)) {
+        return [System.IO.Path]::GetFullPath($PathValue)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $PathValue))
+}
+
+function Clear-DirectoryContents {
+    param([string]$DirectoryPath)
+
+    if (-not (Test-Path $DirectoryPath)) {
+        New-Item -ItemType Directory -Force -Path $DirectoryPath | Out-Null
+        return
+    }
+
+    Get-ChildItem -LiteralPath $DirectoryPath -Force | Remove-Item -Recurse -Force
+}
+
+function Get-VersionFromCsproj {
+    param([string]$CsprojPath)
+
+    $csprojPath = Resolve-FullPath $CsprojPath
+    if (-not (Test-Path $csprojPath)) {
+        throw "找不到 csproj：$csprojPath"
+    }
+
+    [xml]$csproj = Get-Content $csprojPath
+    $versionNode = $csproj.Project.PropertyGroup.Version | Select-Object -First 1
+    if ([string]::IsNullOrWhiteSpace($versionNode)) {
+        throw "csproj 內沒有 <Version>。"
+    }
+
+    return $versionNode.Trim()
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = Get-VersionFromCsproj -CsprojPath $ProjectPath
+}
+
+# Channel 與版號後綴防呆：beta 應帶預發行後綴（如 -beta.1），stable 不應帶。
+$isPrerelease = $Version -match '-'
+if ($Channel -ne 'win' -and -not $isPrerelease) {
+    Write-Warning "Channel='$Channel' 但版本 '$Version' 不含預發行後綴（如 1.6.1-beta.1）。確認這是你要的。"
+}
+if ($Channel -eq 'win' -and $isPrerelease) {
+    Write-Warning "穩定 channel 'win' 但版本 '$Version' 含預發行後綴。穩定版通常不應帶 -beta 後綴。"
+}
+
+$projectFullPath = Resolve-FullPath $ProjectPath
+$publishFullPath = Resolve-FullPath $PublishDir
+$outputFullPath = Resolve-FullPath $OutputDir
+$iconFullPath = Resolve-FullPath $IconPath
+$mainExeFullPath = Join-Path $publishFullPath $MainExe
+$appSettingsPublishPath = Join-Path $publishFullPath "appsettings.json"
+
+if (-not (Test-Path $projectFullPath)) {
+    throw "找不到專案檔：$projectFullPath"
+}
+
+if (-not $SkipPublish) {
+    if (-not (Get-Command "dotnet" -ErrorAction SilentlyContinue)) {
+        throw "找不到 dotnet。請先安裝 .NET SDK，或確認終端機環境變數已更新。"
+    }
+
+    Write-Host "先清空 Publish 資料夾..." -ForegroundColor Cyan
+    Clear-DirectoryContents -DirectoryPath $publishFullPath
+
+    Write-Host "先執行 dotnet publish..." -ForegroundColor Cyan
+    Write-Host "Project    : $projectFullPath"
+    Write-Host "Profile    : $PublishProfile"
+    Write-Host "Config     : $Configuration"
+    Write-Host "PublishDir : $publishFullPath"
+
+    $publishArgs = @(
+        "publish",
+        $projectFullPath,
+        "-c", $Configuration,
+        "-p:PublishProfile=$PublishProfile",
+        "-p:PublishDir=$publishFullPath"
+    )
+
+    & dotnet @publishArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish 失敗，exit code: $LASTEXITCODE"
+    }
+
+    if (Test-Path $appSettingsPublishPath) {
+        Remove-Item -LiteralPath $appSettingsPublishPath -Force
+        Write-Host "已從 Publish 輸出移除 appsettings.json" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+}
+
+if (-not (Get-Command "vpk" -ErrorAction SilentlyContinue)) {
+    throw "找不到 vpk。請先確認已安裝 Velopack CLI，或重新開啟終端機。"
+}
+
+if (-not (Test-Path $publishFullPath)) {
+    throw "找不到 Publish 資料夾：$publishFullPath"
+}
+
+if (-not (Test-Path $mainExeFullPath)) {
+    throw "找不到主程式：$mainExeFullPath"
+}
+
+if (-not (Test-Path $iconFullPath)) {
+    throw "找不到 icon：$iconFullPath"
+}
+
+New-Item -ItemType Directory -Force -Path $outputFullPath | Out-Null
+
+Write-Host "Velopack 打包開始..." -ForegroundColor Cyan
+Write-Host "Version   : $Version"
+Write-Host "PublishDir: $publishFullPath"
+Write-Host "OutputDir : $outputFullPath"
+
+$packArgs = @(
+    "pack",
+    "--packId", $PackId,
+    "--packVersion", $Version,
+    "--packDir", $publishFullPath,
+    "--mainExe", $MainExe,
+    "--packTitle", $PackTitle,
+    "--packAuthors", $PackAuthors,
+    "--icon", $iconFullPath,
+    "--channel", $Channel,
+    "--outputDir", $outputFullPath
+)
+
+& vpk @packArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "vpk pack 失敗，exit code: $LASTEXITCODE"
+}
+
+Write-Host ""
+Write-Host "打包完成，主要產物通常會在這裡：" -ForegroundColor Green
+Write-Host "  Setup      : $outputFullPath\$PackId-$Channel-Setup.exe"
+Write-Host "  Portable   : $outputFullPath\$PackId-$Channel-Portable.zip"
+Write-Host "  Full pkg   : $outputFullPath\$PackId-$Version-full.nupkg"
+Write-Host "  Releases   : $outputFullPath\releases.$Channel.json"
+Write-Host ""
+Write-Host "輸出資料夾內容：" -ForegroundColor Green
+Get-ChildItem $outputFullPath | Select-Object Name, Length, LastWriteTime

--- a/publish-velopack.ps1
+++ b/publish-velopack.ps1
@@ -93,10 +93,17 @@ if (-not $SkipPublish) {
     Write-Host "Config     : $Configuration"
     Write-Host "PublishDir : $publishFullPath"
 
+    # 自封式設定明寫在這裡，不依賴 publish profile。
+    # FolderProfile.pubxml 被 .gitignore 排除（PublishProfiles/），所以任何拿不到它的環境
+    # —— CI checkout、git worktree、新 clone —— 都沒有 <SelfContained>true</SelfContained>。
+    # 而 -p:PublishProfile=... 指向不存在的檔案時 dotnet 不會報錯，只會安靜地退回框架相依建置，
+    # 產出一個看起來正常、但在沒裝 .NET 8 Runtime 的機器上根本開不起來的安裝包。
     $publishArgs = @(
         "publish",
         $projectFullPath,
         "-c", $Configuration,
+        "-r", "win-x64",
+        "-p:SelfContained=true",
         "-p:PublishProfile=$PublishProfile",
         "-p:PublishDir=$publishFullPath"
     )
@@ -104,6 +111,12 @@ if (-not $SkipPublish) {
     & dotnet @publishArgs
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish 失敗，exit code: $LASTEXITCODE"
+    }
+
+    # 上面那個坑安靜到 build 會成功、打包會成功、大小也只是「比較小」而已。
+    # 寧可在這裡炸掉，也不要把跑不起來的東西發出去。
+    if (-not (Test-Path (Join-Path $publishFullPath "coreclr.dll"))) {
+        throw "Publish 輸出不是自封式（找不到 coreclr.dll）。這種包在沒有 .NET Runtime 的機器上開不起來。"
     }
 
     if (Test-Path $appSettingsPublishPath) {

--- a/src/OverTranslate/Services/UpdateService.cs
+++ b/src/OverTranslate/Services/UpdateService.cs
@@ -120,20 +120,26 @@ public static class UpdateService
     }
 
     /// <remarks>
-    /// OVERTRANSLATE_UPDATE_SOURCE overrides where releases are fetched from, so the download and
-    /// apply half of an update can be exercised on one machine. It is the missing counterpart to
-    /// <see cref="CreateFakeUpdate"/>: that one invents a version with no package behind it, so
-    /// 立即更新 necessarily fails there. Point this at a `vpk pack --outputDir` folder holding two
-    /// versions and the whole thing runs for real — check, download, apply, restart — against a feed
-    /// nobody else can see.
+    /// Two environment variables redirect where releases come from, so an update can be rehearsed
+    /// without one reaching users. Both are unset on every user's machine, where this method behaves
+    /// exactly as it did before they existed.
     ///
-    /// The alternative was publishing a GitHub Release to test against, which is not a test: this app
-    /// updates from GitHub Releases, so every such release ships to every user on the channel. There
-    /// is no draft or staging release Velopack can read.
+    /// OVERTRANSLATE_UPDATE_REPO points at a second GitHub repository — a staging repo with no users
+    /// — and is the one to reach for. It keeps <see cref="GithubSource"/> in the loop, so the release
+    /// listing, the asset lookup and the HTTP download are all the code that ships; only the
+    /// repository differs. Rehearsing in the real repo cannot do that safely: a release there is
+    /// visible to every user on the channel the moment it exists, and the only lever separating a
+    /// rehearsal from a real launch is remembering to tick pre-release.
     ///
-    /// Anything <see cref="UpdateManager"/> accepts works — a local directory, or an http(s) feed.
-    /// The channel still applies: the source must contain releases.{channel}.json. Unset, which is
-    /// the only state a user's machine is ever in, this does nothing and GitHub is used as before.
+    /// OVERTRANSLATE_UPDATE_TOKEN carries a PAT for it, which is what lets the staging repo stay
+    /// private. Optional — a public staging repo needs no token.
+    ///
+    /// OVERTRANSLATE_UPDATE_SOURCE takes a local `vpk pack --outputDir` folder instead. It is the
+    /// fast loop: a pack is seconds where a staging release is a few hundred MB uploaded. What it
+    /// cannot cover is everything GithubSource does, so it does not replace the staging repo.
+    ///
+    /// Both differ from <see cref="CreateFakeUpdate"/>, which invents a version with no package
+    /// behind it — enough to drive the notification UI, never enough to download.
     /// </remarks>
     private static UpdateManager CreateManager()
     {
@@ -142,6 +148,14 @@ public static class UpdateService
         var isBeta = string.Equals(envChannel, BetaChannel, StringComparison.OrdinalIgnoreCase);
         var channel = isBeta ? BetaChannel : StableChannel;
         var options = new UpdateOptions { ExplicitChannel = channel };
+
+        var stagingRepo = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_REPO");
+        if (!string.IsNullOrWhiteSpace(stagingRepo))
+        {
+            var token = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_TOKEN");
+            return new UpdateManager(
+                new GithubSource(stagingRepo, token, prerelease: isBeta), options);
+        }
 
         var localSource = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_SOURCE");
         if (!string.IsNullOrWhiteSpace(localSource))

--- a/src/OverTranslate/Services/UpdateService.cs
+++ b/src/OverTranslate/Services/UpdateService.cs
@@ -119,15 +119,36 @@ public static class UpdateService
             new VelopackUpdateInfo(asset, false, null!, []));
     }
 
+    /// <remarks>
+    /// OVERTRANSLATE_UPDATE_SOURCE overrides where releases are fetched from, so the download and
+    /// apply half of an update can be exercised on one machine. It is the missing counterpart to
+    /// <see cref="CreateFakeUpdate"/>: that one invents a version with no package behind it, so
+    /// 立即更新 necessarily fails there. Point this at a `vpk pack --outputDir` folder holding two
+    /// versions and the whole thing runs for real — check, download, apply, restart — against a feed
+    /// nobody else can see.
+    ///
+    /// The alternative was publishing a GitHub Release to test against, which is not a test: this app
+    /// updates from GitHub Releases, so every such release ships to every user on the channel. There
+    /// is no draft or staging release Velopack can read.
+    ///
+    /// Anything <see cref="UpdateManager"/> accepts works — a local directory, or an http(s) feed.
+    /// The channel still applies: the source must contain releases.{channel}.json. Unset, which is
+    /// the only state a user's machine is ever in, this does nothing and GitHub is used as before.
+    /// </remarks>
     private static UpdateManager CreateManager()
     {
         // 設 OVERTRANSLATE_CHANNEL=beta → 訂閱 beta 先行版管線；未設 → 穩定版 (win)。
         var envChannel = Environment.GetEnvironmentVariable("OVERTRANSLATE_CHANNEL");
         var isBeta = string.Equals(envChannel, BetaChannel, StringComparison.OrdinalIgnoreCase);
         var channel = isBeta ? BetaChannel : StableChannel;
+        var options = new UpdateOptions { ExplicitChannel = channel };
+
+        var localSource = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_SOURCE");
+        if (!string.IsNullOrWhiteSpace(localSource))
+            return new UpdateManager(localSource, options);
 
         // beta 的 GitHub Release 會標記為 pre-release，需 prerelease:true 才找得到。
         var source = new GithubSource(GitHubRepoUrl, null, prerelease: isBeta);
-        return new UpdateManager(source, new UpdateOptions { ExplicitChannel = channel });
+        return new UpdateManager(source, options);
     }
 }

--- a/src/OverTranslate/Services/UpdateService.cs
+++ b/src/OverTranslate/Services/UpdateService.cs
@@ -135,10 +135,17 @@ public static class UpdateService
     /// wanders past. Verified against a private repo: Velopack authenticates both the feed request
     /// and the asset download, including the redirect to GitHub's CDN. Omit it for a public one.
     ///
-    /// Unset — the only state a user's machine is ever in — both do nothing and the real repository
-    /// is used exactly as before. Distinct from <see cref="CreateFakeUpdate"/>, which invents a
-    /// version with no package behind it: enough to drive the notification UI, never enough to
-    /// download.
+    /// OVERTRANSLATE_UPDATE_PRERELEASE makes pre-releases visible without switching channel, which
+    /// the beta channel cannot do: it moves both levers at once, and a beta subscriber reads
+    /// releases.beta.json — a different feed, holding differently-named packages. Releases built by
+    /// CI are packed for the stable channel and merely flagged pre-release, so testing them needs
+    /// exactly this: see the pre-release, stay on win. What gets tested is then the same bytes users
+    /// receive once the flag is cleared, rather than a parallel beta build of the same source.
+    ///
+    /// Unset — the only state a user's machine is ever in — all three do nothing and the real
+    /// repository is used exactly as before. Distinct from <see cref="CreateFakeUpdate"/>, which
+    /// invents a version with no package behind it: enough to drive the notification UI, never
+    /// enough to download.
     /// </remarks>
     private static UpdateManager CreateManager()
     {
@@ -149,6 +156,11 @@ public static class UpdateService
         var options = new UpdateOptions { ExplicitChannel = channel };
 
         // beta 的 GitHub Release 會標記為 pre-release，需 prerelease:true 才找得到。
+        // 設 OVERTRANSLATE_UPDATE_PRERELEASE（"0" 以外的任何值）可單獨打開這個開關而不換 channel。
+        var prereleaseOverride = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_PRERELEASE");
+        var seesPrerelease = isBeta
+            || (!string.IsNullOrWhiteSpace(prereleaseOverride) && prereleaseOverride != "0");
+
         var repoUrl = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_REPO");
         var token = string.IsNullOrWhiteSpace(repoUrl)
             ? null
@@ -156,6 +168,6 @@ public static class UpdateService
         if (string.IsNullOrWhiteSpace(repoUrl))
             repoUrl = GitHubRepoUrl;
 
-        return new UpdateManager(new GithubSource(repoUrl, token, prerelease: isBeta), options);
+        return new UpdateManager(new GithubSource(repoUrl, token, prerelease: seesPrerelease), options);
     }
 }

--- a/src/OverTranslate/Services/UpdateService.cs
+++ b/src/OverTranslate/Services/UpdateService.cs
@@ -120,26 +120,25 @@ public static class UpdateService
     }
 
     /// <remarks>
-    /// Two environment variables redirect where releases come from, so an update can be rehearsed
-    /// without one reaching users. Both are unset on every user's machine, where this method behaves
-    /// exactly as it did before they existed.
+    /// OVERTRANSLATE_UPDATE_REPO points the update feed at a second GitHub repository — a staging
+    /// repo with no users — so a release can be rehearsed end to end without one reaching anybody.
+    /// It keeps <see cref="GithubSource"/> in the loop, so the release listing, the asset lookup and
+    /// the HTTP download are all the code that ships; only the repository differs.
     ///
-    /// OVERTRANSLATE_UPDATE_REPO points at a second GitHub repository — a staging repo with no users
-    /// — and is the one to reach for. It keeps <see cref="GithubSource"/> in the loop, so the release
-    /// listing, the asset lookup and the HTTP download are all the code that ships; only the
-    /// repository differs. Rehearsing in the real repo cannot do that safely: a release there is
-    /// visible to every user on the channel the moment it exists, and the only lever separating a
-    /// rehearsal from a real launch is remembering to tick pre-release.
+    /// Rehearsing in the real repo cannot be made safe. A release there is visible to every user on
+    /// the channel the moment it exists, and the only thing separating a rehearsal from a real launch
+    /// is remembering to tick pre-release. The staging repo removes that lever entirely, and lets the
+    /// stable (win) channel be rehearsed too, which pre-releases by definition cannot.
     ///
-    /// OVERTRANSLATE_UPDATE_TOKEN carries a PAT for it, which is what lets the staging repo stay
-    /// private. Optional — a public staging repo needs no token.
+    /// OVERTRANSLATE_UPDATE_TOKEN carries a PAT for it. Supplying one lets the staging repo stay
+    /// private, which is worth doing — rehearsal builds are then not downloadable by anyone who
+    /// wanders past. Verified against a private repo: Velopack authenticates both the feed request
+    /// and the asset download, including the redirect to GitHub's CDN. Omit it for a public one.
     ///
-    /// OVERTRANSLATE_UPDATE_SOURCE takes a local `vpk pack --outputDir` folder instead. It is the
-    /// fast loop: a pack is seconds where a staging release is a few hundred MB uploaded. What it
-    /// cannot cover is everything GithubSource does, so it does not replace the staging repo.
-    ///
-    /// Both differ from <see cref="CreateFakeUpdate"/>, which invents a version with no package
-    /// behind it — enough to drive the notification UI, never enough to download.
+    /// Unset — the only state a user's machine is ever in — both do nothing and the real repository
+    /// is used exactly as before. Distinct from <see cref="CreateFakeUpdate"/>, which invents a
+    /// version with no package behind it: enough to drive the notification UI, never enough to
+    /// download.
     /// </remarks>
     private static UpdateManager CreateManager()
     {
@@ -149,20 +148,14 @@ public static class UpdateService
         var channel = isBeta ? BetaChannel : StableChannel;
         var options = new UpdateOptions { ExplicitChannel = channel };
 
-        var stagingRepo = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_REPO");
-        if (!string.IsNullOrWhiteSpace(stagingRepo))
-        {
-            var token = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_TOKEN");
-            return new UpdateManager(
-                new GithubSource(stagingRepo, token, prerelease: isBeta), options);
-        }
-
-        var localSource = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_SOURCE");
-        if (!string.IsNullOrWhiteSpace(localSource))
-            return new UpdateManager(localSource, options);
-
         // beta 的 GitHub Release 會標記為 pre-release，需 prerelease:true 才找得到。
-        var source = new GithubSource(GitHubRepoUrl, null, prerelease: isBeta);
-        return new UpdateManager(source, options);
+        var repoUrl = Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_REPO");
+        var token = string.IsNullOrWhiteSpace(repoUrl)
+            ? null
+            : Environment.GetEnvironmentVariable("OVERTRANSLATE_UPDATE_TOKEN");
+        if (string.IsNullOrWhiteSpace(repoUrl))
+            repoUrl = GitHubRepoUrl;
+
+        return new UpdateManager(new GithubSource(repoUrl, token, prerelease: isBeta), options);
     }
 }


### PR DESCRIPTION
本分支由 `feat/40-velopack-portable` 延伸而來，所以同時包含 #40 的內容。

## 一、Velopack 打包一併產出 portable 版（#40）

- `publish-velopack.ps1` 拿掉 `--noPortable`，每次打包多產出 `OverTranslate-<channel>-Portable.zip`
- `releases.<channel>.json`（更新 feed）**完全不變**，portable 與安裝版共用同一條更新管線
- 打包時間只多 8 秒

實測結果：portable 在 Velopack 眼中 `IsInstalled = True`，所以 `UpdateService.CheckAsync` 開頭的
`if (!manager.IsInstalled) return null;` **不需要為 portable 放寬** —— 它擋掉的一直都只有開發時直接跑 `bin\Debug`。

| 情境 | `IsInstalled` | `IsPortable` |
|---|---|---|
| portable，解壓到乾淨路徑 | `True` | `True` |
| 安裝版 | `True` | `False` |
| 開發直跑 / `dotnet run` | `False` | `False` |

## 二、更新來源可覆寫（測試用）

`UpdateService.CreateManager` 新增三個環境變數。**全部未設時，行為與改動前完全相同**，
使用者的機器永遠是這個狀態。

| 環境變數 | 作用 |
|---|---|
| `OVERTRANSLATE_UPDATE_REPO` | 更新來源改指另一個 GitHub 倉（排練用，該倉沒有使用者） |
| `OVERTRANSLATE_UPDATE_TOKEN` | 上者的 PAT，讓排練倉可以維持私有 |
| `OVERTRANSLATE_UPDATE_PRERELEASE` | 單獨開啟 pre-release 可見性，**不切換 channel** |

第三個是必要的：CI 打的是 `win` channel 但標成 pre-release，而 `OVERTRANSLATE_CHANNEL=beta`
會同時改動 channel，讀到的是 `releases.beta.json`（不同的 feed、不同檔名的套件）。
分開之後，測到的就是使用者取消勾選 pre-release 後會拿到的同一批二進位。

## 三、壓 tag 自動打包並發布 pre-release

新增 `.github/workflows/release.yml`。

- 觸發：push `v*` tag，或手動 `workflow_dispatch`
- **版號以 tag 為準**（`v2.0.0-beta.1` → `2.0.0-beta.1`），csproj 的 `<Version>` 不參與，
  不一致時只警告。測試時常常只想壓個 tag 看打包結果，不該被迫先發一個改版號的 commit
- **一律 `--prerelease`**，不會直接成為正式版；要正式發布由人到 GitHub 取消勾選
- 打包前跑 `vpk download github` 抓線上最新穩定版的 full 包當 delta 基準（runner 每次都是全新的）。
  這一步 `continue-on-error`，抓不到就只出 full 包繼續，不讓它變成能擋住發布的單點
- 防呆：版號已發布過、或 tag 不是合法 semver，在 build 開始前就失敗

實測 `vpk download github` 從空資料夾抓回線上 `1.7.0-full`（114 MB / 23 秒），
據此產出的 delta 為 33.9 MB（full 是 116 MB）。

## 四、打包腳本與產物歸位

`publish-velopack.ps1` 從 `.gitignore` 移出並納入版控 —— CI 在本倉打包，腳本必須跟著程式碼走。
發版步驟文件仍在 `OverTranslate-Ops`（私有倉）。

Closes #40