### PR TITLE
feat: #57 加入 UI 多語系支援（繁體中文／英文，即時切換）

### DIFF
--- a/src/OverTranslate/App.xaml
+++ b/src/OverTranslate/App.xaml
@@ -7,6 +7,9 @@
                 <!-- Default theme loaded first; ThemeService swaps it on startup if Dark is saved -->
                 <ResourceDictionary Source="Themes/LightTheme.xaml"/>
                 <ResourceDictionary Source="Themes/SharedStyles.xaml"/>
+                <!-- Likewise the default strings; LocalizationService swaps them on startup, and
+                     again whenever the user changes the language -->
+                <ResourceDictionary Source="Resources/Strings.zh-Hant.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/src/OverTranslate/App.xaml.cs
+++ b/src/OverTranslate/App.xaml.cs
@@ -77,6 +77,9 @@ public partial class App
 
         ThemeService.Apply(SettingsService.Instance.Current.Theme);
 
+        // Before any window is built, so nothing is ever constructed against the wrong dictionary.
+        LocalizationService.Apply(LocalizationService.Current);
+
         // Kept in the shipped log: the process's DPI awareness is fixed at launch, and a misreported
         // monitor size is invisible to every managed API, so without this a display-geometry report
         // cannot be diagnosed from a log at all.

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -35,6 +35,21 @@ public class AppSettings
     public string OpenAiApiKey { get; set; } = "";
     public string OpenAiModel { get; set; } = "";
     public string Theme { get; set; } = "Dark";
+    /// <summary>
+    /// The interface language, "zh-Hant" or "en". Empty means "not chosen yet".
+    /// </summary>
+    /// <remarks>
+    /// Empty rather than a hardcoded default so a first run can follow the OS language — see
+    /// <see cref="Services.LocalizationService.ResolveSystemDefault"/>. Once the user picks one it
+    /// is stored verbatim and the OS is never consulted again, because an explicit choice should
+    /// survive someone changing their Windows display language.
+    ///
+    /// This is the interface language only. It has no bearing on
+    /// <see cref="TargetLanguage"/> or <see cref="RealtimeTargetLanguage"/>: what someone reads the
+    /// buttons in and what they want subtitles translated into are unrelated, and a Taiwanese user
+    /// running the app in English still wants Chinese output.
+    /// </remarks>
+    public string UiLanguage { get; set; } = "";
     public bool AutoTranslateAfterSelection { get; set; } = false;
     public bool SaveScreenshotToDisk { get; set; } = false;
     /// <summary>Empty means "use ScreenshotSaveService.DefaultDirectory" (圖片\OverTranslate).</summary>

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -50,17 +50,6 @@ public class AppSettings
     /// running the app in English still wants Chinese output.
     /// </remarks>
     public string UiLanguage { get; set; } = "";
-    /// <summary>
-    /// Width of the shell's nav rail in device-independent pixels, or 0 to use the default.
-    /// </summary>
-    /// <remarks>
-    /// Stored because the width that fits depends on things this app cannot see: how long the
-    /// user's capture shortcut prints, and which interface language they read. Someone who drags
-    /// the rail out to fit "Ctrl+Alt+Shift+F12" has answered a question for good, not for one
-    /// session. Clamped on load to the column's own MinWidth/MaxWidth, so an edited settings file
-    /// cannot produce a rail that covers the page or vanishes.
-    /// </remarks>
-    public double ShellSidebarWidth { get; set; }
     public bool AutoTranslateAfterSelection { get; set; } = false;
     public bool SaveScreenshotToDisk { get; set; } = false;
     /// <summary>Empty means "use ScreenshotSaveService.DefaultDirectory" (圖片\OverTranslate).</summary>

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -50,6 +50,17 @@ public class AppSettings
     /// running the app in English still wants Chinese output.
     /// </remarks>
     public string UiLanguage { get; set; } = "";
+    /// <summary>
+    /// Width of the shell's nav rail in device-independent pixels, or 0 to use the default.
+    /// </summary>
+    /// <remarks>
+    /// Stored because the width that fits depends on things this app cannot see: how long the
+    /// user's capture shortcut prints, and which interface language they read. Someone who drags
+    /// the rail out to fit "Ctrl+Alt+Shift+F12" has answered a question for good, not for one
+    /// session. Clamped on load to the column's own MinWidth/MaxWidth, so an edited settings file
+    /// cannot produce a rail that covers the page or vanishes.
+    /// </remarks>
+    public double ShellSidebarWidth { get; set; }
     public bool AutoTranslateAfterSelection { get; set; } = false;
     public bool SaveScreenshotToDisk { get; set; } = false;
     /// <summary>Empty means "use ScreenshotSaveService.DefaultDirectory" (圖片\OverTranslate).</summary>

--- a/src/OverTranslate/Models/LanguageData.cs
+++ b/src/OverTranslate/Models/LanguageData.cs
@@ -9,7 +9,12 @@ namespace OverTranslate.Models;
 /// a user scanning a long list can find theirs either way, while somewhere with one line to spare
 /// wants only the first. Composing here means neither has to take a string apart to get at one.
 /// </param>
-public record LangItem(string Code, string Name, string English)
+/// <param name="StandsAlone">
+/// True when <paramref name="Name"/> and <paramref name="English"/> are each a complete label on
+/// their own, so the Chinese interface shows the name alone instead of the usual pair. For the OCR
+/// picker's automatic entry, whose name already carries its own parenthetical.
+/// </param>
+public record LangItem(string Code, string Name, string English, bool StandsAlone = false)
 {
     /// <summary>
     /// The label for the pickers, in whichever language the interface is currently in.
@@ -24,10 +29,10 @@ public record LangItem(string Code, string Name, string English)
     {
         get
         {
-            if (string.IsNullOrEmpty(English)) return Name;
-            return LocalizationService.Current == LocalizationService.English
-                ? English
-                : $"{Name} {English}";
+            if (LocalizationService.Current == LocalizationService.English)
+                return string.IsNullOrEmpty(English) ? Name : English;
+
+            return StandsAlone || string.IsNullOrEmpty(English) ? Name : $"{Name} {English}";
         }
     }
 }
@@ -89,7 +94,7 @@ public static class LanguageData
 
     public static readonly List<LangItem> OcrSourceLanguages =
     [
-        new(AutomaticSourceLanguage, "自動（中英日）", ""),
+        new(AutomaticSourceLanguage, "自動（中英日）", "Automatic (ZH/EN/JA)", StandsAlone: true),
         new("EN",      "英語", "English"),
         new("JA",      "日語", "Japanese"),
         new("KO",      "韓語", "Korean"),

--- a/src/OverTranslate/Models/LanguageData.cs
+++ b/src/OverTranslate/Models/LanguageData.cs
@@ -1,3 +1,5 @@
+using OverTranslate.Services;
+
 namespace OverTranslate.Models;
 
 /// <param name="Name">The language's name in the interface's own language, which is what a
@@ -9,9 +11,39 @@ namespace OverTranslate.Models;
 /// </param>
 public record LangItem(string Code, string Name, string English)
 {
-    public string Display => string.IsNullOrEmpty(English) ? Name : $"{Name} {English}";
+    /// <summary>
+    /// The label for the pickers, in whichever language the interface is currently in.
+    /// </summary>
+    /// <remarks>
+    /// The Chinese interface shows both names, which is what the pair was carried separately for.
+    /// The English one shows only <see cref="English"/>: "英語 English" beside an English menu is
+    /// noise to a reader who cannot read the first half, and the doubled-up label is what pushed
+    /// these combo boxes wide in the first place.
+    /// </remarks>
+    public string Display
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(English)) return Name;
+            return LocalizationService.Current == LocalizationService.English
+                ? English
+                : $"{Name} {English}";
+        }
+    }
 }
-public record ProviderItem(TranslationProvider Provider, string Display, bool RequiresApiKey, string? Hint = null);
+/// <param name="DisplayKey">Resource key for the name shown in the pickers.</param>
+/// <param name="HintKey">Resource key for the line under the picker, or null for no hint.</param>
+/// <remarks>
+/// Keys rather than text: the list is static, the interface language is not, and a record built
+/// once at type-initialisation would otherwise keep whichever language the app started in.
+/// Resolving in the properties means callers still just read <see cref="Display"/>.
+/// </remarks>
+public record ProviderItem(
+    TranslationProvider Provider, string DisplayKey, bool RequiresApiKey, string? HintKey = null)
+{
+    public string Display => LocalizationService.Get(DisplayKey);
+    public string? Hint => HintKey is null ? null : LocalizationService.Get(HintKey);
+}
 
 public static class LanguageData
 {
@@ -67,12 +99,12 @@ public static class LanguageData
 
     public static readonly List<ProviderItem> Providers =
     [
-        new(TranslationProvider.Google,  "Google 翻譯 (Web)", false, "傳統 Web 介面"),
-        new(TranslationProvider.Google2, "Google 翻譯 (RPC)", false, "新版 RPC 介面"),
-        new(TranslationProvider.Bing,    "Bing 翻譯", false),
-        new(TranslationProvider.Microsoft, "Microsoft 翻譯", false),
-        new(TranslationProvider.DeepL,   "DeepL 翻譯", true, "需至 DeepL 官方註冊並取得 API Key"),
-        new(TranslationProvider.OpenAI,  "OpenAI", false, "支援 OpenAI API 格式，建議使用本地 LLM，可透過 Ollama 快速安裝與使用。"),
+        new(TranslationProvider.Google,    "S.Provider.Google",    false, "S.Provider.GoogleHint"),
+        new(TranslationProvider.Google2,   "S.Provider.Google2",   false, "S.Provider.Google2Hint"),
+        new(TranslationProvider.Bing,      "S.Provider.Bing",      false),
+        new(TranslationProvider.Microsoft, "S.Provider.Microsoft", false),
+        new(TranslationProvider.DeepL,     "S.Provider.DeepL",     true,  "S.Provider.DeepLHint"),
+        new(TranslationProvider.OpenAI,    "S.Provider.OpenAI",    false, "S.Provider.OpenAIHint"),
     ];
 
     /// <summary>

--- a/src/OverTranslate/Models/LanguageData.cs
+++ b/src/OverTranslate/Models/LanguageData.cs
@@ -35,6 +35,19 @@ public record LangItem(string Code, string Name, string English, bool StandsAlon
             return StandsAlone || string.IsNullOrEmpty(English) ? Name : $"{Name} {English}";
         }
     }
+
+    /// <summary>
+    /// The name alone, in the interface's language, for somewhere with one line to spare.
+    /// </summary>
+    /// <remarks>
+    /// The realtime control bar names the pair it is translating between and has room for neither
+    /// the doubled-up label <see cref="Display"/> produces in Chinese nor a language the reader
+    /// cannot read.
+    /// </remarks>
+    public string ShortName =>
+        LocalizationService.Current == LocalizationService.English && !string.IsNullOrEmpty(English)
+            ? English
+            : Name;
 }
 /// <param name="DisplayKey">Resource key for the name shown in the pickers.</param>
 /// <param name="HintKey">Resource key for the line under the picker, or null for no hint.</param>
@@ -237,4 +250,23 @@ public static class LanguageData
     public static string GetTargetName(string? code) =>
         TargetLanguages.FirstOrDefault(l =>
             l.Code.Equals(code, StringComparison.OrdinalIgnoreCase))?.Name ?? code ?? "";
+
+    /// <summary>
+    /// A source language's name for display, in whichever language the interface is in.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="GetSourceName"/>, which stays Chinese whatever the interface is
+    /// set to, because its caller is not the interface: it names the languages inside the prompt
+    /// sent to an OpenAI-compatible model, and that prompt is written in Chinese throughout. A
+    /// single accessor serving both would tie what a model is asked to do to what language the
+    /// user happens to read the buttons in.
+    /// </remarks>
+    public static string GetSourceDisplayName(string? code) =>
+        OcrSourceLanguages.FirstOrDefault(l =>
+            l.Code.Equals(code, StringComparison.OrdinalIgnoreCase))?.ShortName ?? code ?? "";
+
+    /// <inheritdoc cref="GetSourceDisplayName"/>
+    public static string GetTargetDisplayName(string? code) =>
+        TargetLanguages.FirstOrDefault(l =>
+            l.Code.Equals(code, StringComparison.OrdinalIgnoreCase))?.ShortName ?? code ?? "";
 }

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -1,0 +1,283 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- Mirror of Strings.zh-Hant.xaml. Same keys, same {0} placeholders in the same meaning —
+         StringsParityTests fails the build if the two drift apart.
+
+         Field labels here are deliberately terse. They sit in a shared-width column that sizes
+         itself to the longest one, so a wordy label pushes every input on the page to the right.
+         Prefer the noun ("Shortcut", "Provider") over the sentence. -->
+
+    <!-- ── Shared ── -->
+    <sys:String x:Key="S.Common.Record">Record</sys:String>
+    <sys:String x:Key="S.Common.Cancel">Cancel</sys:String>
+    <sys:String x:Key="S.Common.Edit">Edit</sys:String>
+    <sys:String x:Key="S.Common.Close">Close</sys:String>
+    <sys:String x:Key="S.Common.ApiKey">API key</sys:String>
+
+    <!-- ── Shell window ── -->
+    <sys:String x:Key="S.Shell.About">About</sys:String>
+    <sys:String x:Key="S.Shell.CaptureTranslate">Screen capture</sys:String>
+    <sys:String x:Key="S.Shell.TextTranslate">Text</sys:String>
+    <sys:String x:Key="S.Shell.RealtimeTranslate">Realtime</sys:String>
+    <sys:String x:Key="S.Shell.Settings">Settings</sys:String>
+    <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">Realtime translation is running — stop it before using screen capture</sys:String>
+    <sys:String x:Key="S.Shell.UpdateAvailable">Update to v{0}</sys:String>
+
+    <!-- ── Tray menu ── -->
+    <sys:String x:Key="S.Tray.OpenWindow">Open translation window</sys:String>
+    <sys:String x:Key="S.Tray.RealtimeWindow">Realtime window</sys:String>
+    <sys:String x:Key="S.Tray.Settings">Settings</sys:String>
+    <sys:String x:Key="S.Tray.Exit">Exit</sys:String>
+
+    <!-- ── About ── -->
+    <sys:String x:Key="S.About.Author">Author</sys:String>
+    <sys:String x:Key="S.About.ViewSource">View the source on GitHub</sys:String>
+    <sys:String x:Key="S.About.Version">Version {0}</sys:String>
+    <sys:String x:Key="S.About.OpenSourceBefore" xml:space="preserve">Free and open source. If you find it useful, a </sys:String>
+    <sys:String x:Key="S.About.OpenSourceAfter" xml:space="preserve"> Star on GitHub is much appreciated!</sys:String>
+
+    <!-- ── Toast ── -->
+    <sys:String x:Key="S.Toast.CopyMessage">Copy message</sys:String>
+    <sys:String x:Key="S.Toast.Copied">Copied to the clipboard</sys:String>
+
+    <!-- ── Update ── -->
+    <sys:String x:Key="S.Update.WindowTitle">Update available</sys:String>
+    <sys:String x:Key="S.Update.Heading">Update available</sys:String>
+    <sys:String x:Key="S.Update.CurrentVersion">Current</sys:String>
+    <sys:String x:Key="S.Update.LatestVersion">Latest</sys:String>
+    <sys:String x:Key="S.Update.Explanation">"Update now" downloads and applies the update, then restarts the app.</sys:String>
+    <sys:String x:Key="S.Update.NotesBefore" xml:space="preserve">Curious what changed? </sys:String>
+    <sys:String x:Key="S.Update.NotesLink">See the release notes</sys:String>
+    <sys:String x:Key="S.Update.Later">Later</sys:String>
+    <sys:String x:Key="S.Update.Now">Update now</sys:String>
+    <sys:String x:Key="S.Update.Skip">Skip this version and stop reminding me</sys:String>
+    <sys:String x:Key="S.Update.Downloading">Downloading {0}%</sys:String>
+    <sys:String x:Key="S.Update.Applying">Applying...</sys:String>
+    <sys:String x:Key="S.Update.Retry">Retry</sys:String>
+    <sys:String x:Key="S.Update.Failed">Could not download the update: {0}</sys:String>
+
+    <!-- ── Service errors ── -->
+    <sys:String x:Key="S.Error.OpenAiNoModel">No model name set for the OpenAI-compatible provider.</sys:String>
+    <sys:String x:Key="S.Error.OpenAiHttp">The OpenAI-compatible API returned {0}: {1}</sys:String>
+    <sys:String x:Key="S.Error.OpenAiUnparsable">Could not parse the OpenAI-compatible API response.</sys:String>
+    <sys:String x:Key="S.Error.OpenAiNoTranslation">The OpenAI-compatible API returned no translation.</sys:String>
+    <sys:String x:Key="S.Error.OpenAiBadUrl">The OpenAI-compatible API address must be a valid HTTP or HTTPS URL.</sys:String>
+    <sys:String x:Key="S.Error.UnknownError">Unknown error</sys:String>
+    <sys:String x:Key="S.Error.NoErrorContent">No error details provided</sys:String>
+    <sys:String x:Key="S.Error.OcrUnsupportedLanguage">OCR currently supports AUTO, EN, ZH, ZH-HANT, JA and KO only; "{0}" is not supported yet.</sys:String>
+    <sys:String x:Key="S.Error.OcrSwapTimeout">Timed out waiting for other recognition to finish before switching OCR models.</sys:String>
+    <sys:String x:Key="S.Error.OcrImageConvert">Could not convert the image into a format the ONNX OCR can read.</sys:String>
+    <sys:String x:Key="S.Error.OcrModelMissing">OCR model file not found: {0}</sys:String>
+    <sys:String x:Key="S.Error.NotTranslated">Not translated</sys:String>
+
+    <!-- ── Text translation page ── -->
+    <sys:String x:Key="S.Translation.Title">Text translation</sys:String>
+    <sys:String x:Key="S.Translation.Subtitle">Type or paste text to translate it. Capture results land here too.</sys:String>
+    <sys:String x:Key="S.Translation.SwapTip">Swap languages and text</sys:String>
+    <sys:String x:Key="S.Translation.SpeakSource">Read the source aloud</sys:String>
+    <sys:String x:Key="S.Translation.Source">Source</sys:String>
+    <sys:String x:Key="S.Translation.SpeakResult">Read the translation aloud</sys:String>
+    <sys:String x:Key="S.Translation.Result">Translation</sys:String>
+    <sys:String x:Key="S.Translation.Retry">↻ Retry</sys:String>
+    <sys:String x:Key="S.Translation.MissingApiKey">No API key — enter one in Settings first</sys:String>
+    <sys:String x:Key="S.Translation.ProviderUnavailable">{0} is unavailable right now. Try a different translation source.
+Translation failed: {1}</sys:String>
+    <sys:String x:Key="S.Translation.Translating">Translating...</sys:String>
+    <sys:String x:Key="S.Translation.SpeakFailed">Could not read it aloud: {0}</sys:String>
+
+    <!-- ── Capture toolbar ── -->
+    <sys:String x:Key="S.Toolbar.Translate">Translate</sys:String>
+    <sys:String x:Key="S.Toolbar.Translating">Translating...</sys:String>
+    <sys:String x:Key="S.Toolbar.Retranslate">Translate again</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowSource">Show source</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowTranslation">Show translation</sys:String>
+    <sys:String x:Key="S.Toolbar.Screenshot">Screenshot</sys:String>
+    <sys:String x:Key="S.Toolbar.OpenWindow">Open in window</sys:String>
+    <sys:String x:Key="S.Toolbar.BackupBadge">⚡Backup {0}</sys:String>
+    <sys:String x:Key="S.Toolbar.BackupTooltip">"{0}" could not translate everything, so "{1}" filled in the rest.
+Actually used this time: {2}</sys:String>
+
+    <!-- ── Capture overlay ── -->
+    <sys:String x:Key="S.Capture.CancelTip">Cancel capture</sys:String>
+    <sys:String x:Key="S.Capture.DragPrompt">Drag to select an area to translate</sys:String>
+    <sys:String x:Key="S.Capture.PressPrefix">Press</sys:String>
+    <sys:String x:Key="S.Capture.CancelSuffix">to cancel</sys:String>
+    <sys:String x:Key="S.Overlay.Recognising">Reading</sys:String>
+
+    <!-- ── Secret box ── -->
+    <sys:String x:Key="S.Secret.Show">Show</sys:String>
+    <sys:String x:Key="S.Secret.Hide">Hide</sys:String>
+
+    <!-- ── Tray notifications and capture balloons ── -->
+    <sys:String x:Key="S.Main.MinimizedTitle">OverTranslate is still running</sys:String>
+    <sys:String x:Key="S.Main.MinimizedBody">Minimised to the system tray. Press {0} to start a screen capture translation.</sys:String>
+    <sys:String x:Key="S.Main.DefaultShortcutName">your shortcut</sys:String>
+    <sys:String x:Key="S.Main.RealtimeRunningTitle">Realtime translation is running</sys:String>
+    <sys:String x:Key="S.Main.RealtimeRunningBody">Stop realtime translation before using screen capture.</sys:String>
+    <sys:String x:Key="S.Main.MissingApiKeyTitle">No API key</sys:String>
+    <sys:String x:Key="S.Main.MissingApiKeyBody">Enter an API key in Settings.</sys:String>
+    <sys:String x:Key="S.Main.RecogniseFailedTitle">Recognition failed</sys:String>
+    <sys:String x:Key="S.Main.NoImageBody">The selected image is missing. Select the area again.</sys:String>
+    <sys:String x:Key="S.Main.Recognising">Reading</sys:String>
+    <sys:String x:Key="S.Main.NoTextTitle">No text found</sys:String>
+    <sys:String x:Key="S.Main.NoTextBody">No readable text in the selected area.</sys:String>
+    <sys:String x:Key="S.Main.Translating">Translating</sys:String>
+    <sys:String x:Key="S.Main.TranslateFailedTitle">Translation failed</sys:String>
+    <sys:String x:Key="S.Main.TranslateFailedBody">The current translation source may be temporarily unavailable.
+Switch to a different source and try again.
+Details: {0}</sys:String>
+    <sys:String x:Key="S.Main.CopiedTitle">Copied</sys:String>
+    <sys:String x:Key="S.Main.CopiedBody">The selected area was copied to the clipboard.</sys:String>
+    <sys:String x:Key="S.Main.CopiedAndSavedBody">Copied to the clipboard and saved to:
+{0}</sys:String>
+    <sys:String x:Key="S.Main.CopiedSaveFailedTitle">Copied (not saved)</sys:String>
+    <sys:String x:Key="S.Main.CopiedSaveFailedBody">Copied to the clipboard, but could not be saved: {0}</sys:String>
+    <sys:String x:Key="S.Main.CopyFailedTitle">Copy failed</sys:String>
+    <sys:String x:Key="S.Main.CopyFailedBody">Could not copy the screenshot: {0}</sys:String>
+
+    <!-- ── Realtime translation ── -->
+    <sys:String x:Key="S.Realtime.Title">Realtime translation</sys:String>
+    <sys:String x:Key="S.Realtime.Subtitle">Pick regions of the screen and they are re-translated whenever the text changes — for video, games and anything else that keeps moving.</sys:String>
+
+    <sys:String x:Key="S.Realtime.TranslationSettings">Translation</sys:String>
+    <sys:String x:Key="S.Realtime.SourceLanguage">Source language</sys:String>
+    <sys:String x:Key="S.Realtime.SourceLanguagePrompt">Choose a source language</sys:String>
+    <sys:String x:Key="S.Realtime.TargetLanguage">Target language</sys:String>
+    <sys:String x:Key="S.Realtime.Provider">Provider</sys:String>
+
+    <sys:String x:Key="S.Realtime.Blocks">Blocks</sys:String>
+    <sys:String x:Key="S.Realtime.Screen">Screen</sys:String>
+    <sys:String x:Key="S.Realtime.ScreenHint">Realtime translation currently covers one screen at a time.</sys:String>
+    <sys:String x:Key="S.Realtime.BlockCount">How many</sys:String>
+    <sys:String x:Key="S.Realtime.DecreaseBlocks">Fewer blocks</sys:String>
+    <sys:String x:Key="S.Realtime.IncreaseBlocks">More blocks</sys:String>
+    <sys:String x:Key="S.Realtime.BlockCountHint">Up to 3 blocks at a time.</sys:String>
+
+    <sys:String x:Key="S.Realtime.Appearance">Appearance</sys:String>
+    <sys:String x:Key="S.Realtime.Preview">Preview</sys:String>
+    <sys:String x:Key="S.Realtime.PreviewText">Text will look like this on screen</sys:String>
+    <sys:String x:Key="S.Realtime.TextColor">Text</sys:String>
+    <sys:String x:Key="S.Realtime.ScrimColor">Background</sys:String>
+    <sys:String x:Key="S.Realtime.ResetColors">Reset to defaults</sys:String>
+    <sys:String x:Key="S.Realtime.ResetColorsName">Reset colours</sys:String>
+
+    <sys:String x:Key="S.Realtime.HowItWorks">How it works</sys:String>
+    <sys:String x:Key="S.Realtime.Step1">1. Click "Select blocks" and drag over the areas you want translated.</sys:String>
+    <sys:String x:Key="S.Realtime.Step2">2. Click "Start" on the floating bar. Each block is re-read and updated whenever its content changes.</sys:String>
+    <sys:String x:Key="S.Realtime.Step3">3. Translated areas do not intercept clicks, so games and other apps keep working. Click "Edit" to adjust the blocks.</sys:String>
+    <sys:String x:Key="S.Realtime.Step4">4. Press {0} while translating to pause and resume. Pausing clears the translations and releases the recognition model.</sys:String>
+
+    <sys:String x:Key="S.Realtime.SelectBlocks">Select blocks</sys:String>
+    <sys:String x:Key="S.Realtime.StopSession">Stop</sys:String>
+    <sys:String x:Key="S.Realtime.ActiveHint">Running. Use the floating bar on screen to adjust or stop it.</sys:String>
+    <sys:String x:Key="S.Realtime.NoApiKey">No API key set. Enter one in Settings, or realtime translation will not be able to fetch translations.</sys:String>
+    <sys:String x:Key="S.Realtime.ScreenItem">Screen {0} · {1}×{2}</sys:String>
+    <sys:String x:Key="S.Realtime.ScreenItemPrimary">Screen {0} · {1}×{2} (primary)</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureInProgress">A screen capture translation is in progress. Finish it before starting realtime translation.</sys:String>
+    <sys:String x:Key="S.Realtime.ChooseSourceFirst">Choose a source language first.</sys:String>
+    <sys:String x:Key="S.Realtime.NoScreens">No usable screen found. Reopen this page.</sys:String>
+
+    <!-- Floating control bar -->
+    <sys:String x:Key="S.Realtime.EditHint">Drag on screen to create the areas you want translated</sys:String>
+    <sys:String x:Key="S.Realtime.StartTranslating">Start</sys:String>
+    <sys:String x:Key="S.Realtime.Running">Translating</sys:String>
+    <sys:String x:Key="S.Realtime.Paused">Paused</sys:String>
+    <sys:String x:Key="S.Realtime.Pause">Pause realtime translation</sys:String>
+    <sys:String x:Key="S.Realtime.Resume">Resume realtime translation</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureScreenshot">Capture a screenshot</sys:String>
+
+    <!-- Control bar and edit window messages -->
+    <sys:String x:Key="S.Realtime.MovedToFront">Realtime windows brought to the front</sys:String>
+    <sys:String x:Key="S.Realtime.TooManyBlocks">{0} blocks at most — remove one first</sys:String>
+    <sys:String x:Key="S.Realtime.NeedOneBlock">Drag to create at least one block first</sys:String>
+    <sys:String x:Key="S.Realtime.NothingToCapture">No translations to capture yet</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureFailed">Could not capture the screen — try again</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureCopied">Screenshot copied to the clipboard</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureCopiedAndSaved">Screenshot copied to the clipboard and saved</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureError">Capture failed: {0}</sys:String>
+    <sys:String x:Key="S.Realtime.RemoveBlock">Remove this block</sys:String>
+
+    <!-- Block mode picker -->
+    <sys:String x:Key="S.Realtime.ModeSubtitle">Subtitles</sys:String>
+    <sys:String x:Key="S.Realtime.ModeGameUi">Game UI</sys:String>
+    <sys:String x:Key="S.Realtime.ModeSubtitleSummary">Subtitle lines, dialogue boxes — large text, scaled down to read</sys:String>
+    <sys:String x:Key="S.Realtime.ModeGameUiSummary">Game panels, item text — small text, read at full size</sys:String>
+    <sys:String x:Key="S.Realtime.ModeSubtitleGuidance">For video subtitles, game dialogue and anything else where the text stays in one place.
+Leave half a character to a character of space above and below rather than hugging the text. Widening the sides a little is fine, but avoid taking in large empty areas, which add noise.</sys:String>
+    <sys:String x:Key="S.Realtime.ModeGameUiGuidance">For text spread across the screen, or that moves around as you play.
+Leave some room around each area you want translated rather than hugging its contents. If there are several separate areas, box them separately — one large block reads slowly.</sys:String>
+    <sys:String x:Key="S.Realtime.CollapseGuidance">Hide mode details</sys:String>
+    <sys:String x:Key="S.Realtime.ExpandGuidance">Show mode details</sys:String>
+
+    <!-- Session failures -->
+    <sys:String x:Key="S.Realtime.SessionAborted">Realtime translation stopped: {0}</sys:String>
+    <sys:String x:Key="S.Realtime.MissingApiKey">No API key. Enter one in Settings first.</sys:String>
+    <sys:String x:Key="S.Realtime.RetryingAfterFailure">Translation failed for now, still retrying: {0}</sys:String>
+
+    <!-- ── Translation providers ── -->
+    <sys:String x:Key="S.Provider.Google">Google Translate (Web)</sys:String>
+    <sys:String x:Key="S.Provider.GoogleHint">Legacy web interface</sys:String>
+    <sys:String x:Key="S.Provider.Google2">Google Translate (RPC)</sys:String>
+    <sys:String x:Key="S.Provider.Google2Hint">Newer RPC interface</sys:String>
+    <sys:String x:Key="S.Provider.Bing">Bing Translator</sys:String>
+    <sys:String x:Key="S.Provider.Microsoft">Microsoft Translator</sys:String>
+    <sys:String x:Key="S.Provider.DeepL">DeepL</sys:String>
+    <sys:String x:Key="S.Provider.DeepLHint">Requires an API key from DeepL</sys:String>
+    <sys:String x:Key="S.Provider.OpenAI">OpenAI</sys:String>
+    <sys:String x:Key="S.Provider.OpenAIHint">Any OpenAI-compatible API. A local LLM is recommended — Ollama is the quickest way to set one up.</sys:String>
+
+    <!-- ── Settings page ── -->
+    <sys:String x:Key="S.Settings.Title">Settings</sys:String>
+    <sys:String x:Key="S.Settings.Subtitle">Shortcuts, translation services, screenshots and appearance</sys:String>
+
+    <sys:String x:Key="S.Settings.General">General</sys:String>
+    <sys:String x:Key="S.Settings.CaptureHotkey">Capture</sys:String>
+    <sys:String x:Key="S.Settings.CaptureHotkeyHint">Press this shortcut to start a screen capture translation</sys:String>
+    <sys:String x:Key="S.Settings.WindowHotkey">Open window</sys:String>
+    <sys:String x:Key="S.Settings.WindowHotkeyHint">While realtime translation is running, brings the floating window to the front instead</sys:String>
+    <sys:String x:Key="S.Settings.SourceLanguage">Source</sys:String>
+    <sys:String x:Key="S.Settings.AutoTranslate">Auto</sys:String>
+    <sys:String x:Key="S.Settings.AutoTranslateCheck">Translate as soon as a region is selected</sys:String>
+    <sys:String x:Key="S.Settings.Startup">Startup</sys:String>
+    <sys:String x:Key="S.Settings.StartupCheck">Launch when Windows starts</sys:String>
+
+    <sys:String x:Key="S.Settings.TranslationApi">Translation API</sys:String>
+    <sys:String x:Key="S.Settings.Provider">Provider</sys:String>
+    <sys:String x:Key="S.Settings.ApiBaseUrl">API URL</sys:String>
+    <sys:String x:Key="S.Settings.ModelName">Model</sys:String>
+    <sys:String x:Key="S.Settings.OllamaGuide">Local LLM (Ollama) setup guide</sys:String>
+
+    <sys:String x:Key="S.Settings.Screenshot">Screenshots</sys:String>
+    <sys:String x:Key="S.Settings.SaveScreenshot">Save</sys:String>
+    <sys:String x:Key="S.Settings.SaveScreenshotCheck">Save a copy of every capture</sys:String>
+    <sys:String x:Key="S.Settings.SavePath">Location</sys:String>
+    <sys:String x:Key="S.Settings.SavePathTip">Click to choose a folder</sys:String>
+    <sys:String x:Key="S.Settings.OpenFolderTip">Open folder</sys:String>
+
+    <sys:String x:Key="S.Settings.Appearance">Appearance</sys:String>
+    <sys:String x:Key="S.Settings.Theme">Theme</sys:String>
+    <sys:String x:Key="S.Settings.ThemeLight">Light</sys:String>
+    <sys:String x:Key="S.Settings.ThemeDark">Dark</sys:String>
+    <!-- Card heading, then the row label inside it -->
+    <sys:String x:Key="S.Settings.UiLanguage">Interface language</sys:String>
+    <sys:String x:Key="S.Settings.UiLanguageLabel">Language</sys:String>
+
+    <sys:String x:Key="S.Settings.Advanced">Advanced</sys:String>
+    <sys:String x:Key="S.Settings.Logging">Logging</sys:String>
+    <sys:String x:Key="S.Settings.LoggingCheck">Record detailed information</sys:String>
+    <sys:String x:Key="S.Settings.LoggingHint">Logs more detail to help diagnose problems.</sys:String>
+
+    <sys:String x:Key="S.Settings.AutoSaveHint">Changes are saved automatically</sys:String>
+
+    <!-- Settings page, composed in code-behind -->
+    <sys:String x:Key="S.Settings.Saved">✓ Saved</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyPrompt">Press a shortcut...</sys:String>
+    <sys:String x:Key="S.Settings.FolderPickerTitle">Choose where to save screenshots</sys:String>
+    <sys:String x:Key="S.Settings.LoggingEnvOverride">The log level is currently set by the OVERTRANSLATE_LOGLEVEL environment variable, so this option has no effect.</sys:String>
+    <sys:String x:Key="S.Settings.StartupFailed">✗ Could not change the startup setting: {0}</sys:String>
+    <sys:String x:Key="S.Settings.OpenFolderFailed">✗ Could not open the folder: {0}</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} is already assigned to "{1}"</sys:String>
+
+</ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -1,0 +1,294 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- Keys are grouped by the surface they appear on. Every key here must also exist in
+         Strings.en.xaml — StringsParityTests fails the build otherwise. Strings holding {0}
+         are composite formats consumed through LocalizationService.Format. -->
+
+    <!-- ── Shared ── -->
+    <sys:String x:Key="S.Common.Record">錄製</sys:String>
+    <sys:String x:Key="S.Common.Cancel">取消</sys:String>
+    <sys:String x:Key="S.Common.Edit">編輯</sys:String>
+    <sys:String x:Key="S.Common.Close">關閉</sys:String>
+    <sys:String x:Key="S.Common.ApiKey">API Key</sys:String>
+
+    <!-- ── Shell window ── -->
+    <sys:String x:Key="S.Shell.About">關於</sys:String>
+    <sys:String x:Key="S.Shell.CaptureTranslate">截圖翻譯</sys:String>
+    <sys:String x:Key="S.Shell.TextTranslate">文字翻譯</sys:String>
+    <sys:String x:Key="S.Shell.RealtimeTranslate">即時翻譯</sys:String>
+    <sys:String x:Key="S.Shell.Settings">設定</sys:String>
+    <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">即時翻譯進行中，請先結束後再使用截圖翻譯</sys:String>
+    <sys:String x:Key="S.Shell.UpdateAvailable">可更新至 v{0}</sys:String>
+
+    <!-- ── Tray menu ── -->
+    <sys:String x:Key="S.Tray.OpenWindow">開啟翻譯視窗</sys:String>
+    <sys:String x:Key="S.Tray.RealtimeWindow">即時翻譯視窗</sys:String>
+    <sys:String x:Key="S.Tray.Settings">設定</sys:String>
+    <sys:String x:Key="S.Tray.Exit">結束</sys:String>
+
+    <!-- ── About ── -->
+    <sys:String x:Key="S.About.Author">作者</sys:String>
+    <sys:String x:Key="S.About.ViewSource">在 GitHub 上查看原始碼</sys:String>
+    <sys:String x:Key="S.About.Version">版本 {0}</sys:String>
+    <!-- Split around the star glyph, which sits mid-sentence in both languages but not at the same
+         point. xml:space keeps the trailing space the English half needs — XAML trims element
+         content otherwise, and the Chinese half must have none. -->
+    <sys:String x:Key="S.About.OpenSourceBefore" xml:space="preserve">免費開源，可自由使用。如果覺得有幫助，也歡迎到 GitHub 幫忙點個</sys:String>
+    <sys:String x:Key="S.About.OpenSourceAfter" xml:space="preserve">Star，感謝！</sys:String>
+
+    <!-- ── Toast ── -->
+    <sys:String x:Key="S.Toast.CopyMessage">複製訊息</sys:String>
+    <sys:String x:Key="S.Toast.Copied">已複製到剪貼簿</sys:String>
+
+    <!-- ── Update ── -->
+    <sys:String x:Key="S.Update.WindowTitle">發現新版本</sys:String>
+    <sys:String x:Key="S.Update.Heading">發現新版本！</sys:String>
+    <sys:String x:Key="S.Update.CurrentVersion">目前版本</sys:String>
+    <sys:String x:Key="S.Update.LatestVersion">最新版本</sys:String>
+    <sys:String x:Key="S.Update.Explanation">點擊「立即更新」後將自動下載並套用，完成後自動重新啟動。</sys:String>
+    <sys:String x:Key="S.Update.NotesBefore" xml:space="preserve">想了解這次更新了什麼？</sys:String>
+    <sys:String x:Key="S.Update.NotesLink">查看更新內容</sys:String>
+    <sys:String x:Key="S.Update.Later">稍後再說</sys:String>
+    <sys:String x:Key="S.Update.Now">立即更新</sys:String>
+    <sys:String x:Key="S.Update.Skip">跳過此版本，不要再提醒我</sys:String>
+    <sys:String x:Key="S.Update.Downloading">下載中 {0}%</sys:String>
+    <sys:String x:Key="S.Update.Applying">套用中…</sys:String>
+    <sys:String x:Key="S.Update.Retry">重試</sys:String>
+    <sys:String x:Key="S.Update.Failed">下載更新失敗：{0}</sys:String>
+
+    <!-- ── Service errors ──
+         These reach the user through an exception message shown in a balloon or status line, so
+         they are interface text despite living in the service layer. The LLM prompts in
+         OpenAiCompatibleProvider are deliberately not here: those are sent to a model, not read by
+         a person, and they do not follow the interface language. -->
+    <sys:String x:Key="S.Error.OpenAiNoModel">尚未設定 OpenAI Compatible 的模型名稱。</sys:String>
+    <sys:String x:Key="S.Error.OpenAiHttp">OpenAI Compatible API 回傳 {0}：{1}</sys:String>
+    <sys:String x:Key="S.Error.OpenAiUnparsable">OpenAI Compatible API 回應格式無法解析。</sys:String>
+    <sys:String x:Key="S.Error.OpenAiNoTranslation">OpenAI Compatible API 未回傳譯文。</sys:String>
+    <sys:String x:Key="S.Error.OpenAiBadUrl">OpenAI Compatible API 位址必須是有效的 HTTP 或 HTTPS 網址。</sys:String>
+    <sys:String x:Key="S.Error.UnknownError">未知錯誤</sys:String>
+    <sys:String x:Key="S.Error.NoErrorContent">未提供錯誤內容</sys:String>
+    <sys:String x:Key="S.Error.OcrUnsupportedLanguage">目前 OCR 僅支援 AUTO、EN、ZH、ZH-HANT、JA、KO；「{0}」尚未支援。</sys:String>
+    <sys:String x:Key="S.Error.OcrSwapTimeout">等待其他辨識結束以切換 OCR 模型時逾時。</sys:String>
+    <sys:String x:Key="S.Error.OcrImageConvert">無法將影像轉換為 ONNX OCR 可讀格式。</sys:String>
+    <sys:String x:Key="S.Error.OcrModelMissing">找不到 OCR 模型檔案：{0}</sys:String>
+    <sys:String x:Key="S.Error.NotTranslated">未翻譯</sys:String>
+
+    <!-- ── Text translation page ── -->
+    <sys:String x:Key="S.Translation.Title">文字翻譯</sys:String>
+    <sys:String x:Key="S.Translation.Subtitle">輸入或貼上文字即可翻譯，截圖結果也會送到這裡</sys:String>
+    <sys:String x:Key="S.Translation.SwapTip">對調語言與內容</sys:String>
+    <sys:String x:Key="S.Translation.SpeakSource">朗讀原文</sys:String>
+    <sys:String x:Key="S.Translation.Source">原文</sys:String>
+    <sys:String x:Key="S.Translation.SpeakResult">朗讀譯文</sys:String>
+    <sys:String x:Key="S.Translation.Result">譯文</sys:String>
+    <sys:String x:Key="S.Translation.Retry">↻ 重試</sys:String>
+    <sys:String x:Key="S.Translation.MissingApiKey">缺少 API Key — 請先在設定中輸入</sys:String>
+    <sys:String x:Key="S.Translation.ProviderUnavailable">{0} 目前無法使用，請改用其他翻譯來源。
+翻譯失敗：{1}</sys:String>
+    <sys:String x:Key="S.Translation.Translating">翻譯中…</sys:String>
+    <sys:String x:Key="S.Translation.SpeakFailed">朗讀失敗：{0}</sys:String>
+
+    <!-- ── Capture toolbar ── -->
+    <sys:String x:Key="S.Toolbar.Translate">翻譯</sys:String>
+    <sys:String x:Key="S.Toolbar.Translating">翻譯中...</sys:String>
+    <sys:String x:Key="S.Toolbar.Retranslate">重新翻譯</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowSource">顯示原文</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowTranslation">顯示譯文</sys:String>
+    <sys:String x:Key="S.Toolbar.Screenshot">截圖</sys:String>
+    <sys:String x:Key="S.Toolbar.OpenWindow">開啟翻譯視窗</sys:String>
+    <sys:String x:Key="S.Toolbar.BackupBadge">⚡備援 {0}</sys:String>
+    <sys:String x:Key="S.Toolbar.BackupTooltip">「{0}」未能完整翻譯，已由備援「{1}」進行部分翻譯。
+本次實際翻譯：{2}</sys:String>
+
+    <!-- ── Capture overlay ── -->
+    <sys:String x:Key="S.Capture.CancelTip">取消截圖</sys:String>
+    <sys:String x:Key="S.Capture.DragPrompt">拖曳選取翻譯區域</sys:String>
+    <!-- Split around the Esc key glyph; the two halves keep their order in both languages. -->
+    <sys:String x:Key="S.Capture.PressPrefix">按</sys:String>
+    <sys:String x:Key="S.Capture.CancelSuffix">取消</sys:String>
+    <sys:String x:Key="S.Overlay.Recognising">辨識中</sys:String>
+
+    <!-- ── Secret box ── -->
+    <sys:String x:Key="S.Secret.Show">顯示內容</sys:String>
+    <sys:String x:Key="S.Secret.Hide">隱藏內容</sys:String>
+
+    <!-- ── Tray notifications and capture balloons ── -->
+    <sys:String x:Key="S.Main.MinimizedTitle">OverTranslate 已最小化</sys:String>
+    <sys:String x:Key="S.Main.MinimizedBody">程式已縮小至系統匣，可使用 {0} 開始進行截圖翻譯。</sys:String>
+    <sys:String x:Key="S.Main.DefaultShortcutName">已設定的快捷鍵</sys:String>
+    <sys:String x:Key="S.Main.RealtimeRunningTitle">即時翻譯進行中</sys:String>
+    <sys:String x:Key="S.Main.RealtimeRunningBody">請先結束即時翻譯，再使用截圖翻譯。</sys:String>
+    <sys:String x:Key="S.Main.MissingApiKeyTitle">缺少 API Key</sys:String>
+    <sys:String x:Key="S.Main.MissingApiKeyBody">請在設定中輸入 API Key。</sys:String>
+    <sys:String x:Key="S.Main.RecogniseFailedTitle">辨識失敗</sys:String>
+    <sys:String x:Key="S.Main.NoImageBody">找不到框選影像，請重新框選。</sys:String>
+    <sys:String x:Key="S.Main.Recognising">辨識中</sys:String>
+    <sys:String x:Key="S.Main.NoTextTitle">未偵測到文字</sys:String>
+    <sys:String x:Key="S.Main.NoTextBody">所選區域中未找到可辨識的文字。</sys:String>
+    <sys:String x:Key="S.Main.Translating">翻譯中</sys:String>
+    <sys:String x:Key="S.Main.TranslateFailedTitle">翻譯失敗</sys:String>
+    <sys:String x:Key="S.Main.TranslateFailedBody">目前使用的翻譯來源可能暫時無法使用。
+請切換其他翻譯來源後再試一次。
+詳細資訊：{0}</sys:String>
+    <sys:String x:Key="S.Main.CopiedTitle">已複製</sys:String>
+    <sys:String x:Key="S.Main.CopiedBody">已將框選截圖複製到剪貼簿。</sys:String>
+    <sys:String x:Key="S.Main.CopiedAndSavedBody">已複製到剪貼簿，並儲存至：
+{0}</sys:String>
+    <sys:String x:Key="S.Main.CopiedSaveFailedTitle">已複製（儲存失敗）</sys:String>
+    <sys:String x:Key="S.Main.CopiedSaveFailedBody">已複製到剪貼簿，但無法儲存到本機：{0}</sys:String>
+    <sys:String x:Key="S.Main.CopyFailedTitle">複製失敗</sys:String>
+    <sys:String x:Key="S.Main.CopyFailedBody">無法複製截圖：{0}</sys:String>
+
+    <!-- ── Realtime translation ── -->
+    <sys:String x:Key="S.Realtime.Title">即時翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.Subtitle">在畫面上選取翻譯區域，文字變更時會自動翻譯並顯示在畫面上，適用於影片或遊戲畫面等。</sys:String>
+
+    <sys:String x:Key="S.Realtime.TranslationSettings">翻譯設定</sys:String>
+    <sys:String x:Key="S.Realtime.SourceLanguage">來源語言</sys:String>
+    <sys:String x:Key="S.Realtime.SourceLanguagePrompt">請選擇來源語言</sys:String>
+    <sys:String x:Key="S.Realtime.TargetLanguage">目標語言</sys:String>
+    <sys:String x:Key="S.Realtime.Provider">翻譯服務</sys:String>
+
+    <sys:String x:Key="S.Realtime.Blocks">翻譯區塊</sys:String>
+    <sys:String x:Key="S.Realtime.Screen">使用螢幕</sys:String>
+    <sys:String x:Key="S.Realtime.ScreenHint">即時翻譯目前只支援單一螢幕畫面。</sys:String>
+    <sys:String x:Key="S.Realtime.BlockCount">區塊數量</sys:String>
+    <sys:String x:Key="S.Realtime.DecreaseBlocks">減少區塊數量</sys:String>
+    <sys:String x:Key="S.Realtime.IncreaseBlocks">增加區塊數量</sys:String>
+    <sys:String x:Key="S.Realtime.BlockCountHint">最多可同時建立 3 個翻譯區塊。</sys:String>
+
+    <sys:String x:Key="S.Realtime.Appearance">顯示外觀</sys:String>
+    <sys:String x:Key="S.Realtime.Preview">預覽</sys:String>
+    <sys:String x:Key="S.Realtime.PreviewText">文字會像這樣顯示在畫面上</sys:String>
+    <sys:String x:Key="S.Realtime.TextColor">文字顏色</sys:String>
+    <sys:String x:Key="S.Realtime.ScrimColor">底色</sys:String>
+    <sys:String x:Key="S.Realtime.ResetColors">還原預設值</sys:String>
+    <sys:String x:Key="S.Realtime.ResetColorsName">還原預設顏色</sys:String>
+
+    <sys:String x:Key="S.Realtime.HowItWorks">運作方式</sys:String>
+    <sys:String x:Key="S.Realtime.Step1">1. 點擊「選取翻譯區塊」，在畫面上框選要翻譯的區域。</sys:String>
+    <sys:String x:Key="S.Realtime.Step2">2. 點擊浮動工具列的「開始翻譯」，內容變更時會自動重新辨識並更新譯文。</sys:String>
+    <sys:String x:Key="S.Realtime.Step3">3. 翻譯中的區域不會影響遊戲或介面操作，如需調整翻譯區塊，請按「編輯」。</sys:String>
+    <sys:String x:Key="S.Realtime.Step4">4. 翻譯中按 {0} 可暫停／繼續，暫停時會清除譯文並釋放辨識模型。</sys:String>
+
+    <sys:String x:Key="S.Realtime.SelectBlocks">選取翻譯區塊</sys:String>
+    <sys:String x:Key="S.Realtime.StopSession">結束即時翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.ActiveHint">即時翻譯進行中，可用螢幕上的浮動列調整或結束。</sys:String>
+    <sys:String x:Key="S.Realtime.NoApiKey">尚未設定 API Key，請先到「設定」輸入，否則即時翻譯會無法取得譯文。</sys:String>
+    <!-- Two whole strings rather than a suffix appended to the first: the English marker needs a
+         leading space and the Chinese one must not have any, and leading whitespace in a XAML text
+         node is not something to stake a label on. -->
+    <sys:String x:Key="S.Realtime.ScreenItem">螢幕 {0} · {1}×{2}</sys:String>
+    <sys:String x:Key="S.Realtime.ScreenItemPrimary">螢幕 {0} · {1}×{2}（主螢幕）</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureInProgress">截圖翻譯進行中，請先結束後再啟動即時翻譯。</sys:String>
+    <sys:String x:Key="S.Realtime.ChooseSourceFirst">請先選擇原文語言。</sys:String>
+    <sys:String x:Key="S.Realtime.NoScreens">找不到可用的螢幕，請重新開啟此頁面。</sys:String>
+
+    <!-- Floating control bar -->
+    <sys:String x:Key="S.Realtime.EditHint">在螢幕上拖曳建立要翻譯的區塊</sys:String>
+    <sys:String x:Key="S.Realtime.StartTranslating">開始翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.Running">即時翻譯中</sys:String>
+    <sys:String x:Key="S.Realtime.Paused">已暫停</sys:String>
+    <sys:String x:Key="S.Realtime.Pause">暫停即時翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.Resume">繼續即時翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureScreenshot">擷取畫面截圖</sys:String>
+
+    <!-- Control bar and edit window messages -->
+    <sys:String x:Key="S.Realtime.MovedToFront">已將即時翻譯視窗移至最上層</sys:String>
+    <sys:String x:Key="S.Realtime.TooManyBlocks">最多同時 {0} 個區塊，請先移除一個</sys:String>
+    <sys:String x:Key="S.Realtime.NeedOneBlock">請先拖曳建立至少一個區塊</sys:String>
+    <sys:String x:Key="S.Realtime.NothingToCapture">目前還沒有譯文可以擷取</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureFailed">擷取畫面失敗，請再試一次</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureCopied">畫面截圖已複製到剪貼簿</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureCopiedAndSaved">畫面截圖已複製到剪貼簿並儲存至本機</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureError">擷取失敗：{0}</sys:String>
+    <sys:String x:Key="S.Realtime.RemoveBlock">移除此區塊</sys:String>
+
+    <!-- Block mode picker. The em dash in the summaries separates what the mode is for from what
+         it does to the text; en-dash-with-spaces reads better in English. -->
+    <sys:String x:Key="S.Realtime.ModeSubtitle">字幕</sys:String>
+    <sys:String x:Key="S.Realtime.ModeGameUi">遊戲介面</sys:String>
+    <sys:String x:Key="S.Realtime.ModeSubtitleSummary">整條字幕、對話框——文字大，讀取時會縮小</sys:String>
+    <sys:String x:Key="S.Realtime.ModeGameUiSummary">遊戲面板、物品說明——文字小，讀取時不縮小</sys:String>
+    <sys:String x:Key="S.Realtime.ModeSubtitleGuidance">適合影音字幕、遊戲對話等文字集中且位置較固定的畫面。
+框選時，上下約留半個至一個字的空間，避免貼齊文字；左右可適度放寬，但不要框入過多空白範圍，避免雜訊。</sys:String>
+    <sys:String x:Key="S.Realtime.ModeGameUiGuidance">適合文字分散於不同位置，或內容位置經常變動的遊戲畫面。
+框選時，需翻譯的區域請保留一些空間，避免貼齊內容；若畫面有多個區域則建議分開框選，避免辨識速度過慢。</sys:String>
+    <sys:String x:Key="S.Realtime.CollapseGuidance">收合模式說明</sys:String>
+    <sys:String x:Key="S.Realtime.ExpandGuidance">展開模式說明</sys:String>
+
+    <!-- Session failures -->
+    <sys:String x:Key="S.Realtime.SessionAborted">即時翻譯已中止：{0}</sys:String>
+    <sys:String x:Key="S.Realtime.MissingApiKey">缺少 API Key，請先在設定中輸入。</sys:String>
+    <sys:String x:Key="S.Realtime.RetryingAfterFailure">翻譯暫時失敗，將持續重試：{0}</sys:String>
+
+    <!-- ── Translation providers ──
+         Names as well as hints: "Google 翻譯" is the product's Chinese name, not a label we
+         invented, and it reads wrong on an English interface. -->
+    <sys:String x:Key="S.Provider.Google">Google 翻譯 (Web)</sys:String>
+    <sys:String x:Key="S.Provider.GoogleHint">傳統 Web 介面</sys:String>
+    <sys:String x:Key="S.Provider.Google2">Google 翻譯 (RPC)</sys:String>
+    <sys:String x:Key="S.Provider.Google2Hint">新版 RPC 介面</sys:String>
+    <sys:String x:Key="S.Provider.Bing">Bing 翻譯</sys:String>
+    <sys:String x:Key="S.Provider.Microsoft">Microsoft 翻譯</sys:String>
+    <sys:String x:Key="S.Provider.DeepL">DeepL 翻譯</sys:String>
+    <sys:String x:Key="S.Provider.DeepLHint">需至 DeepL 官方註冊並取得 API Key</sys:String>
+    <sys:String x:Key="S.Provider.OpenAI">OpenAI</sys:String>
+    <sys:String x:Key="S.Provider.OpenAIHint">支援 OpenAI API 格式，建議使用本地 LLM，可透過 Ollama 快速安裝與使用。</sys:String>
+
+    <!-- ── Settings page ── -->
+    <sys:String x:Key="S.Settings.Title">設定</sys:String>
+    <sys:String x:Key="S.Settings.Subtitle">管理快捷鍵、翻譯服務、截圖與外觀</sys:String>
+
+    <sys:String x:Key="S.Settings.General">一般設定</sys:String>
+    <sys:String x:Key="S.Settings.CaptureHotkey">截圖翻譯</sys:String>
+    <sys:String x:Key="S.Settings.CaptureHotkeyHint">按下快捷鍵即可使用截圖翻譯功能</sys:String>
+    <sys:String x:Key="S.Settings.WindowHotkey">開啟翻譯視窗</sys:String>
+    <sys:String x:Key="S.Settings.WindowHotkeyHint">即時翻譯進行中時，改為將浮動視窗移至最上層</sys:String>
+    <sys:String x:Key="S.Settings.SourceLanguage">來源語言</sys:String>
+    <sys:String x:Key="S.Settings.AutoTranslate">自動翻譯</sys:String>
+    <sys:String x:Key="S.Settings.AutoTranslateCheck">框選完成後自動翻譯</sys:String>
+    <sys:String x:Key="S.Settings.Startup">開機啟動</sys:String>
+    <sys:String x:Key="S.Settings.StartupCheck">開機時自動啟動</sys:String>
+
+    <sys:String x:Key="S.Settings.TranslationApi">翻譯 API</sys:String>
+    <sys:String x:Key="S.Settings.Provider">翻譯服務</sys:String>
+    <sys:String x:Key="S.Settings.ApiBaseUrl">API 位址</sys:String>
+    <sys:String x:Key="S.Settings.ModelName">模型名稱</sys:String>
+    <sys:String x:Key="S.Settings.OllamaGuide">本地 LLM (Ollama) 安裝教學</sys:String>
+
+    <sys:String x:Key="S.Settings.Screenshot">截圖</sys:String>
+    <sys:String x:Key="S.Settings.SaveScreenshot">儲存截圖</sys:String>
+    <sys:String x:Key="S.Settings.SaveScreenshotCheck">截圖時自動儲存</sys:String>
+    <sys:String x:Key="S.Settings.SavePath">儲存位置</sys:String>
+    <sys:String x:Key="S.Settings.SavePathTip">點擊以選擇儲存資料夾</sys:String>
+    <sys:String x:Key="S.Settings.OpenFolderTip">開啟資料夾</sys:String>
+
+    <sys:String x:Key="S.Settings.Appearance">外觀</sys:String>
+    <sys:String x:Key="S.Settings.Theme">主題</sys:String>
+    <sys:String x:Key="S.Settings.ThemeLight">淺色</sys:String>
+    <sys:String x:Key="S.Settings.ThemeDark">深色</sys:String>
+    <!-- Card heading, then the row label inside it -->
+    <sys:String x:Key="S.Settings.UiLanguage">介面語言</sys:String>
+    <sys:String x:Key="S.Settings.UiLanguageLabel">語言</sys:String>
+
+    <sys:String x:Key="S.Settings.Advanced">進階設定</sys:String>
+    <sys:String x:Key="S.Settings.Logging">應用紀錄</sys:String>
+    <sys:String x:Key="S.Settings.LoggingCheck">記錄詳細資訊</sys:String>
+    <sys:String x:Key="S.Settings.LoggingHint">啟用後會記錄更多應用紀錄資訊，協助排查問題。</sys:String>
+
+    <sys:String x:Key="S.Settings.AutoSaveHint">設定變更後會自動儲存</sys:String>
+
+    <!-- Settings page, composed in code-behind -->
+    <sys:String x:Key="S.Settings.Saved">✓ 已儲存</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyPrompt">請按下快捷鍵...</sys:String>
+    <sys:String x:Key="S.Settings.FolderPickerTitle">選擇截圖儲存資料夾</sys:String>
+    <sys:String x:Key="S.Settings.LoggingEnvOverride">目前記錄等級由環境變數 OVERTRANSLATE_LOGLEVEL 指定，此選項暫時無效。</sys:String>
+    <sys:String x:Key="S.Settings.StartupFailed">✗ 無法設定開機啟動：{0}</sys:String>
+    <sys:String x:Key="S.Settings.OpenFolderFailed">✗ 無法開啟資料夾：{0}</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} 已指派給「{1}」</sys:String>
+
+</ResourceDictionary>

--- a/src/OverTranslate/Services/LocalizationService.cs
+++ b/src/OverTranslate/Services/LocalizationService.cs
@@ -1,0 +1,157 @@
+using System.Globalization;
+using System.Windows;
+// UseWindowsForms puts System.Windows.Forms in the implicit usings, so this name collides
+using Application = System.Windows.Application;
+
+namespace OverTranslate.Services;
+
+/// <param name="Display">
+/// The language's name written in itself, and the one string in the app that is never translated.
+/// </param>
+/// <remarks>
+/// Deliberately not a resource key. Someone who has landed in a language they cannot read has to be
+/// able to find their way back out, and "繁體中文" is legible from an English interface in a way
+/// that "Traditional Chinese" is not from a Chinese one.
+/// </remarks>
+public record UiLanguageOption(string Code, string Display);
+
+/// <summary>
+/// The UI language, swapped exactly the way <see cref="ThemeService"/> swaps colours.
+/// </summary>
+/// <remarks>
+/// Strings live in a merged <see cref="ResourceDictionary"/> and are consumed through
+/// DynamicResource, so replacing the dictionary re-resolves every binding in place. That matters
+/// here more than it would elsewhere: this app keeps several windows alive at once (the overlay,
+/// the capture toolbar, the realtime blocks, the tray menu), and asking the user to restart to
+/// change a language would leave all of them stale until they did.
+///
+/// Code-behind reads the same dictionary through <see cref="Get"/> / <see cref="Format"/>. Those
+/// return a snapshot rather than a binding, so a string handed to a control that way is only
+/// correct until the next swap — see <see cref="LanguageChanged"/> for how pages refresh it.
+/// </remarks>
+public static class LocalizationService
+{
+    public const string TraditionalChinese = "zh-Hant";
+    public const string English             = "en";
+
+    private static readonly Uri ZhHantUri = new("Resources/Strings.zh-Hant.xaml", UriKind.Relative);
+    private static readonly Uri EnglishUri = new("Resources/Strings.en.xaml",      UriKind.Relative);
+
+    /// <summary>The languages offered in settings, in the order they are listed.</summary>
+    public static readonly List<UiLanguageOption> Options =
+    [
+        new(TraditionalChinese, "繁體中文"),
+        new(English,            "English"),
+    ];
+
+    /// <summary>
+    /// Raised after the dictionary swap, for text that DynamicResource cannot reach.
+    /// </summary>
+    /// <remarks>
+    /// DynamicResource covers everything declared in XAML. It cannot cover a string that was
+    /// composed in code — a hint chosen by which provider is selected, a caption with a percentage
+    /// in it — because that string was already materialised. Pages holding such text subscribe and
+    /// recompose it.
+    /// </remarks>
+    public static event EventHandler? LanguageChanged;
+
+    /// <summary>
+    /// The language in effect: the stored choice, or the OS default when none was made.
+    /// </summary>
+    public static string Current
+    {
+        get
+        {
+            var stored = SettingsService.Instance.Current.UiLanguage;
+            return string.IsNullOrEmpty(stored) ? ResolveSystemDefault() : stored;
+        }
+    }
+
+    /// <summary>
+    /// The language to start a first-run profile in, from the OS UI language.
+    /// </summary>
+    /// <remarks>
+    /// Chinese of any flavour gets Traditional — this app has no Simplified UI, and Traditional is
+    /// far closer for a Simplified reader than English is. Everything else gets English.
+    /// </remarks>
+    public static string ResolveSystemDefault()
+    {
+        var name = CultureInfo.InstalledUICulture.TwoLetterISOLanguageName;
+        return name.Equals("zh", StringComparison.OrdinalIgnoreCase)
+            ? TraditionalChinese
+            : English;
+    }
+
+    public static void Apply(string language)
+    {
+        var dicts = Application.Current.Resources.MergedDictionaries;
+
+        var old = dicts.FirstOrDefault(d =>
+            d.Source?.OriginalString.Contains("Strings.", StringComparison.OrdinalIgnoreCase) == true);
+        if (old != null) dicts.Remove(old);
+
+        dicts.Add(new ResourceDictionary
+        {
+            Source = language == English ? EnglishUri : ZhHantUri
+        });
+
+        LanguageChanged?.Invoke(null, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Strings for code that runs with no <see cref="Application"/>, loaded on first use.
+    /// </summary>
+    /// <remarks>
+    /// Always Traditional Chinese, which is the language these strings are authored in. Not the
+    /// current preference and deliberately not the OS language: this path is reached from unit
+    /// tests and from anything running before the UI exists, and a fallback that changed with the
+    /// machine's locale would make those results depend on where they ran.
+    /// </remarks>
+    private static ResourceDictionary? _fallback;
+
+    private static ResourceDictionary? Fallback
+    {
+        get
+        {
+            if (_fallback is not null) return _fallback;
+
+            try
+            {
+                // Touching the helper registers the pack scheme, which Application would otherwise
+                // have done on startup — without it the Uri below cannot be resolved.
+                _ = System.IO.Packaging.PackUriHelper.UriSchemePack;
+                _fallback = new ResourceDictionary
+                {
+                    Source = new Uri(
+                        "pack://application:,,,/OverTranslate;component/Resources/Strings.zh-Hant.xaml",
+                        UriKind.Absolute)
+                };
+            }
+            catch
+            {
+                // Nothing to be done about it here, and Get still has the key to fall back on.
+            }
+
+            return _fallback;
+        }
+    }
+
+    /// <summary>
+    /// The string for <paramref name="key"/>, or the key itself when it is missing.
+    /// </summary>
+    /// <remarks>
+    /// Returning the key rather than throwing keeps a typo from taking down a window that was
+    /// otherwise fine, and makes the mistake obvious on screen. StringsParityTests is what actually
+    /// catches these, before they ship.
+    /// </remarks>
+    public static string Get(string key)
+    {
+        if (Application.Current?.TryFindResource(key) is string fromApp) return fromApp;
+        if (Fallback?[key] is string fromFallback) return fromFallback;
+        return key;
+    }
+
+    /// <inheritdoc cref="Get"/>
+    public static string Format(string key, params object?[] args) =>
+        string.Format(CultureInfo.CurrentCulture, Get(key), args);
+}

--- a/src/OverTranslate/Services/LocalizationService.cs
+++ b/src/OverTranslate/Services/LocalizationService.cs
@@ -154,4 +154,22 @@ public static class LocalizationService
     /// <inheritdoc cref="Get"/>
     public static string Format(string key, params object?[] args) =>
         string.Format(CultureInfo.CurrentCulture, Get(key), args);
+
+    /// <summary>
+    /// Points a picker at a list whose item labels come from the string dictionary.
+    /// </summary>
+    /// <remarks>
+    /// The clear is the whole point. These lists are static, so re-assigning one is a no-op to
+    /// WPF — it compares the reference, sees the same list, and keeps the item containers it
+    /// already generated along with the text those were built from. The label properties resolve
+    /// per read, so regenerating the containers is all that is needed; nothing short of it works.
+    ///
+    /// Callers set SelectedValue afterwards: clearing ItemsSource drops the selection with it.
+    /// </remarks>
+    public static void BindLocalizedItems(
+        System.Windows.Controls.ItemsControl picker, System.Collections.IEnumerable items)
+    {
+        picker.ItemsSource = null;
+        picker.ItemsSource = items;
+    }
 }

--- a/src/OverTranslate/Services/LocalizationService.cs
+++ b/src/OverTranslate/Services/LocalizationService.cs
@@ -68,15 +68,21 @@ public static class LocalizationService
     }
 
     /// <summary>
-    /// The language to start a first-run profile in, from the OS UI language.
+    /// The language to start a first-run profile in, from the display language Windows is set to.
     /// </summary>
     /// <remarks>
     /// Chinese of any flavour gets Traditional — this app has no Simplified UI, and Traditional is
     /// far closer for a Simplified reader than English is. Everything else gets English.
+    ///
+    /// CurrentUICulture, not InstalledUICulture: the latter is the language Windows was installed
+    /// in and does not move when the user changes their display language afterwards, so someone
+    /// running a Chinese-installed Windows in English would have been handed a Chinese interface
+    /// despite having said otherwise. This only decides the starting point — an explicit choice on
+    /// the settings page is stored and consulted first from then on.
     /// </remarks>
     public static string ResolveSystemDefault()
     {
-        var name = CultureInfo.InstalledUICulture.TwoLetterISOLanguageName;
+        var name = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
         return name.Equals("zh", StringComparison.OrdinalIgnoreCase)
             ? TraditionalChinese
             : English;

--- a/src/OverTranslate/Services/Ocr/OcrLanguageRouter.cs
+++ b/src/OverTranslate/Services/Ocr/OcrLanguageRouter.cs
@@ -13,5 +13,5 @@ internal static class OcrLanguageRouter
         Normalize(code) is "AUTO" or "EN" or "ZH" or "ZH-HANT" or "JA" or "KO";
 
     public static string GetUnsupportedLanguageMessage(string code) =>
-        $"目前 OCR 僅支援 AUTO、EN、ZH、ZH-HANT、JA、KO；「{Normalize(code)}」尚未支援。";
+        LocalizationService.Format("S.Error.OcrUnsupportedLanguage", Normalize(code));
 }

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -296,7 +296,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             while (_inUse > 0)
             {
                 if (!Monitor.Wait(_sync, ModelSwapDrainTimeout))
-                    throw new InvalidOperationException("等待其他辨識結束以切換 OCR 模型時逾時。");
+                    throw new InvalidOperationException(LocalizationService.Get("S.Error.OcrSwapTimeout"));
 
                 ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -989,7 +989,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             if (destination == IntPtr.Zero)
             {
                 skBitmap.Dispose();
-                throw new InvalidOperationException("無法將影像轉換為 ONNX OCR 可讀格式。");
+                throw new InvalidOperationException(LocalizationService.Get("S.Error.OcrImageConvert"));
             }
 
             // Row by row rather than one block: GDI+ and Skia pad their rows independently, so the
@@ -1013,7 +1013,8 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     private static void EnsureModelFile(string path)
     {
         if (!File.Exists(path))
-            throw new FileNotFoundException($"找不到 OCR 模型檔案：{path}", path);
+            throw new FileNotFoundException(
+                LocalizationService.Format("S.Error.OcrModelMissing", path), path);
     }
 
     public void Dispose()

--- a/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
+++ b/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
@@ -54,7 +54,7 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
         var model = options.Model.Trim();
         var configuredApiKey = options.ApiKey.Trim();
         if (model.Length == 0)
-            throw new InvalidOperationException("尚未設定 OpenAI Compatible 的模型名稱。");
+            throw new InvalidOperationException(LocalizationService.Get("S.Error.OpenAiNoModel"));
 
         var translations = new string[blocks.Count];
         await Parallel.ForEachAsync(
@@ -125,7 +125,8 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
         if (!response.IsSuccessStatusCode)
             throw new HttpRequestException(
-                $"OpenAI Compatible API 回傳 {(int)response.StatusCode}：{ReadError(json)}",
+                LocalizationService.Format(
+                    "S.Error.OpenAiHttp", (int)response.StatusCode, ReadError(json)),
                 null,
                 response.StatusCode);
 
@@ -141,12 +142,12 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
         catch (Exception ex) when (
             ex is JsonException or KeyNotFoundException or IndexOutOfRangeException or InvalidOperationException)
         {
-            throw new InvalidOperationException("OpenAI Compatible API 回應格式無法解析。", ex);
+            throw new InvalidOperationException(LocalizationService.Get("S.Error.OpenAiUnparsable"), ex);
         }
 
         var translated = StripThinking(content);
         if (translated.Length == 0)
-            throw new InvalidOperationException("OpenAI Compatible API 未回傳譯文。");
+            throw new InvalidOperationException(LocalizationService.Get("S.Error.OpenAiNoTranslation"));
         return translated;
     }
 
@@ -154,7 +155,7 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     {
         if (!Uri.TryCreate(baseUrl.Trim(), UriKind.Absolute, out var uri) ||
             (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-            throw new InvalidOperationException("OpenAI Compatible API 位址必須是有效的 HTTP 或 HTTPS 網址。");
+            throw new InvalidOperationException(LocalizationService.Get("S.Error.OpenAiBadUrl"));
 
         var builder = new UriBuilder(uri);
         var path = builder.Path.TrimEnd('/');
@@ -239,7 +240,7 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
             using var document = JsonDocument.Parse(json);
             if (document.RootElement.TryGetProperty("error", out var error) &&
                 error.TryGetProperty("message", out var message))
-                return message.GetString() ?? "未知錯誤";
+                return message.GetString() ?? LocalizationService.Get("S.Error.UnknownError");
         }
         catch (JsonException)
         {
@@ -247,7 +248,7 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
         }
 
         var compact = json.Trim();
-        if (compact.Length == 0) return "未提供錯誤內容";
+        if (compact.Length == 0) return LocalizationService.Get("S.Error.NoErrorContent");
         return compact.Length <= 300 ? compact : compact[..300] + "…";
     }
 }

--- a/src/OverTranslate/Services/Providers/ResilientProvider.cs
+++ b/src/OverTranslate/Services/Providers/ResilientProvider.cs
@@ -47,7 +47,7 @@ public class ResilientProvider : ITranslationProvider
         "GoogleTranslator2"   => "Google (RPC)",
         "BingTranslator"      => "Bing",
         "MicrosoftTranslator" => "Microsoft",
-        "(none)"              => "未翻譯",
+        "(none)"              => LocalizationService.Get("S.Error.NotTranslated"),
         _                     => engineName,
     };
 

--- a/src/OverTranslate/Services/Realtime/RealtimePauseHint.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimePauseHint.cs
@@ -25,7 +25,7 @@ public static class RealtimePauseHint
     /// </param>
     public static string ForControlTooltip(string? hotkey, bool paused)
     {
-        var action = paused ? "繼續即時翻譯" : "暫停即時翻譯";
+        var action = LocalizationService.Get(paused ? "S.Realtime.Resume" : "S.Realtime.Pause");
 
         return Normalize(hotkey) is { Length: > 0 } key ? $"{action} ({key})" : action;
     }
@@ -37,7 +37,7 @@ public static class RealtimePauseHint
     /// </summary>
     public static string ForSettingsPage(string? hotkey) =>
         Normalize(hotkey) is { Length: > 0 } key
-            ? $"4. 翻譯中按 {key} 可暫停／繼續，暫停時會清除譯文並釋放辨識模型。"
+            ? LocalizationService.Format("S.Realtime.Step4", key)
             : "";
 
     private static string Normalize(string? hotkey) => hotkey?.Trim() ?? "";

--- a/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
@@ -355,7 +355,7 @@ public sealed class RealtimeTranslationSession
         catch (Exception ex)
         {
             Log.Error(ex, "Realtime region {Region} ended unexpectedly", region.Id);
-            Failed?.Invoke(this, $"即時翻譯已中止：{ex.Message}");
+            Failed?.Invoke(this, LocalizationService.Format("S.Realtime.SessionAborted", ex.Message));
         }
     }
 
@@ -708,7 +708,7 @@ public sealed class RealtimeTranslationSession
         {
             var apiKey = SettingsService.Instance.Current.ApiKey;
             if (_translation.ProviderRequiresApiKey(_provider) && string.IsNullOrWhiteSpace(apiKey))
-                throw new InvalidOperationException("缺少 API Key，請先在設定中輸入。");
+                throw new InvalidOperationException(LocalizationService.Get("S.Realtime.MissingApiKey"));
 
             var (results, _) = await _translation.TranslateAsync(
                 missing, sourceLanguage, targetLanguage, apiKey, cancellationToken: token, engine: _provider);
@@ -775,7 +775,7 @@ public sealed class RealtimeTranslationSession
     {
         InvalidOperationException => ex.Message,
         NotSupportedException => ex.Message,
-        _ => $"翻譯暫時失敗，將持續重試：{ex.Message}"
+        _ => LocalizationService.Format("S.Realtime.RetryingAfterFailure", ex.Message)
     };
 
     /// <summary>

--- a/src/OverTranslate/Views/Capture/ScreenCaptureWindow.xaml
+++ b/src/OverTranslate/Views/Capture/ScreenCaptureWindow.xaml
@@ -129,7 +129,7 @@
                             <Button Content="✕"
                                     Style="{StaticResource IconButton}"
                                     VerticalAlignment="Center"
-                                    ToolTip="取消截圖"
+                                    ToolTip="{DynamicResource S.Capture.CancelTip}"
                                     Click="CancelCaptureBtn_Click"/>
 
                             <Rectangle Width="1" Height="34"
@@ -144,14 +144,14 @@
                                            FontFamily="{StaticResource AppFont}"
                                            FontSize="14"
                                            FontWeight="SemiBold"
-                                           Text="拖曳選取翻譯區域"/>
+                                           Text="{DynamicResource S.Capture.DragPrompt}"/>
 
                                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                                     <TextBlock Foreground="{DynamicResource AppTextSecondary}"
                                                FontFamily="{StaticResource AppFont}"
                                                FontSize="12"
                                                VerticalAlignment="Center"
-                                               Text="按"/>
+                                               Text="{DynamicResource S.Capture.PressPrefix}"/>
 
                                     <!-- Drawn as a keycap so the shortcut reads as a physical key
                                          rather than as prose. -->
@@ -173,7 +173,7 @@
                                                FontFamily="{StaticResource AppFont}"
                                                FontSize="12"
                                                VerticalAlignment="Center"
-                                               Text="取消"/>
+                                               Text="{DynamicResource S.Capture.CancelSuffix}"/>
                                 </StackPanel>
                             </StackPanel>
                         </StackPanel>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
@@ -76,14 +76,14 @@
 
                 <!-- Translate -->
                 <Button x:Name="TranslateBtn"
-                        Content="翻譯"
+                        Content="{DynamicResource S.Toolbar.Translate}"
                         Style="{StaticResource ToolbarAccentButton}"
                         Margin="0,0,4,0"
                         Click="TranslateBtn_Click"/>
 
                 <!-- Toggle original / translated bubbles -->
                 <Button x:Name="ToggleBtn"
-                        Content="顯示原文"
+                        Content="{DynamicResource S.Toolbar.ShowSource}"
                         Style="{StaticResource ToolbarFlatButton}"
                         IsEnabled="False"
                         Margin="0,0,4,0"
@@ -91,14 +91,14 @@
 
                 <!-- Copy current selection screenshot to clipboard (subtle accent: tonal, not primary) -->
                 <Button x:Name="CopyShotBtn"
-                        Content="截圖"
+                        Content="{DynamicResource S.Toolbar.Screenshot}"
                         Style="{StaticResource ToolbarSubtleAccentButton}"
                         Margin="0,0,4,0"
                         Click="CopyShotBtn_Click"/>
 
                 <!-- Open translation window -->
                 <Button x:Name="OpenWindowBtn"
-                        Content="開啟翻譯視窗"
+                        Content="{DynamicResource S.Toolbar.OpenWindow}"
                         Style="{StaticResource ToolbarFlatButton}"
                         Margin="0,0,4,0"
                         Click="OpenWindowBtn_Click"/>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
@@ -168,7 +168,9 @@ public partial class ToolbarWindow : Window
         _isBusy = busy;
         if (busy) HideEngineBadge(); // stale badge shouldn't linger while the next batch runs
         TranslateBtn.IsEnabled = !busy;
-        TranslateBtn.Content   = busy ? "翻譯中..." : (_hasTranslated ? "重新翻譯" : "翻譯");
+        TranslateBtn.Content = LocalizationService.Get(
+            busy ? "S.Toolbar.Translating"
+                 : _hasTranslated ? "S.Toolbar.Retranslate" : "S.Toolbar.Translate");
         ToggleBtn.IsEnabled = !_isBusy && _toggleEnabled;
         OpenWindowBtn.IsEnabled = !_isBusy;
     }
@@ -177,7 +179,8 @@ public partial class ToolbarWindow : Window
     {
         _hasTranslated = hasTranslated;
         if (!_isBusy)
-            TranslateBtn.Content = hasTranslated ? "重新翻譯" : "翻譯";
+            TranslateBtn.Content = LocalizationService.Get(
+                hasTranslated ? "S.Toolbar.Retranslate" : "S.Toolbar.Translate");
     }
 
     /// <summary>
@@ -193,8 +196,9 @@ public partial class ToolbarWindow : Window
             return;
         }
 
-        EngineBadgeText.Text  = $"⚡備援 {usage.BackupEngine}";
-        EngineBadge.ToolTip = $"「{usage.Primary}」未能完整翻譯，已由備援「{usage.BackupEngine}」進行部分翻譯。\n本次實際翻譯：{ usage.Summary}";
+        EngineBadgeText.Text = LocalizationService.Format("S.Toolbar.BackupBadge", usage.BackupEngine);
+        EngineBadge.ToolTip = LocalizationService.Format(
+            "S.Toolbar.BackupTooltip", usage.Primary, usage.BackupEngine, usage.Summary);
         EngineBadge.Visibility = Visibility.Visible;
     }
 
@@ -208,7 +212,7 @@ public partial class ToolbarWindow : Window
     {
         _toggleEnabled   = enabled;
         _bubblesVisible  = true;
-        ToggleBtn.Content   = "顯示原文";
+        ToggleBtn.Content = LocalizationService.Get("S.Toolbar.ShowSource");
         ToggleBtn.IsEnabled = !_isBusy && _toggleEnabled;
         BubblesVisibilityChanged?.Invoke(this, _bubblesVisible);
     }
@@ -216,7 +220,8 @@ public partial class ToolbarWindow : Window
     private void ToggleBtn_Click(object sender, RoutedEventArgs e)
     {
         _bubblesVisible   = !_bubblesVisible;
-        ToggleBtn.Content = _bubblesVisible ? "顯示原文" : "顯示譯文";
+        ToggleBtn.Content = LocalizationService.Get(
+            _bubblesVisible ? "S.Toolbar.ShowSource" : "S.Toolbar.ShowTranslation");
         BubblesVisibilityChanged?.Invoke(this, _bubblesVisible);
     }
 

--- a/src/OverTranslate/Views/Controls/SecretBox.xaml
+++ b/src/OverTranslate/Views/Controls/SecretBox.xaml
@@ -82,7 +82,7 @@
 
             <Button x:Name="RevealToggle" Grid.Column="1"
                     Style="{StaticResource RevealButton}"
-                    ToolTip="顯示內容"
+                    ToolTip="{DynamicResource S.Secret.Show}"
                     Click="RevealToggle_Click">
                 <TextBlock x:Name="RevealIcon"
                            FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"

--- a/src/OverTranslate/Views/Controls/SecretBox.xaml.cs
+++ b/src/OverTranslate/Views/Controls/SecretBox.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using OverTranslate.Services;
 // UseWindowsForms puts System.Windows.Forms in the implicit usings, so this name collides
 using UserControl = System.Windows.Controls.UserControl;
 
@@ -68,7 +69,8 @@ public partial class SecretBox : UserControl
 
         // Segoe Fluent Icons: Hide (crossed-out eye) while revealed, RedEye while masked.
         RevealIcon.Text = _revealed ? "" : "";
-        RevealToggle.ToolTip = _revealed ? "隱藏內容" : "顯示內容";
+        RevealToggle.ToolTip = LocalizationService.Get(
+            _revealed ? "S.Secret.Hide" : "S.Secret.Show");
 
         // Keep the caret where the user was typing instead of dropping focus on the button.
         if (_revealed)

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -96,11 +96,13 @@ public partial class MainWindow : Window
     private void ShowStartupBalloon()
     {
         var hotkeyDisplay = SettingsService.Instance.Current.HotkeyDisplay;
-        var shortcutText = string.IsNullOrWhiteSpace(hotkeyDisplay) ? "已設定的快捷鍵" : hotkeyDisplay;
+        var shortcutText = string.IsNullOrWhiteSpace(hotkeyDisplay)
+            ? LocalizationService.Get("S.Main.DefaultShortcutName")
+            : hotkeyDisplay;
 
         ShowTrayNotification(
-            "OverTranslate 已最小化",
-            $"程式已縮小至系統匣，可使用 {shortcutText} 開始進行截圖翻譯。");
+            LocalizationService.Get("S.Main.MinimizedTitle"),
+            LocalizationService.Format("S.Main.MinimizedBody", shortcutText));
     }
 
     /// <summary>
@@ -215,7 +217,9 @@ public partial class MainWindow : Window
     {
         if (!Views.Realtime.RealtimeSessionController.Instance.IsActive) return false;
 
-        ShowTrayNotification("即時翻譯進行中", "請先結束即時翻譯，再使用截圖翻譯。");
+        ShowTrayNotification(
+            LocalizationService.Get("S.Main.RealtimeRunningTitle"),
+            LocalizationService.Get("S.Main.RealtimeRunningBody"));
         return true;
     }
 
@@ -476,7 +480,9 @@ public partial class MainWindow : Window
 
         if (AppServices.Translation.RequiresApiKey && string.IsNullOrWhiteSpace(settings.ApiKey))
         {
-            ShowBalloon("缺少 API Key", "請在設定中輸入 API Key。", selRect);
+            ShowBalloon(
+                LocalizationService.Get("S.Main.MissingApiKeyTitle"),
+                LocalizationService.Get("S.Main.MissingApiKeyBody"), selRect);
             return;
         }
 
@@ -486,7 +492,9 @@ public partial class MainWindow : Window
         {
             if (requestCaptureWindow == null || !requestCaptureWindow.PrepareForTranslation())
             {
-                ShowBalloon("辨識失敗", "找不到框選影像，請重新框選。", selRect);
+                ShowBalloon(
+                    LocalizationService.Get("S.Main.RecogniseFailedTitle"),
+                    LocalizationService.Get("S.Main.NoImageBody"), selRect);
                 return;
             }
 
@@ -509,7 +517,7 @@ public partial class MainWindow : Window
                 _lastSelPhysTop,
                 _lastSelPhysWidth,
                 _lastSelPhysHeight,
-                "辨識中");
+                LocalizationService.Get("S.Main.Recognising"));
 
             var recognizedBlocks = await AppServices.Ocr.RecognizeAsync(workBitmap, req.SourceLang, cancellationToken);
             if (!IsCurrentSelectionSession(requestSessionId, requestToolbar, requestCaptureWindow))
@@ -519,7 +527,9 @@ public partial class MainWindow : Window
             if (_lastOcrBlocks.Count == 0)
             {
                 requestToolbar?.SetTranslationState(false);
-                ShowBalloon("未偵測到文字", "所選區域中未找到可辨識的文字。", selRect, ToastKind.Info);
+                ShowBalloon(
+                    LocalizationService.Get("S.Main.NoTextTitle"),
+                    LocalizationService.Get("S.Main.NoTextBody"), selRect, ToastKind.Info);
                 return;
             }
 
@@ -528,7 +538,7 @@ public partial class MainWindow : Window
                 _lastSelPhysTop,
                 _lastSelPhysWidth,
                 _lastSelPhysHeight,
-                "翻譯中");
+                LocalizationService.Get("S.Main.Translating"));
 
             var (translated, _) = await AppServices.Translation.TranslateAsync(
                 _lastOcrBlocks, req.SourceLang, req.TargetLang, settings.ApiKey,
@@ -595,7 +605,9 @@ public partial class MainWindow : Window
                 return;
 
             requestToolbar?.SetTranslationState(false);
-            ShowBalloon("未偵測到文字", "所選區域中未找到可辨識的文字。", selRect, ToastKind.Info);
+            ShowBalloon(
+                LocalizationService.Get("S.Main.NoTextTitle"),
+                LocalizationService.Get("S.Main.NoTextBody"), selRect, ToastKind.Info);
         }
         catch (Exception ex)
         {
@@ -608,7 +620,9 @@ public partial class MainWindow : Window
             _overlayWindow?.UpdateBlocks(_lastColoredBlocks, _lastSelPhysLeft, _lastSelPhysTop, _lastSelPhysWidth, _lastSelPhysHeight, req.SourceLang, req.TargetLang);
             requestToolbar?.SetTranslationState(_lastColoredBlocks.Count > 0);
             requestToolbar?.SetToggleEnabled(_lastColoredBlocks.Count > 0);
-            ShowBalloon("翻譯失敗", $"目前使用的翻譯來源可能暫時無法使用。\n請切換其他翻譯來源後再試一次。\n詳細資訊：{ex.Message}", selRect);
+            ShowBalloon(
+                LocalizationService.Get("S.Main.TranslateFailedTitle"),
+                LocalizationService.Format("S.Main.TranslateFailedBody", ex.Message), selRect);
         }
         finally
         {
@@ -639,7 +653,9 @@ public partial class MainWindow : Window
             var background = _captureWindow?.CreateSelectionImage();
             if (background is null)
             {
-                ShowBalloon("複製失敗", "找不到框選影像，請重新框選。", selRect);
+                ShowBalloon(
+                    LocalizationService.Get("S.Main.CopyFailedTitle"),
+                    LocalizationService.Get("S.Main.NoImageBody"), selRect);
                 return;
             }
 
@@ -671,7 +687,9 @@ public partial class MainWindow : Window
             var settings = SettingsService.Instance.Current;
             if (!settings.SaveScreenshotToDisk)
             {
-                ShowBalloon("已複製", "已將框選截圖複製到剪貼簿。", selRect, ToastKind.Success);
+                ShowBalloon(
+                    LocalizationService.Get("S.Main.CopiedTitle"),
+                    LocalizationService.Get("S.Main.CopiedBody"), selRect, ToastKind.Success);
                 return;
             }
 
@@ -679,18 +697,24 @@ public partial class MainWindow : Window
             try
             {
                 var savedPath = ScreenshotSaveService.Save(result, settings.ScreenshotSavePath);
-                ShowBalloon("已複製", $"已複製到剪貼簿，並儲存至：\n{savedPath}", selRect, ToastKind.Success);
+                ShowBalloon(
+                    LocalizationService.Get("S.Main.CopiedTitle"),
+                    LocalizationService.Format("S.Main.CopiedAndSavedBody", savedPath), selRect, ToastKind.Success);
             }
             catch (Exception ex)
             {
                 Log.Warn(ex, "Screenshot copied to clipboard but saving to disk failed");
-                ShowBalloon("已複製（儲存失敗）", $"已複製到剪貼簿，但無法儲存到本機：{ex.Message}", selRect);
+                ShowBalloon(
+                    LocalizationService.Get("S.Main.CopiedSaveFailedTitle"),
+                    LocalizationService.Format("S.Main.CopiedSaveFailedBody", ex.Message), selRect);
             }
         }
         catch (Exception ex)
         {
             Log.Error(ex, "Copy screenshot failed");
-            ShowBalloon("複製失敗", $"無法複製截圖：{ex.Message}", selRect);
+            ShowBalloon(
+                LocalizationService.Get("S.Main.CopyFailedTitle"),
+                LocalizationService.Format("S.Main.CopyFailedBody", ex.Message), selRect);
         }
     }
 

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml
@@ -54,7 +54,7 @@
                                FontSize="15"
                                FontWeight="SemiBold"
                                VerticalAlignment="Center"
-                               Text="辨識中"/>
+                               Text="{DynamicResource S.Overlay.Recognising}"/>
                 </StackPanel>
             </Border>
         </Canvas>

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
@@ -52,7 +52,7 @@
                                FontFamily="{StaticResource AppFont}"
                                FontSize="12.5"
                                Foreground="{DynamicResource AppTextPrimary}"
-                               Text="在螢幕上拖曳建立要翻譯的區塊"/>
+                               Text="{DynamicResource S.Realtime.EditHint}"/>
 
                     <!-- Trailing and a size down: a running count is a reference, not an instruction.
                          Subordinate by position and size rather than by a dimmer colour — it is the
@@ -67,14 +67,14 @@
                     <Separator Style="{StaticResource VerticalSeparator}"/>
 
                     <Button x:Name="StartBtn"
-                            Content="開始翻譯"
+                            Content="{DynamicResource S.Realtime.StartTranslating}"
                             Style="{StaticResource ToolbarAccentButton}"
                             Margin="0,0,4,0"
                             Click="StartBtn_Click"/>
 
                     <Button Content="✕"
                             Style="{StaticResource ToolbarIconButton}"
-                            ToolTip="結束即時翻譯"
+                            ToolTip="{DynamicResource S.Realtime.StopSession}"
                             Click="CloseBtn_Click"/>
                 </StackPanel>
 
@@ -99,7 +99,7 @@
                                FontFamily="{StaticResource AppFont}"
                                FontSize="12.5"
                                Foreground="{DynamicResource AppTextPrimary}"
-                               Text="即時翻譯中"/>
+                               Text="{DynamicResource S.Realtime.Running}"/>
 
                     <!-- Source and target are not two equal labels: the target is the thing on screen
                          from here on, so it keeps the primary colour and the source steps back one
@@ -159,7 +159,7 @@
                             FontSize="13"
                             Content="&#xE769;"
                             Margin="0,0,4,0"
-                            AutomationProperties.Name="暫停即時翻譯"
+                            AutomationProperties.Name="{DynamicResource S.Realtime.Pause}"
                             Click="PauseBtn_Click"/>
 
                     <!-- Icon rather than a word: the two buttons beside it are the session's own
@@ -171,18 +171,18 @@
                             FontSize="15"
                             Content="&#xE722;"
                             Margin="0,0,4,0"
-                            ToolTip="擷取畫面截圖"
-                            AutomationProperties.Name="擷取畫面截圖"
+                            ToolTip="{DynamicResource S.Realtime.CaptureScreenshot}"
+                            AutomationProperties.Name="{DynamicResource S.Realtime.CaptureScreenshot}"
                             Click="ShotBtn_Click"/>
 
-                    <Button Content="編輯"
+                    <Button Content="{DynamicResource S.Common.Edit}"
                             Style="{StaticResource ToolbarFlatButton}"
                             Margin="0,0,4,0"
                             Click="EditBtn_Click"/>
 
                     <Button Content="✕"
                             Style="{StaticResource ToolbarIconButton}"
-                            ToolTip="結束即時翻譯"
+                            ToolTip="{DynamicResource S.Realtime.StopSession}"
                             Click="CloseBtn_Click"/>
                 </StackPanel>
             </Grid>

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
@@ -130,8 +130,8 @@ public partial class RealtimeControlWindow : Window
     /// </remarks>
     public void SetLanguages(string sourceCode, string targetCode)
     {
-        SourceLangText.Text = Models.LanguageData.GetSourceName(sourceCode);
-        TargetLangText.Text = Models.LanguageData.GetTargetName(targetCode);
+        SourceLangText.Text = Models.LanguageData.GetSourceDisplayName(sourceCode);
+        TargetLangText.Text = Models.LanguageData.GetTargetDisplayName(targetCode);
         _hasLanguages = SourceLangText.Text.Length > 0 && TargetLangText.Text.Length > 0;
 
         if (!_messageTimer.IsEnabled) RestoreText();

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
@@ -46,14 +46,14 @@ public partial class RealtimeControlWindow : Window
     private readonly DispatcherTimer _messageTimer;
 
     private RealtimeControlMode _mode = RealtimeControlMode.Edit;
-    private readonly string _editHint = "在螢幕上拖曳建立要翻譯的區塊";
+    private static string EditHint => LocalizationService.Get("S.Realtime.EditHint");
     // What the capsule says before SetLanguages has named the pair. A transient message borrows the
     // same slot and RestoreText brings whichever of the two applies back.
-    private readonly string _runStatus = "即時翻譯中";
+    private static string RunStatus => LocalizationService.Get("S.Realtime.Running");
     // Not transient, unlike everything else that lands in that slot: a paused session looks exactly
     // like a session with nothing to translate — no words, no scrims, a still screen — so the one
     // thing that separates them has to stay on screen for as long as the state lasts.
-    private readonly string _pausedStatus = "已暫停";
+    private static string PausedStatus => LocalizationService.Get("S.Realtime.Paused");
     private bool _hasLanguages;
     private bool _isPaused;
 
@@ -271,8 +271,8 @@ public partial class RealtimeControlWindow : Window
 
     private void RestoreText()
     {
-        EditHintText.Text = _editHint;
-        RunStatusText.Text = _isPaused ? _pausedStatus : _runStatus;
+        EditHintText.Text = EditHint;
+        RunStatusText.Text = _isPaused ? PausedStatus : RunStatus;
 
         // The pair steps aside while paused: it describes work that is not happening, and it is the
         // one thing on this line long enough to hide the word that says so.
@@ -300,7 +300,7 @@ public partial class RealtimeControlWindow : Window
         PauseBtn.Content = _isPaused ? "\uE768" : "\uE769";
         PauseBtn.ToolTip = RealtimePauseHint.ForControlTooltip(RealtimePauseHint.CurrentHotkey, _isPaused);
         System.Windows.Automation.AutomationProperties.SetName(
-            PauseBtn, _isPaused ? "繼續即時翻譯" : "暫停即時翻譯");
+            PauseBtn, LocalizationService.Get(_isPaused ? "S.Realtime.Resume" : "S.Realtime.Pause"));
     }
 
     // ── Placement and dragging ───────────────────────────────────────────────────────────────────

--- a/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
@@ -545,7 +545,7 @@ public partial class RealtimeEditWindow : Window
                 Width = removeSize,
                 Height = removeSize,
                 Cursor = Cursors.Hand,
-                ToolTip = "移除此區塊",
+                ToolTip = LocalizationService.Get("S.Realtime.RemoveBlock"),
                 Template = BuildRemoveTemplate(removeSize, uiScale),
             };
 
@@ -703,15 +703,11 @@ public partial class RealtimeEditWindow : Window
         /// recogniser then does with it: the reasons live in <see cref="RealtimeDetectorSize"/> and
         /// <see cref="CollapsedDetection"/>, and neither is something to explain over a paused game.
         /// </summary>
-        private const string SubtitleHint =
-            "適合影音字幕、遊戲對話等文字集中且位置較固定的畫面。\n" +
-            "框選時，上下約留半個至一個字的空間，避免貼齊文字；" +
-            "左右可適度放寬，但不要框入過多空白範圍，避免雜訊。";
+        private static string SubtitleHint =>
+            LocalizationService.Get("S.Realtime.ModeSubtitleGuidance");
 
-        private const string PanelHint =
-            "適合文字分散於不同位置，或內容位置經常變動的遊戲畫面。\n" +
-            "框選時，需翻譯的區域請保留一些空間，避免貼齊內容；" +
-            "若畫面有多個區域則建議分開框選，避免辨識速度過慢。";
+        private static string PanelHint =>
+            LocalizationService.Get("S.Realtime.ModeGameUiGuidance");
 
         private readonly TranslateTransform _pillOffset = new();
         private readonly Border[] _segments;
@@ -774,7 +770,11 @@ public partial class RealtimeEditWindow : Window
                 RenderTransform = _pillOffset,
             };
 
-            _labels = [BuildLabel("字幕", uiScale), BuildLabel("遊戲介面", uiScale)];
+            _labels =
+            [
+                BuildLabel(LocalizationService.Get("S.Realtime.ModeSubtitle"), uiScale),
+                BuildLabel(LocalizationService.Get("S.Realtime.ModeGameUi"), uiScale),
+            ];
 
             // Rounded on the outer end only, so a press on either half stays inside the capsule.
             _highlights =
@@ -785,8 +785,10 @@ public partial class RealtimeEditWindow : Window
 
             _segments =
             [
-                BuildSegment(_labels[0], _highlights[0], segmentWidth, "整條字幕、對話框——文字大，讀取時會縮小"),
-                BuildSegment(_labels[1], _highlights[1], segmentWidth, "遊戲面板、物品說明——文字小，讀取時不縮小"),
+                BuildSegment(_labels[0], _highlights[0], segmentWidth,
+                    LocalizationService.Get("S.Realtime.ModeSubtitleSummary")),
+                BuildSegment(_labels[1], _highlights[1], segmentWidth,
+                    LocalizationService.Get("S.Realtime.ModeGameUiSummary")),
             ];
 
             var row = new StackPanel
@@ -999,7 +1001,8 @@ public partial class RealtimeEditWindow : Window
 
         private void UpdateGuidanceToggleLabel()
         {
-            var label = _guidanceExpanded ? "收合模式說明" : "展開模式說明";
+            var label = LocalizationService.Get(
+                _guidanceExpanded ? "S.Realtime.CollapseGuidance" : "S.Realtime.ExpandGuidance");
             _guidanceToggle.ToolTip = label;
             System.Windows.Automation.AutomationProperties.SetName(_guidanceToggle, label);
         }

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml
@@ -11,8 +11,8 @@
 
         <!-- ── Page header ── -->
         <StackPanel Grid.Row="0" Margin="0,0,0,18">
-            <TextBlock Text="即時翻譯" Style="{StaticResource PageTitle}"/>
-            <TextBlock Text="在畫面上選取翻譯區域，文字變更時會自動翻譯並顯示在畫面上，適用於影片或遊戲畫面等。"
+            <TextBlock Text="{DynamicResource S.Realtime.Title}" Style="{StaticResource PageTitle}"/>
+            <TextBlock Text="{DynamicResource S.Realtime.Subtitle}"
                        Style="{StaticResource PageSubtitle}"/>
         </StackPanel>
 
@@ -28,12 +28,12 @@
                      across. -->
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
-                        <TextBlock Text="翻譯設定" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.TranslationSettings}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- OCR source languages only: this page recognises text off the screen, so
                              a language the recogniser cannot read has nothing to offer here. Left
                              unset on purpose — see RealtimePage.ApplyPageDefaults. -->
-                        <TextBlock Text="來源語言" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.SourceLanguage}" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                         <!-- Placeholder rather than a line of help underneath: the field is empty
                              because the user has to answer it, and saying so inside the empty space
                              puts the instruction where they are already looking. Margin matches the
@@ -44,7 +44,7 @@
                                       Style="{StaticResource ModernComboBox}"
                                       SelectedValuePath="Code"/>
                             <TextBlock x:Name="SrcLangPlaceholder"
-                                       Text="請選擇來源語言"
+                                       Text="{DynamicResource S.Realtime.SourceLanguagePrompt}"
                                        FontFamily="{StaticResource AppFont}"
                                        FontSize="{StaticResource AppFontSize}"
                                        Foreground="{DynamicResource AppTextSecondary}"
@@ -53,7 +53,7 @@
                                        IsHitTestVisible="False"/>
                         </Grid>
 
-                        <TextBlock Text="目標語言" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.TargetLanguage}" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                         <ComboBox x:Name="TgtLangBox"
                                   Style="{StaticResource ModernComboBox}"
                                   SelectedValuePath="Code"
@@ -61,7 +61,7 @@
 
                         <!-- Grouped so the spacing below stays the same whether or not the chosen
                              service has anything to warn about -->
-                        <TextBlock Text="翻譯服務" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.Provider}" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                         <StackPanel>
                             <ComboBox x:Name="ProviderBox"
                                       Style="{StaticResource ModernComboBox}"
@@ -76,15 +76,15 @@
                 <!-- ── 區塊設定 ── -->
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
-                        <TextBlock Text="翻譯區塊" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.Blocks}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- One screen per session, chosen here rather than assumed: the primary
                              monitor is not where the game or the video necessarily is. -->
-                        <TextBlock Text="使用螢幕" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.Screen}" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                         <ComboBox x:Name="ScreenBox"
                                   Style="{StaticResource ModernComboBox}"
                                   SelectedValuePath="DeviceName"/>
-                        <TextBlock Text="即時翻譯目前只支援單一螢幕畫面。"
+                        <TextBlock Text="{DynamicResource S.Realtime.ScreenHint}"
                                    Style="{StaticResource FieldHint}"
                                    Margin="0,6,0,14" TextWrapping="Wrap" LineHeight="16"/>
 
@@ -92,13 +92,13 @@
                              box that accepts typing invites 0, 99 and empty, each of which then
                              needs its own rule. The number is display-only and the two buttons are
                              the only way in, so no input can be wrong. -->
-                        <TextBlock Text="區塊數量" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.BlockCount}" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                         <Border Style="{StaticResource StepperBorder}" HorizontalAlignment="Left">
                             <StackPanel Orientation="Horizontal">
                                 <Button x:Name="BlockCountDown"
                                         Style="{StaticResource StepperButton}"
                                         Content="&#xE949;"
-                                        AutomationProperties.Name="減少區塊數量"
+                                        AutomationProperties.Name="{DynamicResource S.Realtime.DecreaseBlocks}"
                                         Click="BlockCountDown_Click"/>
                                 <TextBlock x:Name="BlockCountText"
                                            Style="{StaticResource StepperValue}"
@@ -106,11 +106,11 @@
                                 <Button x:Name="BlockCountUp"
                                         Style="{StaticResource StepperButton}"
                                         Content="&#xE948;"
-                                        AutomationProperties.Name="增加區塊數量"
+                                        AutomationProperties.Name="{DynamicResource S.Realtime.IncreaseBlocks}"
                                         Click="BlockCountUp_Click"/>
                             </StackPanel>
                         </Border>
-                        <TextBlock Text="最多可同時建立 3 個翻譯區塊。"
+                        <TextBlock Text="{DynamicResource S.Realtime.BlockCountHint}"
                                    Style="{StaticResource FieldHint}"
                                    Margin="0,6,0,0" TextWrapping="Wrap" LineHeight="16"/>
                     </StackPanel>
@@ -126,7 +126,7 @@
                      they line up with their own control no matter how wide the hex text gets. -->
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
-                        <TextBlock Text="顯示外觀" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.Appearance}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- Preview first, above the two controls that feed it. A session hides the
                              shell window, so this is the last moment the user can see the two
@@ -134,7 +134,7 @@
                              without ending the session. Drawn on a mid-grey so a light scrim and a
                              dark one are both visibly translucent; the real backdrop is whatever
                              they are watching, which this cannot know. -->
-                        <TextBlock Text="預覽" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.Preview}" Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                         <!-- A fixed mid-grey in both themes, not a theme brush: the real backdrop is
                              whatever the user is watching, and a preview that turned white in the
                              light theme would make a white scrim look invisible and a black one look
@@ -151,7 +151,7 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center">
                                 <TextBlock x:Name="PreviewText"
-                                           Text="文字會像這樣顯示在畫面上"
+                                           Text="{DynamicResource S.Realtime.PreviewText}"
                                            FontFamily="Microsoft JhengHei, Segoe UI Variable Text, Segoe UI, Sans-Serif"
                                            FontSize="14"
                                            FontWeight="SemiBold"/>
@@ -169,7 +169,7 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="文字顏色"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Realtime.TextColor}"
                                        Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                             <Button Grid.Column="0" Grid.Row="1"
                                     x:Name="TextColorBtn"
@@ -191,7 +191,7 @@
                                 </StackPanel>
                             </Button>
 
-                            <TextBlock Grid.Column="1" Grid.Row="0" Text="底色"
+                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{DynamicResource S.Realtime.ScrimColor}"
                                        Style="{StaticResource FieldLabel}" Margin="0,0,0,6"/>
                             <Button Grid.Column="1" Grid.Row="1"
                                     x:Name="ScrimColorBtn"
@@ -225,8 +225,8 @@
                                     Height="34"
                                     FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                     Content="&#xE72C;"
-                                    ToolTip="還原預設值"
-                                    AutomationProperties.Name="還原預設顏色"
+                                    ToolTip="{DynamicResource S.Realtime.ResetColors}"
+                                    AutomationProperties.Name="{DynamicResource S.Realtime.ResetColorsName}"
                                     Click="ResetColorsBtn_Click"/>
                         </Grid>
                     </StackPanel>
@@ -239,13 +239,13 @@
                      way to put the overlays away for a scene without giving up the blocks. -->
                 <Border Style="{StaticResource CardBorder}">
                     <StackPanel>
-                        <TextBlock Text="運作方式" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Text="{DynamicResource S.Realtime.HowItWorks}" Style="{StaticResource SectionHeader}"/>
                         <TextBlock Style="{StaticResource FieldHint}" TextWrapping="Wrap" LineHeight="16" Margin="0,0,0,6"
-                                   Text="1. 點擊「選取翻譯區塊」，在畫面上框選要翻譯的區域。"/>
+                                   Text="{DynamicResource S.Realtime.Step1}"/>
                         <TextBlock Style="{StaticResource FieldHint}" TextWrapping="Wrap" LineHeight="16" Margin="0,0,0,6"
-                                   Text="2. 點擊浮動工具列的「開始翻譯」，內容變更時會自動重新辨識並更新譯文。"/>
+                                   Text="{DynamicResource S.Realtime.Step2}"/>
                         <TextBlock Style="{StaticResource FieldHint}" TextWrapping="Wrap" LineHeight="16"
-                                   Text="3. 翻譯中的區域不會影響遊戲或介面操作，如需調整翻譯區塊，請按「編輯」。"/>
+                                   Text="{DynamicResource S.Realtime.Step3}"/>
                         <!-- Filled in by RenderPauseHint, which names the user's own shortcut and
                              drops the line entirely when they have cleared it. Its top margin sits
                              on this line rather than under the one above, so a hidden hint does not
@@ -262,7 +262,7 @@
         <!-- ── Footer ── -->
         <DockPanel Grid.Row="2" Margin="0,14,0,0" VerticalAlignment="Center">
             <Button x:Name="PrimaryBtn"
-                    Content="選取翻譯區塊"
+                    Content="{DynamicResource S.Realtime.SelectBlocks}"
                     Style="{StaticResource AccentButton}"
                     Height="36" MinWidth="140" Padding="16,0"
                     DockPanel.Dock="Left"

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
@@ -195,7 +195,7 @@ public partial class RealtimePage : UserControl
                          string.IsNullOrWhiteSpace(SettingsService.Instance.Current.ApiKey);
 
         ProviderHint.Text = missingKey
-            ? "尚未設定 API Key，請先到「設定」輸入，否則即時翻譯會無法取得譯文。"
+            ? LocalizationService.Get("S.Realtime.NoApiKey")
             : item?.Hint ?? "";
         ProviderHint.Foreground = missingKey
             ? (System.Windows.Media.Brush)FindResource("AppError")
@@ -210,7 +210,9 @@ public partial class RealtimePage : UserControl
         var items = screens
             .Select((screen, index) => new ScreenItem(
                 screen.DeviceName,
-                $"螢幕 {index + 1} · {screen.Bounds.Width}×{screen.Bounds.Height}{(screen.Primary ? "（主螢幕）" : "")}",
+                LocalizationService.Format(
+                    screen.Primary ? "S.Realtime.ScreenItemPrimary" : "S.Realtime.ScreenItem",
+                    index + 1, screen.Bounds.Width, screen.Bounds.Height),
                 screen.Bounds,
                 screen.Primary))
             .ToList();
@@ -266,19 +268,19 @@ public partial class RealtimePage : UserControl
         // layer is usually over this button — but the toolbar phase leaves the screen usable.
         if (System.Windows.Application.Current.MainWindow is MainWindow { IsCapturing: true })
         {
-            SetStatus("截圖翻譯進行中，請先結束後再啟動即時翻譯。", isError: true);
+            SetStatus(LocalizationService.Get("S.Realtime.CaptureInProgress"), isError: true);
             return;
         }
 
         if (SrcLangBox.SelectedValue is not string sourceLanguage)
         {
-            SetStatus("請先選擇原文語言。", isError: true);
+            SetStatus(LocalizationService.Get("S.Realtime.ChooseSourceFirst"), isError: true);
             return;
         }
 
         if (ScreenBox.SelectedItem is not ScreenItem screen)
         {
-            SetStatus("找不到可用的螢幕，請重新開啟此頁面。", isError: true);
+            SetStatus(LocalizationService.Get("S.Realtime.NoScreens"), isError: true);
             return;
         }
 
@@ -419,7 +421,8 @@ public partial class RealtimePage : UserControl
     {
         bool active = RealtimeSessionController.Instance.IsActive;
 
-        PrimaryBtn.Content = active ? "結束即時翻譯" : "選取翻譯區塊";
+        PrimaryBtn.Content = LocalizationService.Get(
+            active ? "S.Realtime.StopSession" : "S.Realtime.SelectBlocks");
 
         // Locked rather than hidden while running: the user can see what the session was started
         // with, and changing any of it would mean rebuilding every block anyway.
@@ -436,7 +439,7 @@ public partial class RealtimePage : UserControl
         SrcLangPlaceholder.Visibility = hasSource ? Visibility.Collapsed : Visibility.Visible;
 
         SetStatus(
-            active ? "即時翻譯進行中，可用螢幕上的浮動列調整或結束。" : "",
+            active ? LocalizationService.Get("S.Realtime.ActiveHint") : "",
             isError: false);
     }
 

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
@@ -77,11 +77,7 @@ public partial class RealtimePage : UserControl
     {
         InitializeComponent();
 
-        SrcLangBox.ItemsSource = LanguageData.OcrSourceLanguages
-            .Where(language => !LanguageData.IsAutomaticSource(language.Code));
-        TgtLangBox.ItemsSource = LanguageData.TargetLanguages;
-
-        ProviderBox.ItemsSource = LanguageData.Providers;
+        BindPickers();
 
         ApplyPageDefaults();
 
@@ -128,8 +124,38 @@ public partial class RealtimePage : UserControl
     /// Re-reads what may have changed while the user was elsewhere: the attached monitors, and
     /// whether a session is running.
     /// </summary>
+    /// <summary>
+    /// Fills the three language and provider pickers.
+    /// </summary>
+    /// <remarks>
+    /// Re-run on every <see cref="Reload"/> rather than only at construction, because the item
+    /// labels come from the string dictionary and the shell keeps this page for its lifetime —
+    /// built once, it would still be showing the language the app started in. The selections are
+    /// carried across by hand: rebinding drops them, and unlike the other pages nothing here
+    /// restores them afterwards, because this page's choices are deliberately not persisted.
+    /// </remarks>
+    private void BindPickers()
+    {
+        var source   = SrcLangBox.SelectedValue;
+        var target   = TgtLangBox.SelectedValue;
+        var provider = ProviderBox.SelectedValue;
+
+        LocalizationService.BindLocalizedItems(
+            SrcLangBox,
+            LanguageData.OcrSourceLanguages
+                .Where(language => !LanguageData.IsAutomaticSource(language.Code))
+                .ToList());
+        LocalizationService.BindLocalizedItems(TgtLangBox,  LanguageData.TargetLanguages);
+        LocalizationService.BindLocalizedItems(ProviderBox, LanguageData.Providers);
+
+        SrcLangBox.SelectedValue  = source;
+        TgtLangBox.SelectedValue  = target;
+        ProviderBox.SelectedValue = provider;
+    }
+
     public void Reload()
     {
+        BindPickers();
         LoadScreens();
         RenderColours();
         RenderPauseHint();

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -180,7 +180,7 @@ internal sealed class RealtimeSessionController
             AlwaysOnTop.Reassert(control);
             // Says the click did something even when nothing was covering the bar, which is the
             // more common case: a user who tries this is looking for a sign of life.
-            control.ShowMessage("已將即時翻譯視窗移至最上層");
+            control.ShowMessage(LocalizationService.Get("S.Realtime.MovedToFront"));
         }
 
         Log.Info("Realtime layers re-asserted on top by request");
@@ -295,7 +295,7 @@ internal sealed class RealtimeSessionController
             control.SetBlockCount(_blocks.Count, request.MaxBlocks);
         };
         edit.LimitReached += (_, _) =>
-            control.ShowMessage($"最多同時 {request.MaxBlocks} 個區塊，請先移除一個");
+            control.ShowMessage(LocalizationService.Format("S.Realtime.TooManyBlocks", request.MaxBlocks));
         _edit = edit;
         edit.Show();
 
@@ -327,7 +327,7 @@ internal sealed class RealtimeSessionController
 
         if (_blocks.Count == 0)
         {
-            control.ShowMessage("請先拖曳建立至少一個區塊");
+            control.ShowMessage(LocalizationService.Get("S.Realtime.NeedOneBlock"));
             return;
         }
 
@@ -383,7 +383,7 @@ internal sealed class RealtimeSessionController
             {
                 // Composing here would produce a plain screenshot, which is not what was asked for
                 // and gives no sign that anything was missing.
-                control.ShowMessage("目前還沒有譯文可以擷取");
+                control.ShowMessage(LocalizationService.Get("S.Realtime.NothingToCapture"));
                 return;
             }
 
@@ -396,7 +396,7 @@ internal sealed class RealtimeSessionController
             var image = RealtimeShowcaseCapture.Compose(request.ScreenBounds, overlays);
             if (image is null)
             {
-                control.ShowMessage("擷取畫面失敗，請再試一次", RealtimeMessageKind.Failure);
+                control.ShowMessage(LocalizationService.Get("S.Realtime.CaptureFailed"), RealtimeMessageKind.Failure);
                 return;
             }
 
@@ -405,13 +405,13 @@ internal sealed class RealtimeSessionController
             var settings = SettingsService.Instance.Current;
             if (!settings.SaveScreenshotToDisk)
             {
-                control.ShowMessage("畫面截圖已複製到剪貼簿");
+                control.ShowMessage(LocalizationService.Get("S.Realtime.CaptureCopied"));
                 return;
             }
 
             var path = ScreenshotSaveService.Save(image, settings.ScreenshotSavePath);
             Log.Info("Realtime showcase capture saved to {Path}", path);
-            control.ShowMessage("畫面截圖已複製到剪貼簿並儲存至本機");
+            control.ShowMessage(LocalizationService.Get("S.Realtime.CaptureCopiedAndSaved"));
         }
         catch (Exception ex)
         {
@@ -419,7 +419,7 @@ internal sealed class RealtimeSessionController
             // folder. Neither is worth ending a session over, and the bar is where the user is
             // looking.
             Log.Warn(ex, "Realtime showcase capture failed");
-            control.ShowMessage($"擷取失敗：{ex.Message}", RealtimeMessageKind.Failure);
+            control.ShowMessage(LocalizationService.Format("S.Realtime.CaptureError", ex.Message), RealtimeMessageKind.Failure);
         }
     }
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -12,8 +12,8 @@
 
         <!-- ── Page header ── -->
         <StackPanel Grid.Row="0" Margin="0,0,0,18">
-            <TextBlock Text="設定" Style="{StaticResource PageTitle}"/>
-            <TextBlock Text="管理快捷鍵、翻譯服務、截圖與外觀"
+            <TextBlock Text="{DynamicResource S.Settings.Title}" Style="{StaticResource PageTitle}"/>
+            <TextBlock Text="{DynamicResource S.Settings.Subtitle}"
                        Style="{StaticResource PageSubtitle}"/>
         </StackPanel>
 
@@ -23,8 +23,43 @@
                       HorizontalScrollBarVisibility="Disabled"
                       Padding="0,0,8,0">
             <!-- Stretch (not Left) so the cards fill the column instead of shrink-wrapping
-                 to their content; MaxWidth keeps the rows readable on a wide window -->
-            <StackPanel MaxWidth="760">
+                 to their content; MaxWidth keeps the rows readable on a wide window.
+
+                 IsSharedSizeScope aligns the label column across every card: the rows used to
+                 share a hardcoded 100px, which fit four Chinese characters exactly and clipped
+                 the moment the same labels were written in English. Auto + SharedSizeGroup keeps
+                 the alignment without betting on a width. -->
+            <StackPanel MaxWidth="760" Grid.IsSharedSizeScope="True">
+
+                <!-- ── 介面語言 ── -->
+                <!-- First card on the page, and a card of its own: it is the one setting that
+                     changes how every other setting reads, so a user who opened this page because
+                     they cannot read it should not have to scroll past five cards of text they
+                     cannot read to find it. -->
+                <Border Style="{StaticResource CardBorder}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.UiLanguage}"
+                                   Style="{StaticResource SectionHeader}"/>
+
+                        <Grid Grid.Row="1">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.UiLanguageLabel}"
+                                       Style="{StaticResource FieldLabel}"/>
+                            <ComboBox  Grid.Column="1" x:Name="UiLanguageBox"
+                                       Style="{StaticResource ModernComboBox}"
+                                       SelectedValuePath="Code"
+                                       SelectionChanged="UiLanguageBox_SelectionChanged"/>
+                        </Grid>
+                    </Grid>
+                </Border>
 
                 <!-- ── 一般設定 ── -->
                 <Border Style="{StaticResource CardBorder}">
@@ -38,12 +73,12 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Text="一般設定" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.General}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- Hotkey row -->
                         <Grid Grid.Row="1" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
                             </Grid.ColumnDefinitions>
@@ -51,7 +86,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="截圖翻譯"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.CaptureHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
                             <TextBox   Grid.Column="1" Grid.Row="0" x:Name="HotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
@@ -60,12 +95,12 @@
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="2" Grid.Row="0" x:Name="RecordBtn" Content="錄製"
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="RecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
                             <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
-                                       Text="按下快捷鍵即可使用截圖翻譯功能"
+                                       Text="{DynamicResource S.Settings.CaptureHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
                         </Grid>
 
@@ -75,7 +110,7 @@
                              startup and nothing in the interface names it. -->
                         <Grid Grid.Row="2" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
                             </Grid.ColumnDefinitions>
@@ -83,7 +118,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="開啟翻譯視窗"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.WindowHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
                             <TextBox   Grid.Column="1" Grid.Row="0" x:Name="WindowHotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
@@ -92,22 +127,22 @@
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="2" Grid.Row="0" x:Name="WindowRecordBtn" Content="錄製"
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="WindowRecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
                             <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
-                                       Text="即時翻譯進行中時，改為將浮動視窗移至最上層"
+                                       Text="{DynamicResource S.Settings.WindowHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
                         </Grid>
 
                         <!-- Source language row -->
                         <Grid Grid.Row="3" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="來源語言" Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SourceLanguage}" Style="{StaticResource FieldLabel}"/>
                             <ComboBox  Grid.Column="1" x:Name="SourceLangBox"
                                        Style="{StaticResource ModernComboBox}"
                                        SelectedValuePath="Code"
@@ -117,12 +152,12 @@
                         <!-- 框選完成自動翻譯 -->
                         <Grid Grid.Row="4" Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="自動翻譯" Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.AutoTranslate}" Style="{StaticResource FieldLabel}"/>
                             <CheckBox  Grid.Column="1" x:Name="AutoTranslateCheckBox"
-                                       Content="框選完成後自動翻譯"
+                                       Content="{DynamicResource S.Settings.AutoTranslateCheck}"
                                        Style="{StaticResource ModernCheckBox}"
                                        VerticalAlignment="Center"
                                        Checked="AutoTranslate_Toggled"
@@ -132,12 +167,12 @@
                         <!-- 開機自動啟動 -->
                         <Grid Grid.Row="5" Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="開機啟動" Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.Startup}" Style="{StaticResource FieldLabel}"/>
                             <CheckBox  Grid.Column="1" x:Name="StartupCheckBox"
-                                       Content="開機時自動啟動"
+                                       Content="{DynamicResource S.Settings.StartupCheck}"
                                        Style="{StaticResource ModernCheckBox}"
                                        VerticalAlignment="Center"
                                        Checked="Startup_Toggled"
@@ -156,19 +191,19 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Text="翻譯 API" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.TranslationApi}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- Provider row -->
                         <Grid Grid.Row="1" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="翻譯服務" Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.Provider}" Style="{StaticResource FieldLabel}"/>
                             <ComboBox  Grid.Column="1" Grid.Row="0" x:Name="ProviderBox"
                                        Style="{StaticResource ModernComboBox}"
                                        SelectedValuePath="Provider"
@@ -180,11 +215,11 @@
                         <!-- API Key row (conditionally visible) -->
                         <Grid Grid.Row="2" x:Name="DeepLApiKeyRow">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0" x:Name="ApiKeyLabel"
-                                       Text="API Key" Style="{StaticResource FieldLabel}"/>
+                                       Text="{DynamicResource S.Common.ApiKey}" Style="{StaticResource FieldLabel}"/>
                             <controls:SecretBox Grid.Column="1" x:Name="ApiKeyBox"
                                                 SecretChanged="ApiKeyBox_SecretChanged"/>
                         </Grid>
@@ -192,7 +227,7 @@
                         <!-- OpenAI Compatible settings (conditionally visible) -->
                         <Grid Grid.Row="3" x:Name="OpenAiSettingsPanel">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
@@ -202,20 +237,20 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="API 位址"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.ApiBaseUrl}"
                                        Style="{StaticResource FieldLabel}"/>
                             <TextBox Grid.Column="1" Grid.Row="0" x:Name="OpenAiBaseUrlBox"
                                      Style="{StaticResource ModernTextBox}"
                                      TextChanged="OpenAiSetting_TextChanged"/>
 
-                            <TextBlock Grid.Column="0" Grid.Row="1" Text="API Key"
+                            <TextBlock Grid.Column="0" Grid.Row="1" Text="{DynamicResource S.Common.ApiKey}"
                                        Margin="0,10,0,0"
                                        Style="{StaticResource FieldLabel}"/>
                             <controls:SecretBox Grid.Column="1" Grid.Row="1" x:Name="OpenAiApiKeyBox"
                                                 Margin="0,10,0,0"
                                                 SecretChanged="OpenAiSecret_SecretChanged"/>
 
-                            <TextBlock Grid.Column="0" Grid.Row="2" Text="模型名稱"
+                            <TextBlock Grid.Column="0" Grid.Row="2" Text="{DynamicResource S.Settings.ModelName}"
                                        Margin="0,10,0,0"
                                        Style="{StaticResource FieldLabel}"/>
                             <TextBox Grid.Column="1" Grid.Row="2" x:Name="OpenAiModelBox"
@@ -231,7 +266,7 @@
                                 <Hyperlink x:Name="OllamaGuideLink"
                                            Foreground="{DynamicResource AppTextSecondary}"
                                            RequestNavigate="OllamaGuideLink_RequestNavigate"
-                                           NavigateUri="https://github.com/asd880921/OverTranslate/blob/main/OLLAMA_GUIDE.md">本地 LLM (Ollama) 安裝教學</Hyperlink>
+                                           NavigateUri="https://github.com/asd880921/OverTranslate/blob/main/OLLAMA_GUIDE.md"><Run Text="{DynamicResource S.Settings.OllamaGuide}"/></Hyperlink>
                             </TextBlock>
                         </Grid>
                     </Grid>
@@ -246,17 +281,17 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Text="截圖" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Screenshot}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- 同時儲存到本機 -->
                         <Grid Grid.Row="1">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="儲存截圖" Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SaveScreenshot}" Style="{StaticResource FieldLabel}"/>
                             <CheckBox  Grid.Column="1" x:Name="SaveScreenshotCheckBox"
-                                       Content="截圖時自動儲存"
+                                       Content="{DynamicResource S.Settings.SaveScreenshotCheck}"
                                        Style="{StaticResource ModernCheckBox}"
                                        VerticalAlignment="Center"
                                        Checked="SaveScreenshotCheckBox_Toggled"
@@ -266,23 +301,23 @@
                         <!-- 儲存位置（僅在開關開啟時顯示） -->
                         <Grid Grid.Row="2" x:Name="ScreenshotPathRow" Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="儲存位置" Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SavePath}" Style="{StaticResource FieldLabel}"/>
                             <TextBox   Grid.Column="1" x:Name="ScreenshotPathBox"
                                        Style="{StaticResource ModernTextBox}"
                                        IsReadOnly="True"
                                        Cursor="Hand"
                                        Margin="0,0,4,0"
-                                       ToolTip="點擊以選擇儲存資料夾"
+                                       ToolTip="{DynamicResource S.Settings.SavePathTip}"
                                        PreviewMouseLeftButtonDown="ScreenshotPathBox_PreviewMouseLeftButtonDown"/>
                             <Button    Grid.Column="2" x:Name="OpenScreenshotFolderBtn"
                                        Content="📂"
                                        Style="{StaticResource IconButton}"
                                        Height="34"
-                                       ToolTip="開啟資料夾"
+                                       ToolTip="{DynamicResource S.Settings.OpenFolderTip}"
                                        Click="OpenScreenshotFolderBtn_Click"/>
                         </Grid>
                     </Grid>
@@ -296,22 +331,22 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Text="外觀" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Appearance}" Style="{StaticResource SectionHeader}"/>
 
                         <Grid Grid.Row="1">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="主題" Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.Theme}" Style="{StaticResource FieldLabel}"/>
                             <StackPanel Grid.Column="1" Orientation="Horizontal">
                                 <RadioButton x:Name="LightThemeRadio"
-                                             Content="淺色"
+                                             Content="{DynamicResource S.Settings.ThemeLight}"
                                              GroupName="ThemeGroup"
                                              Style="{StaticResource ThemeRadioButton}"
                                              Checked="ThemeRadio_Checked"/>
                                 <RadioButton x:Name="DarkThemeRadio"
-                                             Content="深色"
+                                             Content="{DynamicResource S.Settings.ThemeDark}"
                                              GroupName="ThemeGroup"
                                              Style="{StaticResource ThemeRadioButton}"
                                              Margin="0"
@@ -331,28 +366,28 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Text="進階設定" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Advanced}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- 詳細記錄 -->
                         <Grid Grid.Row="1">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="應用紀錄"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.Logging}"
                                        Style="{StaticResource FieldLabel}"/>
                             <CheckBox  Grid.Column="1" Grid.Row="0" x:Name="VerboseLoggingCheckBox"
-                                       Content="記錄詳細資訊"
+                                       Content="{DynamicResource S.Settings.LoggingCheck}"
                                        Style="{StaticResource ModernCheckBox}"
                                        VerticalAlignment="Center"
                                        Checked="VerboseLogging_Toggled"
                                        Unchecked="VerboseLogging_Toggled"/>
                             <TextBlock Grid.Column="1" Grid.Row="1" x:Name="VerboseLoggingHint"
-                                       Text="啟用後會記錄更多應用紀錄資訊，協助排查問題。"
+                                       Text="{DynamicResource S.Settings.LoggingHint}"
                                        Style="{StaticResource FieldHint}"/>
                         </Grid>
                     </Grid>
@@ -365,7 +400,7 @@
              that contract and flashes a confirmation on each write -->
         <Grid Grid.Row="2" Margin="0,12,0,0" Height="20">
             <TextBlock x:Name="AutoSaveHint"
-                       Text="設定變更後會自動儲存"
+                       Text="{DynamicResource S.Settings.AutoSaveHint}"
                        VerticalAlignment="Center"
                        FontFamily="{StaticResource AppFont}"
                        FontSize="12"

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -109,9 +109,12 @@ public partial class SettingsPage : UserControl
         _statusHold = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(1600) };
         _statusHold.Tick += (_, _) => { _statusHold.Stop(); FadeStatusOut(); };
 
-        // Static event, instance handler: without the unsubscribe this page could not be collected
-        // for as long as the app ran, and the shell builds a fresh one each time it is navigated to.
-        LocalizationService.LanguageChanged += OnLanguageChanged;
+        // Paired with Loaded rather than subscribed once: the shell keeps one instance of this
+        // page for its lifetime and swaps it in and out of the content host, so unsubscribing on
+        // Unloaded without re-subscribing on Loaded would leave it deaf from the first time the
+        // user navigated away. A static event holding an instance handler also has to be let go
+        // of at some point, which rules out subscribing only once.
+        Loaded   += (_, _) => LocalizationService.LanguageChanged += OnLanguageChanged;
         Unloaded += (_, _) => LocalizationService.LanguageChanged -= OnLanguageChanged;
 
         LoadSettings();
@@ -130,11 +133,11 @@ public partial class SettingsPage : UserControl
         {
             var s = SettingsService.Instance.Current;
 
-            SourceLangBox.ItemsSource = LanguageData.OcrSourceLanguages;
+            LocalizationService.BindLocalizedItems(SourceLangBox, LanguageData.OcrSourceLanguages);
             SourceLangBox.SelectedValue = LanguageData.GetValidOcrSourceCode(s.SourceLanguage);
             if (SourceLangBox.SelectedValue == null) SourceLangBox.SelectedIndex = 0;
 
-            ProviderBox.ItemsSource = LanguageData.Providers;
+            LocalizationService.BindLocalizedItems(ProviderBox, LanguageData.Providers);
             ProviderBox.SelectedValue = s.Provider;
             if (ProviderBox.SelectedValue == null) ProviderBox.SelectedIndex = 0;
             ProviderHint.Text = (ProviderBox.SelectedItem as ProviderItem)?.Hint ?? "";

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -39,7 +39,7 @@ public partial class SettingsPage : UserControl
     /// false for the window one, which it names nowhere.
     /// </param>
     private sealed record HotkeyField(
-        string Name,
+        string NameKey,
         TextBox Box,
         Button Record,
         Func<AppSettings, string> Display,
@@ -62,7 +62,7 @@ public partial class SettingsPage : UserControl
         _hotkeyFields =
         [
             new HotkeyField(
-                "截圖翻譯",
+                "S.Settings.CaptureHotkey",
                 HotkeyBox, RecordBtn,
                 s => s.HotkeyDisplay,
                 s => (s.HotkeyModifiers, s.HotkeyVirtualKey),
@@ -74,7 +74,7 @@ public partial class SettingsPage : UserControl
                 },
                 AdvertisedInShell: true),
             new HotkeyField(
-                "開啟翻譯視窗",
+                "S.Settings.WindowHotkey",
                 WindowHotkeyBox, WindowRecordBtn,
                 s => s.TranslationWindowHotkeyDisplay,
                 s => (s.TranslationWindowHotkeyModifiers, s.TranslationWindowHotkeyVirtualKey),
@@ -108,6 +108,11 @@ public partial class SettingsPage : UserControl
 
         _statusHold = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(1600) };
         _statusHold.Tick += (_, _) => { _statusHold.Stop(); FadeStatusOut(); };
+
+        // Static event, instance handler: without the unsubscribe this page could not be collected
+        // for as long as the app ran, and the shell builds a fresh one each time it is navigated to.
+        LocalizationService.LanguageChanged += OnLanguageChanged;
+        Unloaded += (_, _) => LocalizationService.LanguageChanged -= OnLanguageChanged;
 
         LoadSettings();
     }
@@ -143,6 +148,12 @@ public partial class SettingsPage : UserControl
             LightThemeRadio.IsChecked = s.Theme != ThemeService.Dark;
             DarkThemeRadio.IsChecked  = s.Theme == ThemeService.Dark;
 
+            // LocalizationService.Current, not s.UiLanguage: an unset preference is showing the
+            // system default right now, and the picker has to agree with what is on screen.
+            UiLanguageBox.ItemsSource = LocalizationService.Options;
+            UiLanguageBox.SelectedValue = LocalizationService.Current;
+            if (UiLanguageBox.SelectedValue == null) UiLanguageBox.SelectedIndex = 0;
+
             StartupCheckBox.IsChecked = StartupService.IsEnabled;
 
             AutoTranslateCheckBox.IsChecked = s.AutoTranslateAfterSelection;
@@ -174,7 +185,7 @@ public partial class SettingsPage : UserControl
 
     private void FlashSaved()
     {
-        StatusText.Text       = "✓ 已儲存";
+        StatusText.Text       = LocalizationService.Get("S.Settings.Saved");
         StatusText.Foreground = (System.Windows.Media.Brush)FindResource("AppSuccess");
 
         StatusText.BeginAnimation(OpacityProperty, null);
@@ -261,7 +272,7 @@ public partial class SettingsPage : UserControl
         }
         catch (Exception ex)
         {
-            ShowError($"✗ 無法設定開機啟動：{ex.Message}");
+            ShowError(LocalizationService.Format("S.Settings.StartupFailed", ex.Message));
         }
     }
 
@@ -285,7 +296,7 @@ public partial class SettingsPage : UserControl
         if (!LogLevelService.IsOverriddenByEnvironment) return;
 
         VerboseLoggingCheckBox.IsEnabled = false;
-        VerboseLoggingHint.Text = "目前記錄等級由環境變數 OVERTRANSLATE_LOGLEVEL 指定，此選項暫時無效。";
+        VerboseLoggingHint.Text = LocalizationService.Get("S.Settings.LoggingEnvOverride");
     }
 
     private void ThemeRadio_Checked(object sender, RoutedEventArgs e)
@@ -295,6 +306,33 @@ public partial class SettingsPage : UserControl
         ThemeService.Apply(theme);
         Persist(s => s.Theme = theme);
     }
+
+    private void UiLanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_loading) return;
+
+        if (UiLanguageBox.SelectedValue as string is not { } language) return;
+
+        // Persist first: the swap re-runs LoadSettings through LanguageChanged, and both that and
+        // LocalizationService.Current read the stored value back.
+        Persist(s => s.UiLanguage = language);
+        LocalizationService.Apply(language);
+
+        // Persist already flashed the confirmation, but it did so in the outgoing language and
+        // LoadSettings does not touch the status line. Say it again in the new one.
+        FlashSaved();
+    }
+
+    /// <summary>
+    /// Re-renders the text on this page that DynamicResource cannot reach.
+    /// </summary>
+    /// <remarks>
+    /// Three things on this page are composed in code and so hold a string from the language that
+    /// was in effect when they were built: the provider list and its hint, the pickers' language
+    /// labels, and the environment-override notice. LoadSettings rebuilds all of them, and is
+    /// already guarded against writing back.
+    /// </remarks>
+    private void OnLanguageChanged(object? sender, EventArgs e) => LoadSettings();
 
     private void SaveScreenshotCheckBox_Toggled(object sender, RoutedEventArgs e)
     {
@@ -316,7 +354,7 @@ public partial class SettingsPage : UserControl
 
         var dialog = new OpenFolderDialog
         {
-            Title = "選擇截圖儲存資料夾",
+            Title = LocalizationService.Get("S.Settings.FolderPickerTitle"),
             InitialDirectory = ScreenshotPathBox.Text
         };
         if (dialog.ShowDialog(Window.GetWindow(this)) != true) return;
@@ -338,7 +376,7 @@ public partial class SettingsPage : UserControl
         }
         catch (Exception ex)
         {
-            ShowError($"✗ 無法開啟資料夾：{ex.Message}");
+            ShowError(LocalizationService.Format("S.Settings.OpenFolderFailed", ex.Message));
         }
     }
 
@@ -367,8 +405,8 @@ public partial class SettingsPage : UserControl
         StopRecording();
 
         _recording = field;
-        field.Box.Text = "請按下快捷鍵...";
-        field.Record.Content = "取消";
+        field.Box.Text = LocalizationService.Get("S.Settings.HotkeyPrompt");
+        field.Record.Content = LocalizationService.Get("S.Common.Cancel");
         field.Box.Focus();
     }
 
@@ -383,7 +421,7 @@ public partial class SettingsPage : UserControl
         if (_recording is not { } field) return;
 
         field.Box.Text = field.Display(SettingsService.Instance.Current);
-        field.Record.Content = "錄製";
+        field.Record.Content = LocalizationService.Get("S.Common.Record");
         _recording = null;
     }
 
@@ -445,7 +483,8 @@ public partial class SettingsPage : UserControl
 
         if (taken is not null)
         {
-            ShowError($"✗ {display} 已指派給「{taken.Name}」");
+            ShowError(LocalizationService.Format(
+                "S.Settings.HotkeyTaken", display, LocalizationService.Get(taken.NameKey)));
             StopRecording();
             return;
         }

--- a/src/OverTranslate/Views/Shell/AboutOverlay.xaml
+++ b/src/OverTranslate/Views/Shell/AboutOverlay.xaml
@@ -45,7 +45,7 @@
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
                         Margin="0,-4,-8,0"
-                        ToolTip="關閉"
+                        ToolTip="{DynamicResource S.Common.Close}"
                         Click="CloseBtn_Click"/>
 
                 <StackPanel Grid.Row="0" HorizontalAlignment="Center" Margin="24,4,24,18">
@@ -67,7 +67,7 @@
 
                 <StackPanel Grid.Row="2" Margin="0,16,0,16">
                     <Grid Margin="0,0,0,12">
-                        <TextBlock Text="作者"
+                        <TextBlock Text="{DynamicResource S.About.Author}"
                                    FontFamily="{StaticResource AppFont}"
                                    FontSize="13"
                                    Foreground="{DynamicResource AppTextSecondary}"
@@ -89,7 +89,7 @@
                                        FontSize="14" Text="&#xE774;"
                                        Width="22" VerticalAlignment="Center"
                                        Foreground="{DynamicResource AppTextSecondary}"/>
-                            <TextBlock Text="在 GitHub 上查看原始碼"
+                            <TextBlock Text="{DynamicResource S.About.ViewSource}"
                                        VerticalAlignment="Center"
                                        FontFamily="{StaticResource AppFont}"/>
                         </StackPanel>
@@ -107,12 +107,12 @@
                            Foreground="{DynamicResource AppTextSecondary}"
                            TextWrapping="Wrap"
                            LineHeight="18">
-                    <Run Text="免費開源，可自由使用。如果覺得有幫助，也歡迎到 GitHub 幫忙點個"/>
+                    <Run Text="{DynamicResource S.About.OpenSourceBefore}"/>
                     <Run Text="&#xE735;"
                          FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                          FontSize="11"
                          Foreground="{DynamicResource AppAccent}"/>
-                    <Run Text="Star，感謝！"/>
+                    <Run Text="{DynamicResource S.About.OpenSourceAfter}"/>
                 </TextBlock>
             </Grid>
         </Border>

--- a/src/OverTranslate/Views/Shell/AboutOverlay.xaml.cs
+++ b/src/OverTranslate/Views/Shell/AboutOverlay.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
+using OverTranslate.Services;
 // UseWindowsForms puts System.Windows.Forms in the implicit usings, so these names collide
 using UserControl = System.Windows.Controls.UserControl;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
@@ -25,7 +26,7 @@ public partial class AboutOverlay : UserControl
     {
         InitializeComponent();
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
-        VersionText.Text = $"版本 {version}";
+        VersionText.Text = LocalizationService.Format("S.About.Version", version);
     }
 
     public void Open()

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -291,8 +291,7 @@
                       Focusable="False"
                       ResizeDirection="Columns"
                       ResizeBehavior="CurrentAndNext"
-                      Cursor="SizeWE"
-                      DragCompleted="SidebarSplitter_DragCompleted"/>
+                      Cursor="SizeWE"/>
 
         <!-- ══════════ About modal ══════════ -->
         <shell:AboutOverlay Grid.ColumnSpan="2" x:Name="About"/>

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -3,15 +3,22 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:shell="clr-namespace:OverTranslate.Views.Shell"
         Title="OverTranslate"
-        Width="1000" Height="640"
-        MinWidth="780" MinHeight="520"
+        Width="1080" Height="640"
+        MinWidth="840" MinHeight="520"
         WindowStartupLocation="CenterScreen"
         ShowInTaskbar="True"
         Background="{DynamicResource AppWindowBg}">
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="208"/>
+            <!-- 208 was sized to the Chinese labels, which fit the rail's primary action and its
+                 shortcut on one line with room to spare. English does not — "Screen capture" and
+                 "Ctrl+Alt+A" share that line, and the shortcut is docked first — so the default
+                 is wider and the user can settle it themselves with the splitter below.
+                 MinWidth still fits an icon and a short label; MaxWidth stops the rail from
+                 eating the page beside it. -->
+            <ColumnDefinition x:Name="SidebarColumn"
+                              Width="240" MinWidth="200" MaxWidth="380"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
@@ -267,6 +274,25 @@
                 <TranslateTransform x:Name="ContentTransform"/>
             </Border.RenderTransform>
         </Border>
+
+        <!-- ══════════ Sidebar splitter ══════════ -->
+        <!-- Sits on the rail's trailing edge rather than in a column of its own, so it costs no
+             layout width and the seam stays exactly where the two backgrounds meet. Transparent
+             with a wider hit area than it looks: the visible boundary is the Border's edge, and a
+             drawn handle would be a permanent line across a window that otherwise has none.
+             Declared after both panels so it takes the mouse ahead of them, and before the About
+             overlay so a modal still covers it. -->
+        <GridSplitter Grid.Column="0"
+                      x:Name="SidebarSplitter"
+                      Width="6"
+                      HorizontalAlignment="Right"
+                      VerticalAlignment="Stretch"
+                      Background="Transparent"
+                      Focusable="False"
+                      ResizeDirection="Columns"
+                      ResizeBehavior="CurrentAndNext"
+                      Cursor="SizeWE"
+                      DragCompleted="SidebarSplitter_DragCompleted"/>
 
         <!-- ══════════ About modal ══════════ -->
         <shell:AboutOverlay Grid.ColumnSpan="2" x:Name="About"/>

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -141,7 +141,7 @@
                         <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                    FontSize="14" Text="&#xE946;"
                                    Width="24" VerticalAlignment="Center"/>
-                        <TextBlock Text="關於" VerticalAlignment="Center"/>
+                        <TextBlock Text="{DynamicResource S.Shell.About}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 
@@ -188,7 +188,7 @@
                                    VerticalAlignment="Center"
                                    Foreground="{DynamicResource AppTextSecondary}"/>
 
-                        <TextBlock Text="截圖翻譯"
+                        <TextBlock Text="{DynamicResource S.Shell.CaptureTranslate}"
                                    FontWeight="SemiBold"
                                    VerticalAlignment="Center"/>
                     </DockPanel>
@@ -217,7 +217,7 @@
                                 <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                            FontSize="15" Text="&#xE8C1;"
                                            Width="24" VerticalAlignment="Center"/>
-                                <TextBlock Text="文字翻譯" VerticalAlignment="Center"/>
+                                <TextBlock Text="{DynamicResource S.Shell.TextTranslate}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </RadioButton>
 
@@ -232,7 +232,7 @@
                                 <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                            FontSize="15" Text="&#xE9D9;"
                                            Width="24" VerticalAlignment="Center"/>
-                                <TextBlock Text="即時翻譯" VerticalAlignment="Center"/>
+                                <TextBlock Text="{DynamicResource S.Shell.RealtimeTranslate}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </RadioButton>
 
@@ -244,7 +244,7 @@
                                 <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                            FontSize="15" Text="&#xE713;"
                                            Width="24" VerticalAlignment="Center"/>
-                                <TextBlock Text="設定" VerticalAlignment="Center"/>
+                                <TextBlock Text="{DynamicResource S.Shell.Settings}" VerticalAlignment="Center"/>
                             </StackPanel>
                         </RadioButton>
                     </StackPanel>

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -99,8 +99,31 @@ public partial class ShellWindow : Window
         LocalizationService.LanguageChanged += OnLanguageChanged;
         Closed += (_, _) => LocalizationService.LanguageChanged -= OnLanguageChanged;
 
+        RestoreSidebarWidth();
+
         // Nav_Checked drives navigation, so this also renders the initial page
         TranslationNav.IsChecked = true;
+    }
+
+    private void RestoreSidebarWidth()
+    {
+        var stored = SettingsService.Instance.Current.ShellSidebarWidth;
+        if (stored <= 0) return;
+
+        // Clamped against the column's own bounds rather than trusted: this comes off disk, and
+        // the values there are the only thing standing between a hand-edited file and a rail wide
+        // enough to hide the page.
+        var width = Math.Clamp(stored, SidebarColumn.MinWidth, SidebarColumn.MaxWidth);
+        SidebarColumn.Width = new GridLength(width);
+    }
+
+    private void SidebarSplitter_DragCompleted(
+        object sender, System.Windows.Controls.Primitives.DragCompletedEventArgs e)
+    {
+        // On completion rather than on every delta: dragging raises this continuously, and the
+        // settings file is rewritten in full on each save.
+        SettingsService.Instance.Current.ShellSidebarWidth = SidebarColumn.ActualWidth;
+        SettingsService.Instance.Save();
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -92,8 +92,21 @@ public partial class ShellWindow : Window
         UpdateNotifier.AvailabilityChanged += OnUpdateAvailabilityChanged;
         RefreshUpdateAvailability();
 
+        // The rail's two composed strings — the update row's version and the capture button's
+        // blocked-by-realtime tooltip — are set from code, so DynamicResource does not reach them
+        // and they would keep the language they were built in. The settings page that changes the
+        // language lives inside this window, so they are always on screen when it happens.
+        LocalizationService.LanguageChanged += OnLanguageChanged;
+        Closed += (_, _) => LocalizationService.LanguageChanged -= OnLanguageChanged;
+
         // Nav_Checked drives navigation, so this also renders the initial page
         TranslationNav.IsChecked = true;
+    }
+
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        RefreshCaptureAvailability();
+        RefreshUpdateAvailability();
     }
 
     /// <summary>
@@ -154,7 +167,9 @@ public partial class ShellWindow : Window
         var running = Realtime.RealtimeSessionController.Instance.IsActive;
 
         CaptureBtn.IsEnabled = !running;
-        CaptureBtn.ToolTip = running ? "即時翻譯進行中，請先結束後再使用截圖翻譯" : null;
+        CaptureBtn.ToolTip = running
+            ? LocalizationService.Get("S.Shell.CaptureBlockedByRealtime")
+            : null;
     }
 
     private void OnUpdateAvailabilityChanged(object? sender, EventArgs e) =>
@@ -181,7 +196,7 @@ public partial class ShellWindow : Window
         // information that tells the user whether this is the release they already decided about.
         // 「至」carries the relationship to the version directly above — this is where that number
         // goes, not merely that a number exists. "v" matches that label's own formatting.
-        UpdateBtnText.Text = $"可更新至 v{update.LatestVersion}";
+        UpdateBtnText.Text = LocalizationService.Format("S.Shell.UpdateAvailable", update.LatestVersion);
         UpdateBtn.Visibility = Visibility.Visible;
     }
 

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -8,8 +8,9 @@ using OverTranslate.Services;
 using OverTranslate.Views.Realtime;
 using OverTranslate.Views.Settings;
 using OverTranslate.Views.Translation;
-// UseWindowsForms puts System.Windows.Forms in the implicit usings, so this name collides
+// UseWindowsForms puts System.Windows.Forms in the implicit usings, so these names collide
 using Point = System.Windows.Point;
+using Size = System.Windows.Size;
 
 namespace OverTranslate.Views.Shell;
 
@@ -28,6 +29,24 @@ public enum ShellPage
 public partial class ShellWindow : Window
 {
     private static ShellWindow? _instance;
+
+    /// <summary>
+    /// The shell's dimensions from the last time it was open, for as long as the process lives.
+    /// </summary>
+    /// <remarks>
+    /// In memory rather than in the settings file, on purpose. Closing this window is the ordinary
+    /// way to get it off the screen — the app goes on running in the tray — so reopening it during
+    /// the same sitting should give back the window the user had, not the one the app ships with.
+    /// Surviving a restart is a different question, and the answer there is the designed default:
+    /// centred, at a size picked to fit the content.
+    /// </remarks>
+    private static Size? _lastSize;
+
+    /// <inheritdoc cref="_lastSize"/>
+    private static WindowState _lastWindowState = WindowState.Normal;
+
+    /// <inheritdoc cref="_lastSize"/>
+    private static double? _lastSidebarWidth;
 
     private static readonly Duration IndicatorDuration = new(TimeSpan.FromMilliseconds(180));
     private static readonly Duration ContentDuration   = new(TimeSpan.FromMilliseconds(120));
@@ -99,31 +118,28 @@ public partial class ShellWindow : Window
         LocalizationService.LanguageChanged += OnLanguageChanged;
         Closed += (_, _) => LocalizationService.LanguageChanged -= OnLanguageChanged;
 
-        RestoreSidebarWidth();
+        RestoreSessionLayout();
 
         // Nav_Checked drives navigation, so this also renders the initial page
         TranslationNav.IsChecked = true;
     }
 
-    private void RestoreSidebarWidth()
+    /// <inheritdoc cref="_lastSize"/>
+    private void RestoreSessionLayout()
     {
-        var stored = SettingsService.Instance.Current.ShellSidebarWidth;
-        if (stored <= 0) return;
+        if (_lastSize is { } size)
+        {
+            Width  = size.Width;
+            Height = size.Height;
+        }
 
-        // Clamped against the column's own bounds rather than trusted: this comes off disk, and
-        // the values there are the only thing standing between a hand-edited file and a rail wide
-        // enough to hide the page.
-        var width = Math.Clamp(stored, SidebarColumn.MinWidth, SidebarColumn.MaxWidth);
-        SidebarColumn.Width = new GridLength(width);
-    }
+        if (_lastWindowState == WindowState.Maximized) WindowState = WindowState.Maximized;
 
-    private void SidebarSplitter_DragCompleted(
-        object sender, System.Windows.Controls.Primitives.DragCompletedEventArgs e)
-    {
-        // On completion rather than on every delta: dragging raises this continuously, and the
-        // settings file is rewritten in full on each save.
-        SettingsService.Instance.Current.ShellSidebarWidth = SidebarColumn.ActualWidth;
-        SettingsService.Instance.Save();
+        if (_lastSidebarWidth is { } railWidth)
+        {
+            SidebarColumn.Width = new GridLength(
+                Math.Clamp(railWidth, SidebarColumn.MinWidth, SidebarColumn.MaxWidth));
+        }
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)
@@ -372,6 +388,23 @@ public partial class ShellWindow : Window
     }
 
     private void AboutBtn_Click(object sender, RoutedEventArgs e) => About.Open();
+
+    protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
+    {
+        // RestoreBounds rather than the live size: a maximised window's actual size is the screen's,
+        // and handing that back as a normal-state size would reopen a window that fills the display
+        // without being maximised — and with no way to shrink it back short of dragging.
+        var bounds = WindowState == WindowState.Normal
+            ? new Rect(Left, Top, Width, Height)
+            : RestoreBounds;
+
+        _lastSize = new Size(bounds.Width, bounds.Height);
+        // Minimised is a state to reopen out of, not into.
+        _lastWindowState = WindowState == WindowState.Minimized ? WindowState.Normal : WindowState;
+        _lastSidebarWidth = SidebarColumn.ActualWidth;
+
+        base.OnClosing(e);
+    }
 
     protected override void OnClosed(EventArgs e)
     {

--- a/src/OverTranslate/Views/Shell/ToastWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ToastWindow.xaml
@@ -67,7 +67,7 @@
                                     Margin="0,-5,-6,0">
                             <Button Content="⧉"
                                     Style="{StaticResource ToastIconButton}"
-                                    ToolTip="複製訊息"
+                                    ToolTip="{DynamicResource S.Toast.CopyMessage}"
                                     Click="CopyButton_Click"/>
 
                             <!-- A hair smaller: ✕ carries more ink than ⧉ at the same point size,
@@ -75,7 +75,7 @@
                             <Button Content="✕"
                                     Style="{StaticResource ToastIconButton}"
                                     FontSize="11"
-                                    ToolTip="關閉"
+                                    ToolTip="{DynamicResource S.Common.Close}"
                                     Click="CloseButton_Click"/>
                         </StackPanel>
                     </Grid>
@@ -90,7 +90,7 @@
 
                     <TextBlock Grid.Row="2"
                                x:Name="CopyHint"
-                               Text="已複製到剪貼簿"
+                               Text="{DynamicResource S.Toast.Copied}"
                                FontSize="11"
                                Foreground="{DynamicResource AppSuccess}"
                                Visibility="Collapsed"

--- a/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml
+++ b/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml
@@ -74,7 +74,7 @@
                                    FontSize="14" Text="&#xE737;"
                                    Width="22" VerticalAlignment="Center"
                                    Foreground="{DynamicResource AppTextSecondary}"/>
-                        <TextBlock x:Name="OpenWindowLabel" Text="開啟翻譯視窗" VerticalAlignment="Center"/>
+                        <TextBlock x:Name="OpenWindowLabel" Text="{DynamicResource S.Tray.OpenWindow}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 
@@ -87,7 +87,7 @@
                                    FontSize="14" Text="&#xE713;"
                                    Width="22" VerticalAlignment="Center"
                                    Foreground="{DynamicResource AppTextSecondary}"/>
-                        <TextBlock Text="設定" VerticalAlignment="Center"/>
+                        <TextBlock Text="{DynamicResource S.Tray.Settings}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 
@@ -103,7 +103,7 @@
                                    FontSize="14" Text="&#xE8BB;"
                                    Width="22" VerticalAlignment="Center"
                                    Foreground="{DynamicResource AppTextSecondary}"/>
-                        <TextBlock Text="結束" VerticalAlignment="Center"/>
+                        <TextBlock Text="{DynamicResource S.Tray.Exit}" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
 

--- a/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Input;
+using OverTranslate.Services;
 
 namespace OverTranslate.Views.Shell;
 
@@ -75,7 +76,8 @@ public partial class TrayMenuWindow : Window
 
     public void SetRealtimeRunning(bool running)
     {
-        OpenWindowLabel.Text = running ? "即時翻譯視窗" : "開啟翻譯視窗";
+        OpenWindowLabel.Text = LocalizationService.Get(
+            running ? "S.Tray.RealtimeWindow" : "S.Tray.OpenWindow");
         OpenWindowIcon.Text = running ? PinIcon : WindowIcon;
     }
 

--- a/src/OverTranslate/Views/Shell/UpdateWindow.xaml
+++ b/src/OverTranslate/Views/Shell/UpdateWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="OverTranslate.Views.Shell.UpdateWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="發現新版本"
+        Title="{DynamicResource S.Update.WindowTitle}"
         Width="360"
         SizeToContent="Height"
         ResizeMode="CanMinimize"
@@ -23,7 +23,7 @@
                        FontSize="36" Text="&#xE895;"
                        HorizontalAlignment="Center"
                        Foreground="{DynamicResource AppAccent}"/>
-            <TextBlock Text="發現新版本！"
+            <TextBlock Text="{DynamicResource S.Update.Heading}"
                        FontFamily="{StaticResource AppFont}"
                        FontSize="18"
                        FontWeight="SemiBold"
@@ -40,7 +40,7 @@
                         <ColumnDefinition Width="70"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" Text="目前版本" Style="{StaticResource FieldLabel}"/>
+                    <TextBlock Grid.Column="0" Text="{DynamicResource S.Update.CurrentVersion}" Style="{StaticResource FieldLabel}"/>
                     <TextBlock Grid.Column="1" x:Name="CurrentVersionText"
                                FontFamily="{StaticResource AppFont}"
                                FontSize="13"
@@ -52,7 +52,7 @@
                         <ColumnDefinition Width="70"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" Text="最新版本" Style="{StaticResource FieldLabel}"/>
+                    <TextBlock Grid.Column="0" Text="{DynamicResource S.Update.LatestVersion}" Style="{StaticResource FieldLabel}"/>
                     <TextBlock Grid.Column="1" x:Name="LatestVersionText"
                                FontFamily="{StaticResource AppFont}"
                                FontSize="13"
@@ -60,7 +60,7 @@
                                Foreground="{DynamicResource AppAccent}"
                                VerticalAlignment="Center"/>
                 </Grid>
-                <TextBlock Text="點擊「立即更新」後將自動下載並套用，完成後自動重新啟動。"
+                <TextBlock Text="{DynamicResource S.Update.Explanation}"
                            FontFamily="{StaticResource AppFont}"
                            FontSize="12"
                            Foreground="{DynamicResource AppTextSecondary}"
@@ -87,11 +87,11 @@
                            Margin="0,8,0,0"
                            TextWrapping="Wrap"
                            Foreground="{DynamicResource AppTextSecondary}">
-                    想了解這次更新了什麼？<Hyperlink x:Name="ReleaseNotesLink"
+                    <Run Text="{DynamicResource S.Update.NotesBefore}"/><Hyperlink x:Name="ReleaseNotesLink"
                               Foreground="{DynamicResource AppAccent}"
                               TextDecorations="None"
                               RequestNavigate="ReleaseNotesLink_RequestNavigate"
-                              NavigateUri="https://github.com/asd880921/OverTranslate/releases/latest">查看更新內容</Hyperlink>
+                              NavigateUri="https://github.com/asd880921/OverTranslate/releases/latest"><Run Text="{DynamicResource S.Update.NotesLink}"/></Hyperlink>
                 </TextBlock>
             </StackPanel>
         </Border>
@@ -104,7 +104,7 @@
                     <ColumnDefinition Width="8"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <Button x:Name="DismissBtn" Grid.Column="0" Content="稍後再說"
+                <Button x:Name="DismissBtn" Grid.Column="0" Content="{DynamicResource S.Update.Later}"
                         Style="{StaticResource FlatButton}"
                         Height="36"
                         Click="DismissBtn_Click"/>
@@ -117,7 +117,7 @@
                                    FontSize="13" Text="&#xE896;"
                                    VerticalAlignment="Center"
                                    Margin="0,0,6,0"/>
-                        <TextBlock x:Name="DownloadBtnText" Text="立即更新"
+                        <TextBlock x:Name="DownloadBtnText" Text="{DynamicResource S.Update.Now}"
                                    FontFamily="{StaticResource AppFont}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
@@ -125,7 +125,7 @@
             </Grid>
 
             <!-- Below the pair rather than beside it, and unstyled as a link rather than a third
-                 button: 稍後再說 and 立即更新 are the two answers to the question being asked, while
+                 button: Later and Update now are the two answers to the question being asked, while
                  this one changes what the application does in future. Giving it equal weight in the
                  row would put a lasting choice one mis-click away from the dismiss button it would
                  sit next to. -->
@@ -137,7 +137,7 @@
                 <Hyperlink x:Name="SkipVersionLink"
                            Foreground="{DynamicResource AppTextSecondary}"
                            TextDecorations="None"
-                           Click="SkipVersionLink_Click">跳過此版本，不要再提醒我</Hyperlink>
+                           Click="SkipVersionLink_Click"><Run Text="{DynamicResource S.Update.Skip}"/></Hyperlink>
             </TextBlock>
         </StackPanel>
     </Grid>

--- a/src/OverTranslate/Views/Shell/UpdateWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/UpdateWindow.xaml.cs
@@ -56,7 +56,7 @@ public partial class UpdateWindow : Window
             DownloadBtn.IsEnabled = false;
             SkipVersionLink.IsEnabled = false;
             ErrorText.Visibility = Visibility.Collapsed;
-            DownloadBtnText.Text = "下載中 0%";
+            DownloadBtnText.Text = LocalizationService.Format("S.Update.Downloading", 0);
             DownloadProgress.IsIndeterminate = false;
             DownloadProgress.Value = 0;
             DownloadProgress.Visibility = Visibility.Visible;
@@ -69,11 +69,11 @@ public partial class UpdateWindow : Window
             DismissBtn.IsEnabled = true;
             DownloadBtn.IsEnabled = true;
             SkipVersionLink.IsEnabled = true;
-            DownloadBtnText.Text = "重試";
+            DownloadBtnText.Text = LocalizationService.Get("S.Update.Retry");
             DownloadProgress.BeginAnimation(System.Windows.Controls.ProgressBar.ValueProperty, null);
             DownloadProgress.IsIndeterminate = false;
             DownloadProgress.Visibility = Visibility.Collapsed;
-            ErrorText.Text = $"下載更新失敗：{ex.Message}";
+            ErrorText.Text = LocalizationService.Format("S.Update.Failed", ex.Message);
             ErrorText.Visibility = Visibility.Visible;
         }
     }
@@ -83,7 +83,7 @@ public partial class UpdateWindow : Window
         Dispatcher.Invoke(() =>
         {
             DownloadProgress.Value = percent;
-            DownloadBtnText.Text = $"下載中 {percent}%";
+            DownloadBtnText.Text = LocalizationService.Format("S.Update.Downloading", percent);
         });
     }
 
@@ -98,7 +98,7 @@ public partial class UpdateWindow : Window
         // The apply step exposes no progress at all, so an indeterminate bar is the honest signal:
         // still working, duration unknown. It keeps moving, which a bar frozen at 100% would not.
         DownloadProgress.IsIndeterminate = true;
-        DownloadBtnText.Text = "套用中…";
+        DownloadBtnText.Text = LocalizationService.Get("S.Update.Applying");
 
         // Let those two land on screen: ApplyUpdatesAndRestart blocks this thread and then kills the
         // process, so anything not painted by now is never painted at all.
@@ -109,7 +109,7 @@ public partial class UpdateWindow : Window
     {
         var completed = new TaskCompletionSource();
 
-        DownloadBtnText.Text = "下載中 100%";
+        DownloadBtnText.Text = LocalizationService.Format("S.Update.Downloading", 100);
         var toFull = new DoubleAnimation(100, TimeSpan.FromMilliseconds(280))
         {
             EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml
@@ -12,8 +12,8 @@
 
         <!-- ── Page header ── -->
         <StackPanel Grid.Row="0">
-            <TextBlock Text="文字翻譯" Style="{StaticResource PageTitle}"/>
-            <TextBlock Text="輸入或貼上文字即可翻譯，截圖結果也會送到這裡"
+            <TextBlock Text="{DynamicResource S.Translation.Title}" Style="{StaticResource PageTitle}"/>
+            <TextBlock Text="{DynamicResource S.Translation.Subtitle}"
                        Style="{StaticResource PageSubtitle}"/>
         </StackPanel>
 
@@ -29,7 +29,7 @@
                     Style="{StaticResource IconButton}"
                     Width="32" Height="32" Margin="0,0,6,0"
                     FontSize="13"
-                    ToolTip="對調語言與內容"
+                    ToolTip="{DynamicResource S.Translation.SwapTip}"
                     Click="SwapBtn_Click"/>
 
             <ComboBox x:Name="TgtLangBox"
@@ -74,9 +74,9 @@
                                     Content="🔊"
                                     Width="30" Height="26" Padding="0"
                                     Style="{StaticResource IconButton}"
-                                    ToolTip="朗讀原文"
+                                    ToolTip="{DynamicResource S.Translation.SpeakSource}"
                                     Click="SrcTtsBtn_Click"/>
-                            <TextBlock Text="原文"
+                            <TextBlock Text="{DynamicResource S.Translation.Source}"
                                        FontFamily="{StaticResource AppFont}"
                                        FontSize="12"
                                        FontWeight="SemiBold"
@@ -118,9 +118,9 @@
                                     Content="🔊"
                                     Width="30" Height="26" Padding="0"
                                     Style="{StaticResource IconButton}"
-                                    ToolTip="朗讀譯文"
+                                    ToolTip="{DynamicResource S.Translation.SpeakResult}"
                                     Click="TgtTtsBtn_Click"/>
-                            <TextBlock Text="譯文"
+                            <TextBlock Text="{DynamicResource S.Translation.Result}"
                                        FontFamily="{StaticResource AppFont}"
                                        FontSize="12"
                                        FontWeight="SemiBold"
@@ -152,7 +152,7 @@
         <DockPanel Grid.Row="3" Margin="0,12,0,0" VerticalAlignment="Center">
             <!-- Retry surfaces only when an auto-translate fails (no permanent translate button) -->
             <Button x:Name="RetryBtn"
-                    Content="↻ 重試"
+                    Content="{DynamicResource S.Translation.Retry}"
                     Style="{StaticResource FlatButton}"
                     Height="30" Padding="14,0"
                     DockPanel.Dock="Left"

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml
@@ -38,9 +38,14 @@
                       SelectedValuePath="Code"
                       VerticalContentAlignment="Center"/>
 
+            <!-- 180, not 148: sized to the longest provider name in either language
+                 ("Google Translate (RPC)"), since the English names run longer than the Chinese
+                 ones they were measured against. Fixed rather than Auto on purpose — an Auto
+                 ComboBox takes its width from the widest entry in the list, which for the language
+                 pickers beside it would be whichever language happens to have the longest name. -->
             <ComboBox x:Name="ProviderBox"
                       Style="{StaticResource ModernComboBox}"
-                      Width="148" Height="32"
+                      Width="180" Height="32"
                       SelectedValuePath="Provider"
                       VerticalContentAlignment="Center"/>
         </StackPanel>

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -181,7 +181,7 @@ public partial class TranslationPage : UserControl
         var apiKey = SettingsService.Instance.Current.ApiKey;
         if (_translationService.RequiresApiKey && string.IsNullOrWhiteSpace(apiKey))
         {
-            SetStatus("缺少 API Key — 請先在設定中輸入", isError: true);
+            SetStatus(LocalizationService.Get("S.Translation.MissingApiKey"), isError: true);
             ShowRetry(false);
             return;
         }
@@ -220,7 +220,9 @@ public partial class TranslationPage : UserControl
             // a line that says what the user can actually do; keep the original text underneath
             // so the cause is still reportable.
             SetStatus(
-                $"{LanguageData.GetProviderDisplay(provider)} 目前無法使用，請改用其他翻譯來源。\n翻譯失敗：{ex.Message}",
+                LocalizationService.Format(
+                    "S.Translation.ProviderUnavailable",
+                    LanguageData.GetProviderDisplay(provider), ex.Message),
                 isError: true);
             ShowRetry(true);
         }
@@ -233,7 +235,7 @@ public partial class TranslationPage : UserControl
         TranslatingBar.Visibility = on ? Visibility.Visible : Visibility.Collapsed;
         if (on)
         {
-            StatusText.Text       = "翻譯中…";
+            StatusText.Text       = LocalizationService.Get("S.Translation.Translating");
             StatusText.Foreground = (System.Windows.Media.Brush)FindResource("AppAccent");
         }
     }
@@ -255,7 +257,7 @@ public partial class TranslationPage : UserControl
         _ttsActiveBtn = btn;
         UpdateTtsIcons();           // show ⏹ immediately on click (don't wait for the fetch)
         try { await _tts.SpeakAsync(text, lang); }
-        catch (Exception ex) { SetStatus($"朗讀失敗：{ex.Message}", isError: true); }
+        catch (Exception ex) { SetStatus(LocalizationService.Format("S.Translation.SpeakFailed", ex.Message), isError: true); }
     }
 
     // StateChanged only needs to handle "stopped/ended/failed" — start is reflected on click.

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -314,9 +314,9 @@ public partial class TranslationPage : UserControl
 
     private void InitializeSelectors(string sourceLang, string targetLang)
     {
-        SrcLangBox.ItemsSource  = LanguageData.SourceLanguages;
-        TgtLangBox.ItemsSource  = LanguageData.TargetLanguages;
-        ProviderBox.ItemsSource = LanguageData.Providers;
+        LocalizationService.BindLocalizedItems(SrcLangBox,  LanguageData.SourceLanguages);
+        LocalizationService.BindLocalizedItems(TgtLangBox,  LanguageData.TargetLanguages);
+        LocalizationService.BindLocalizedItems(ProviderBox, LanguageData.Providers);
 
         SrcLangBox.SelectedValue  = LanguageData.GetValidSourceCode(sourceLang);
         TgtLangBox.SelectedValue  = LanguageData.GetValidTargetCode(targetLang);

--- a/tests/OverTranslate.Tests/LanguageDataTests.cs
+++ b/tests/OverTranslate.Tests/LanguageDataTests.cs
@@ -1,4 +1,5 @@
 using OverTranslate.Models;
+using OverTranslate.Services;
 using OverTranslate.Services.Providers;
 using Xunit;
 
@@ -44,6 +45,41 @@ public class LanguageDataTests
             language.Code == LanguageData.AutomaticSourceLanguage);
         Assert.Equal("AUTO", LanguageData.GetValidOcrSourceCode("auto"));
         Assert.Equal("AUTO", LanguageData.GetValidSourceCode("auto"));
+    }
+
+    /// <summary>
+    /// The realtime control bar's language pair follows the interface language; the names inside
+    /// the OpenAI prompt do not.
+    /// </summary>
+    /// <remarks>
+    /// One accessor used to serve both, which is how "英語 → 繁體中文" ended up on an English
+    /// control bar. Splitting them is the fix, and this is the line that has to stay split: the
+    /// prompt around those names is written in Chinese, and swapping only the names to English
+    /// because the user changed their buttons would alter what the model is asked to do.
+    /// </remarks>
+    [Theory]
+    [InlineData("zh-Hant", "英語", "繁體中文")]
+    [InlineData("en", "English", "Traditional Chinese")]
+    public void DisplayNames_FollowTheInterfaceLanguage_ButPromptNamesDoNot(
+        string uiLanguage, string expectedSource, string expectedTarget)
+    {
+        var settings = SettingsService.Instance.Current;
+        var original = settings.UiLanguage;
+        try
+        {
+            settings.UiLanguage = uiLanguage;
+
+            Assert.Equal(expectedSource, LanguageData.GetSourceDisplayName("EN"));
+            Assert.Equal(expectedTarget, LanguageData.GetTargetDisplayName("ZH-HANT"));
+
+            // The prompt's names stay put whichever language the interface is in.
+            Assert.Equal("英語", LanguageData.GetSourceName("EN"));
+            Assert.Equal("繁體中文", LanguageData.GetTargetName("ZH-HANT"));
+        }
+        finally
+        {
+            settings.UiLanguage = original;
+        }
     }
 
     [Theory]

--- a/tests/OverTranslate.Tests/LanguageDataTests.cs
+++ b/tests/OverTranslate.Tests/LanguageDataTests.cs
@@ -12,9 +12,11 @@ public class LanguageDataTests
         var provider = LanguageData.Providers.Single(item =>
             item.Provider == TranslationProvider.OpenAI);
 
-        Assert.Equal("OpenAI", provider.Display);
+        // The wording moved to the string dictionaries when the interface gained a second language,
+        // so what is asserted here is the wiring; StringsParityTests covers what the text says.
+        Assert.Equal("S.Provider.OpenAI", provider.DisplayKey);
         Assert.False(provider.RequiresApiKey);
-        Assert.Contains("Ollama", provider.Hint);
+        Assert.Equal("S.Provider.OpenAIHint", provider.HintKey);
     }
 
     [Fact]

--- a/tests/OverTranslate.Tests/StringsParityTests.cs
+++ b/tests/OverTranslate.Tests/StringsParityTests.cs
@@ -1,0 +1,123 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// Holds the string dictionaries to each other, so a key added to one is never left out of the
+/// other.
+/// </summary>
+/// <remarks>
+/// A missing key does not break the build and does not throw: LocalizationService.Get returns the
+/// key itself, so the mistake ships as a label reading "S.Settings.SavePath" on someone's screen.
+/// That is exactly the kind of thing nobody notices in the language they don't use, which is what
+/// this test is for.
+///
+/// The files are parsed as XML rather than loaded as ResourceDictionaries — no WPF application
+/// object is needed to compare keys, and parsing keeps the failure message pointed at the file.
+/// </remarks>
+public class StringsParityTests
+{
+    private static readonly XNamespace X = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    /// <summary>Placeholders like {0}, ignoring {} escapes.</summary>
+    private static readonly Regex Placeholder = new(@"\{(\d+)\}", RegexOptions.Compiled);
+
+    private static string ResourcesDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "OverTranslate", "Resources");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not find src/OverTranslate/Resources above {AppContext.BaseDirectory}");
+    }
+
+    private static Dictionary<string, string> Load(string fileName)
+    {
+        var path = Path.Combine(ResourcesDirectory(), fileName);
+        return XDocument.Load(path).Root!
+            .Elements()
+            .Where(e => e.Attribute(X + "Key") is not null)
+            .ToDictionary(e => e.Attribute(X + "Key")!.Value, e => e.Value);
+    }
+
+    public static readonly string ChineseFile = "Strings.zh-Hant.xaml";
+    public static readonly string EnglishFile = "Strings.en.xaml";
+
+    [Fact]
+    public void Both_dictionaries_define_exactly_the_same_keys()
+    {
+        var zh = Load(ChineseFile);
+        var en = Load(EnglishFile);
+
+        var missingFromEnglish = zh.Keys.Except(en.Keys).OrderBy(k => k).ToList();
+        var missingFromChinese = en.Keys.Except(zh.Keys).OrderBy(k => k).ToList();
+
+        Assert.True(
+            missingFromEnglish.Count == 0,
+            $"Missing from {EnglishFile}: {string.Join(", ", missingFromEnglish)}");
+        Assert.True(
+            missingFromChinese.Count == 0,
+            $"Missing from {ChineseFile}: {string.Join(", ", missingFromChinese)}");
+    }
+
+    /// <summary>
+    /// A translation that drops or invents a {0} is a FormatException at the moment the message is
+    /// shown — which is to say, on the error path, where it replaces a real diagnostic with a crash.
+    /// </summary>
+    [Fact]
+    public void Composite_formats_use_the_same_placeholders_in_both_languages()
+    {
+        var zh = Load(ChineseFile);
+        var en = Load(EnglishFile);
+
+        foreach (var (key, chinese) in zh)
+        {
+            if (!en.TryGetValue(key, out var english)) continue;
+
+            var inChinese = Placeholder.Matches(chinese).Select(m => m.Groups[1].Value).ToHashSet();
+            var inEnglish = Placeholder.Matches(english).Select(m => m.Groups[1].Value).ToHashSet();
+
+            Assert.True(
+                inChinese.SetEquals(inEnglish),
+                $"{key} uses {{{string.Join(",", inChinese.Order())}}} in {ChineseFile} " +
+                $"but {{{string.Join(",", inEnglish.Order())}}} in {EnglishFile}");
+        }
+    }
+
+    /// <summary>
+    /// The OpenAI hint is the only place the interface tells anyone that a local model is an
+    /// option, and Ollama is the route it points at. Losing that in one language loses it for
+    /// those users entirely.
+    /// </summary>
+    [Fact]
+    public void OpenAi_hint_recommends_Ollama_in_both_languages()
+    {
+        foreach (var file in new[] { ChineseFile, EnglishFile })
+            Assert.Contains("Ollama", Load(file)["S.Provider.OpenAIHint"]);
+    }
+
+    /// <summary>
+    /// Full-width punctuation is correct in Chinese and wrong in English, and it is the single
+    /// easiest thing to carry over when translating by copying a line and editing it in place.
+    /// </summary>
+    [Fact]
+    public void English_strings_use_no_full_width_punctuation()
+    {
+        var offenders = Load(EnglishFile)
+            .Where(kv => kv.Value.Any("，。：；「」（）、？！／".Contains))
+            .Select(kv => $"{kv.Key}: {kv.Value}")
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            $"Full-width punctuation in {EnglishFile}:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, offenders));
+    }
+}

--- a/tests/OverTranslate.Tests/StringsParityTests.cs
+++ b/tests/OverTranslate.Tests/StringsParityTests.cs
@@ -24,19 +24,21 @@ public class StringsParityTests
     /// <summary>Placeholders like {0}, ignoring {} escapes.</summary>
     private static readonly Regex Placeholder = new(@"\{(\d+)\}", RegexOptions.Compiled);
 
-    private static string ResourcesDirectory()
+    private static string ProjectDirectory()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null)
         {
-            var candidate = Path.Combine(dir.FullName, "src", "OverTranslate", "Resources");
-            if (Directory.Exists(candidate)) return candidate;
+            var candidate = Path.Combine(dir.FullName, "src", "OverTranslate");
+            if (Directory.Exists(Path.Combine(candidate, "Resources"))) return candidate;
             dir = dir.Parent;
         }
 
         throw new DirectoryNotFoundException(
-            $"Could not find src/OverTranslate/Resources above {AppContext.BaseDirectory}");
+            $"Could not find src/OverTranslate above {AppContext.BaseDirectory}");
     }
+
+    private static string ResourcesDirectory() => Path.Combine(ProjectDirectory(), "Resources");
 
     private static Dictionary<string, string> Load(string fileName)
     {
@@ -89,6 +91,85 @@ public class StringsParityTests
                 $"{key} uses {{{string.Join(",", inChinese.Order())}}} in {ChineseFile} " +
                 $"but {{{string.Join(",", inEnglish.Order())}}} in {EnglishFile}");
         }
+    }
+
+    /// <summary>Every "S.…" key named in XAML or code-behind.</summary>
+    /// <remarks>
+    /// Keys are looked up by string at runtime, so neither a typo nor a rename is a compile error —
+    /// the reference just resolves to nothing. DynamicResource silently renders empty and
+    /// LocalizationService.Get returns the key itself, which is how a label saying
+    /// "S.Settings.SavePath" would reach a user.
+    /// </remarks>
+    private static Dictionary<string, List<string>> KeysReferencedInSource()
+    {
+        var project = ProjectDirectory();
+        var references = new Dictionary<string, List<string>>();
+
+        var inXaml = new Regex(@"DynamicResource\s+(S\.[A-Za-z0-9_.]+)", RegexOptions.Compiled);
+        var inCode = new Regex(@"""(S\.[A-Za-z0-9_.]+)""", RegexOptions.Compiled);
+
+        foreach (var path in Directory.EnumerateFiles(project, "*.*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(project, path);
+
+            // obj/ holds generated copies of the same XAML; Resources/ is the definitions themselves.
+            if (relative.StartsWith("obj") || relative.StartsWith("bin") ||
+                relative.StartsWith("Resources")) continue;
+
+            var pattern = Path.GetExtension(path) switch
+            {
+                ".xaml" => inXaml,
+                ".cs"   => inCode,
+                _       => null
+            };
+            if (pattern is null) continue;
+
+            foreach (Match match in pattern.Matches(File.ReadAllText(path)))
+            {
+                var key = match.Groups[1].Value;
+                if (!references.TryGetValue(key, out var files))
+                    references[key] = files = [];
+                files.Add(relative);
+            }
+        }
+
+        return references;
+    }
+
+    [Fact]
+    public void Every_key_referenced_in_source_is_defined()
+    {
+        var defined = Load(ChineseFile).Keys.ToHashSet();
+
+        var missing = KeysReferencedInSource()
+            .Where(entry => !defined.Contains(entry.Key))
+            .Select(entry => $"{entry.Key} (in {string.Join(", ", entry.Value.Distinct())})")
+            .Order()
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            $"Referenced but not defined:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, missing));
+    }
+
+    /// <summary>
+    /// Catches the other half of a rename: the old key left behind in the dictionaries.
+    /// </summary>
+    [Fact]
+    public void Every_defined_key_is_referenced_somewhere()
+    {
+        var referenced = KeysReferencedInSource().Keys.ToHashSet();
+
+        var orphans = Load(ChineseFile).Keys
+            .Where(key => !referenced.Contains(key))
+            .Order()
+            .ToList();
+
+        Assert.True(
+            orphans.Count == 0,
+            $"Defined but never referenced:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, orphans));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #57

介面新增英文支援，可在設定頁即時切換，不需重啟。

## 機制

字串放在兩個 `ResourceDictionary`（`Resources/Strings.zh-Hant.xaml` / `Strings.en.xaml`），`LocalizationService` 抽換 `Application.Current.Resources.MergedDictionaries` —— 與既有的 `ThemeService` 同一套做法。XAML 走 `DynamicResource`，程式碼走 `LocalizationService.Get` / `Format`。

選用這個做法而非 `.resx` + `x:Static`，是因為本專案有多個常駐獨立視窗（Overlay、Toolbar、RealtimeBlock、TrayMenu、Toast），要求重啟才能換語言體驗過差；且日後若要改成即時切換，等於 200+ 條字串要再改一次。

`Get` 在沒有 WPF `Application` 時（單元測試、UI 建立前的背景路徑）回退到直接載入字典，固定用繁中 —— 不跟隨系統語系，否則測試結果會隨執行機器的地區設定而變。

## 範圍

- 212 個資源鍵 × 2 語言，涵蓋全部 14 個 XAML 與其 code-behind
- Services 層會冒到 UI 的 exception message 一併納入
- **不含**：`OpenAiCompatibleProvider` 的 LLM prompt（送給模型不是給人讀的）、Log 訊息

## 預設語言

首次啟動依 Windows **目前的顯示語言**（`CurrentUICulture`）決定：任何中文 → 繁中，其他 → 英文。使用者在設定頁選過之後就存進設定檔，不再看系統，換 Windows 顯示語言不會蓋掉明確的偏好。

簡中使用者拿到繁中而非英文，是刻意的：本專案沒有簡中介面，繁中對簡中讀者遠比英文近。

## 版面

- 設定頁 12 個 `ColumnDefinition Width="100"` → `Auto` + `SharedSizeGroup`。原本剛好容納四個中文字，英文標籤一律截斷
- 導覽列 208 → 240，視窗 1000×640 → 1080×640。快捷鍵在 `DockPanel` 右側先佔位，剩下才輪到標籤
- 導覽列新增可拖曳分隔線（min 200 / max 380）
- 文字翻譯頁 provider 下拉 148 → 180

視窗尺寸與導覽列寬度採 **session 記憶**（process 存活期間），不寫入設定檔：關閉視窗是把它移出畫面的常規操作（程式續留系統匣），同一次使用中重開應該回到原樣；跨重啟則回到預設值。

## 測試

新增 `StringsParityTests`（7 項）：
- 兩份字典的鍵完全一致
- composite format 的 `{0}` 佔位符兩邊相符 —— 少一個或多一個會在顯示訊息的當下拋 `FormatException`，正好是在錯誤路徑上
- 英文字典不得含全形標點
- **資源鍵引用稽核**：鍵是執行期字串查詢，打錯不會編譯錯誤，只會讓畫面顯示鍵名。這兩項測試比對原始碼中所有 `S.*` 引用與字典定義，雙向檢查缺失與孤兒

另加一項守住「控制列語言名隨介面語言、但 LLM prompt 內的語言名不隨」這條分界。

共 354 個測試通過，0 警告。

## 已知限制

即時翻譯 session 進行中切換語言，浮動控制列的文字會停在舊語言，直到下次狀態變更（暫停／繼續／編輯）。
