### PR TITLE
修正 workflow YAML 語法錯誤

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,15 +137,17 @@ jobs:
               if (-not (Test-Path $a)) { throw "缺少產物：$a" }
           }
 
-          $notes = @"
-自動打包產出，尚未正式發布。
-
-確認無誤後，到本頁按 **Edit release** 取消勾選 *Set as a pre-release*，
-使用者才會收到這一版。
-
-- commit: ${{ github.sha }}
-- 觸發：${{ github.event_name }}
-"@
+          # 不要用 here-string。它的結尾 "@ 必須頂在行首，而這整段是 YAML 的 run: | 區塊，
+          # 行首沒有縮排就會把 block scalar 截斷，整個 workflow 檔變成無效 YAML
+          # ——症狀是每次 push 都產生一個 0 秒就失敗的 run，連 tag 觸發都不會執行。
+          $notes = @(
+              '自動打包產出，尚未正式發布。'
+              ''
+              '確認無誤後，到本頁按 **Edit release** 取消勾選 *Set as a pre-release*，使用者才會收到這一版。'
+              ''
+              "- commit: ${{ github.sha }}"
+              "- 觸發：${{ github.event_name }}"
+          ) -join "`n"
 
           gh release create '${{ steps.ver.outputs.tag }}' `
               --repo ${{ github.repository }} `


### PR DESCRIPTION
PowerShell here-string 的結尾 `"@` 必須頂在行首，但那整段寫在 YAML 的 `run: |` 區塊裡。
行首沒有縮排就把 block scalar 截斷了，整個 workflow 檔因此變成無效 YAML。

症狀：每次 push 都產生一個 **0 秒就失敗**的 run，GitHub 顯示
`Invalid workflow file: .github/workflows/release.yml#L141`。
更麻煩的是 **tag 觸發也不會執行** —— 壓上去的 `0.0.1-test` 什麼都沒發生。

改用陣列 `-join` 組字串，不受縮排影響。已用 pyyaml 驗過語法，
`on.push.tags` 與 9 個步驟都解析正確。