### PR TITLE
appsettings.json 的移除不應受 -SkipPublish 影響

### DIFF
--- a/publish-velopack.ps1
+++ b/publish-velopack.ps1
@@ -128,11 +128,6 @@ if (-not $SkipPublish) {
         throw "Publish 輸出不是自封式（找不到 coreclr.dll）。這種包在沒有 .NET Runtime 的機器上開不起來。"
     }
 
-    if (Test-Path $appSettingsPublishPath) {
-        Remove-Item -LiteralPath $appSettingsPublishPath -Force
-        Write-Host "已從 Publish 輸出移除 appsettings.json" -ForegroundColor Yellow
-    }
-
     Write-Host ""
 }
 
@@ -146,6 +141,14 @@ if (-not (Test-Path $publishFullPath)) {
 
 if (-not (Test-Path $mainExeFullPath)) {
     throw "找不到主程式：$mainExeFullPath"
+}
+
+# 在 pack 之前、且不受 -SkipPublish 影響。打包進去的 appsettings.json 會在更新時覆蓋
+# 使用者既有的設定，而 -SkipPublish 的用途正是「已手動 publish、只想重新打包」——
+# 那個資料夾沒有經過上面的流程，裡面就會有這個檔。
+if (Test-Path $appSettingsPublishPath) {
+    Remove-Item -LiteralPath $appSettingsPublishPath -Force
+    Write-Host "已從 Publish 輸出移除 appsettings.json" -ForegroundColor Yellow
 }
 
 if (-not (Test-Path $iconFullPath)) {


### PR DESCRIPTION
移除 `appsettings.json` 的動作原本在 `if (-not $SkipPublish)` 區塊裡。

但 `PUBLISH.md` 把 `-SkipPublish` 寫成正常用法：

> 已手動 publish、只想重新打包時，加 `-SkipPublish`。

「手動 publish」出來的資料夾沒有經過這個腳本，裡面就會有 `appsettings.json`，
而 `-SkipPublish` 正好跳過移除 —— 它會被打包進去，並在使用者更新時覆蓋掉他們既有的設定
（API Key、快捷鍵）。

移到 `vpk pack` 之前、區塊之外，兩條路都會執行。

CI 不受影響（CI 不使用 `-SkipPublish`），目前發出去的套件也確認過沒有這個檔。