### PR TITLE
feat: 即時翻譯記住原文語言並開放底色不透明度

### DIFF
--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -28,6 +28,17 @@ public class AppSettings
     public string SourceLanguage { get; set; } = LanguageData.DefaultOcrSourceLanguage;
     public string TargetLanguage { get; set; } = "ZH-HANT";
     public TranslationProvider Provider { get; set; } = TranslationProvider.Microsoft;
+    /// <summary>
+    /// The language 即時翻譯 reads from, or empty for "not chosen yet".
+    /// </summary>
+    /// <remarks>
+    /// Empty rather than <see cref="LanguageData.DefaultOcrSourceLanguage"/>, which is 自動 — a mode
+    /// the realtime picker deliberately does not offer, because recognition there gets one look at a
+    /// frame and no retry. A blank field asks the question; a default would answer it badly. Only a
+    /// language the user picked themselves is ever written here, so what comes back is always an
+    /// answer they gave once.
+    /// </remarks>
+    public string RealtimeSourceLanguage { get; set; } = "";
     public string RealtimeTargetLanguage { get; set; } = LanguageData.DefaultTargetLanguage;
     public TranslationProvider RealtimeProvider { get; set; } = TranslationProvider.Microsoft;
     public string ApiKey { get; set; } = "";
@@ -83,11 +94,25 @@ public class AppSettings
     /// <summary>
     /// Realtime subtitle colours, "#RRGGBB". Unlike everything else on 即時翻譯 these are kept: which
     /// screen and how many blocks belong to one sitting, but a reader who needs yellow on dark blue
-    /// needs it every time. The scrim's alpha is not stored — see RealtimeSubtitleColors.
+    /// needs it every time.
     /// </summary>
     public string RealtimeTextColor { get; set; } = Services.Realtime.RealtimeSubtitleColors.DefaultText;
     /// <inheritdoc cref="RealtimeTextColor"/>
     public string RealtimeScrimColor { get; set; } = Services.Realtime.RealtimeSubtitleColors.DefaultScrim;
+
+    /// <summary>
+    /// How opaque the band behind the subtitle is drawn, 0–100 — see
+    /// <see cref="Services.Realtime.RealtimeSubtitleColors.MinScrimOpacity"/>.
+    /// </summary>
+    /// <remarks>
+    /// Its own key rather than an alpha channel on <see cref="RealtimeScrimColor"/>, which could have
+    /// carried one as <c>#AARRGGBB</c>. Two reasons, and the second is the one that decided it: the
+    /// colour is picked in a system dialog that has no alpha to give back, so the two values do not
+    /// arrive together; and a reader who wants the band lighter over one game and heavier over the
+    /// next is changing this and not their colour, which a combined key would make them redo.
+    /// </remarks>
+    public int RealtimeScrimOpacity { get; set; } =
+        Services.Realtime.RealtimeSubtitleColors.DefaultScrimOpacity;
 
     /// <summary>
     /// Whether the per-block framing guidance on the edit layer is unfolded. Expanded on a first run,

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -160,8 +160,9 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.PreviewText">Text will look like this on screen</sys:String>
     <sys:String x:Key="S.Realtime.TextColor">Text</sys:String>
     <sys:String x:Key="S.Realtime.ScrimColor">Background</sys:String>
+    <sys:String x:Key="S.Realtime.ScrimOpacity">Background opacity</sys:String>
     <sys:String x:Key="S.Realtime.ResetColors">Reset to defaults</sys:String>
-    <sys:String x:Key="S.Realtime.ResetColorsName">Reset colours</sys:String>
+    <sys:String x:Key="S.Realtime.ResetColorsName">Reset appearance</sys:String>
 
     <sys:String x:Key="S.Realtime.HowItWorks">How it works</sys:String>
     <sys:String x:Key="S.Realtime.Step1">1. Click "Select blocks" and drag over the areas you want translated.</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -165,8 +165,10 @@
     <sys:String x:Key="S.Realtime.PreviewText">文字會像這樣顯示在畫面上</sys:String>
     <sys:String x:Key="S.Realtime.TextColor">文字顏色</sys:String>
     <sys:String x:Key="S.Realtime.ScrimColor">底色</sys:String>
+    <!-- 「不透明度」而非「透明度」：滑桿往右是底色越厚，用「透明度」會讓數字與方向相反。 -->
+    <sys:String x:Key="S.Realtime.ScrimOpacity">底色不透明度</sys:String>
     <sys:String x:Key="S.Realtime.ResetColors">還原預設值</sys:String>
-    <sys:String x:Key="S.Realtime.ResetColorsName">還原預設顏色</sys:String>
+    <sys:String x:Key="S.Realtime.ResetColorsName">還原預設外觀</sys:String>
 
     <sys:String x:Key="S.Realtime.HowItWorks">運作方式</sys:String>
     <sys:String x:Key="S.Realtime.Step1">1. 點擊「選取翻譯區塊」，在畫面上框選要翻譯的區域。</sys:String>

--- a/src/OverTranslate/Services/Realtime/RealtimeSubtitleColors.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeSubtitleColors.cs
@@ -8,28 +8,68 @@ namespace OverTranslate.Services.Realtime;
 /// settings file.
 /// </summary>
 /// <remarks>
-/// Only the hue is the user's. The scrim's alpha is fixed here, because it is not a preference: the
-/// band exists to hide the source line underneath it, and at a lower alpha the original shows
-/// through and the reader gets two overlapping sentences — which is the feature failing at the only
-/// thing it does. A higher one would be a solid block over content the user is watching.
+/// The text colour has no alpha to speak of — it is the thing being read, so it is always fully
+/// opaque. The scrim carries one, and it is the user's.
+///
+/// It was fixed here at first, on the argument that the band exists to hide the source line
+/// underneath and a sheer one leaves the reader with two overlapping sentences. That argument is
+/// still right about subtitles burnt into a video, and wrong about everything else this feature is
+/// pointed at: a dialogue box in a game is drawn on its own opaque panel, and there the band is
+/// covering artwork rather than text. One value cannot serve both, and the person who can see the
+/// screen is the one who knows which they are looking at.
 /// </remarks>
 public static class RealtimeSubtitleColors
 {
     public const string DefaultText = "#FAFAFA";
     public const string DefaultScrim = "#000000";
 
-    /// <summary>Opaque enough to hide a subtitle, sheer enough to keep the picture behind it.</summary>
-    public const byte ScrimAlpha = 0xB8;
+    /// <summary>
+    /// The scrim's opacity as a percentage — 0 for none at all, 100 for a solid band.
+    /// </summary>
+    /// <remarks>
+    /// Stored as a percentage rather than as the alpha byte it becomes, because appsettings.json is a
+    /// file people open and edit, and <c>72</c> is a number they can reason about where <c>184</c> is
+    /// not. The rounding back and forth is lossy in the last bit and nothing here cares: the eye
+    /// cannot see one step of alpha, and nothing compares two scrims for equality.
+    ///
+    /// The floor really is zero. It lets the band be turned off entirely, which over a video means
+    /// the original subtitle showing through the translation — the failure the fixed value existed to
+    /// prevent. It is offered anyway: the preview on 顯示外觀 shows exactly that happening before the
+    /// session starts, and refusing the setting would also refuse the game panel it was released for.
+    /// </remarks>
+    public const int MinScrimOpacity = 0;
+
+    /// <inheritdoc cref="MinScrimOpacity"/>
+    public const int MaxScrimOpacity = 100;
+
+    /// <summary>
+    /// Opaque enough to hide a subtitle, sheer enough to keep the picture behind it — what the band
+    /// was fixed at before it was offered, and so what it still starts at.
+    /// </summary>
+    public const int DefaultScrimOpacity = 72;
 
     /// <summary>The translated text's colour, always fully opaque.</summary>
     public static Color Text(string? hex) => Parse(hex) ?? Parse(DefaultText)!.Value;
 
-    /// <summary>The band behind the text, at the fixed alpha above.</summary>
-    public static Color Scrim(string? hex)
+    /// <summary>The band behind the text, at the given opacity.</summary>
+    public static Color Scrim(string? hex, int opacity)
     {
         var rgb = Parse(hex) ?? Parse(DefaultScrim)!.Value;
-        return Color.FromArgb(ScrimAlpha, rgb.R, rgb.G, rgb.B);
+        return Color.FromArgb(ScrimAlpha(opacity), rgb.R, rgb.G, rgb.B);
     }
+
+    /// <summary>The alpha channel a stored opacity comes to, clamping anything out of range.</summary>
+    /// <remarks>
+    /// Clamped rather than rejected for the same reason <see cref="Parse"/> returns null rather than
+    /// throwing: a hand-edited <c>150</c> should cost the user the difference between what they typed
+    /// and full opacity, not their subtitles.
+    /// </remarks>
+    public static byte ScrimAlpha(int opacity) =>
+        (byte)Math.Round(ClampOpacity(opacity) * 255.0 / MaxScrimOpacity);
+
+    /// <inheritdoc cref="ScrimAlpha"/>
+    public static int ClampOpacity(int opacity) =>
+        Math.Clamp(opacity, MinScrimOpacity, MaxScrimOpacity);
 
     /// <summary>Back to the form stored in the settings file.</summary>
     public static string Format(Color color) =>
@@ -42,7 +82,8 @@ public static class RealtimeSubtitleColors
     /// </summary>
     /// <remarks>
     /// An eight-digit value keeps its RGB and loses its alpha instead of being rejected: someone who
-    /// writes one is asking for that colour, and the alpha is not theirs to set.
+    /// writes one is asking for that colour, and the alpha it carries is not where this reads one —
+    /// see <see cref="MinScrimOpacity"/> for the key that is.
     /// </remarks>
     private static Color? Parse(string? hex)
     {

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1282,4 +1282,97 @@
         </Style.Triggers>
     </Style>
 
+    <!-- ═══════════════════════════════════════════ -->
+    <!--  SLIDER                                     -->
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Templated rather than left to the stock one, which draws itself from the Windows classic
+         palette and would arrive as a grey Win95 track in both of this app's themes. The parts are
+         the standard ones — a Track with two RepeatButtons and a Thumb — so keyboard, page-click and
+         drag all keep working; only the paint is ours. -->
+    <Style x:Key="SliderTrackFill" TargetType="RepeatButton">
+        <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="Focusable"             Value="False"/>
+        <Setter Property="IsTabStop"             Value="False"/>
+        <Setter Property="Background"            Value="Transparent"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <!-- Transparent rather than absent, so clicking anywhere along the track still
+                         reaches the RepeatButton and pages towards the click. -->
+                    <Border Background="{TemplateBinding Background}"
+                            Height="4"
+                            CornerRadius="2"
+                            VerticalAlignment="Center"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SliderThumb" TargetType="Thumb">
+        <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="Width"  Value="16"/>
+        <Setter Property="Height" Value="16"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Ellipse x:Name="Dot"
+                             Fill="{DynamicResource AppAccent}"
+                             Stroke="{DynamicResource AppCardBg}"
+                             StrokeThickness="2"/>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Dot" Property="Fill" Value="{DynamicResource AppAccentHover}"/>
+                        </Trigger>
+                        <Trigger Property="IsDragging" Value="True">
+                            <Setter TargetName="Dot" Property="Fill" Value="{DynamicResource AppAccentPressed}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="AppSlider" TargetType="Slider">
+        <Setter Property="Height"               Value="24"/>
+        <Setter Property="SmallChange"          Value="1"/>
+        <Setter Property="LargeChange"          Value="10"/>
+        <!-- A click on the track jumps to that point rather than paging towards it. For a value the
+             user is judging by eye against a preview, "put it there" is the whole interaction. -->
+        <Setter Property="IsMoveToPointEnabled" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Slider">
+                    <Grid VerticalAlignment="Center" Background="Transparent">
+                        <Border Height="4"
+                                CornerRadius="2"
+                                VerticalAlignment="Center"
+                                Background="{DynamicResource AppInputBorder}"/>
+                        <Track x:Name="PART_Track">
+                            <Track.DecreaseRepeatButton>
+                                <!-- The filled half: the same bar as the track, painted accent, so
+                                     how far along the value sits reads without the number. -->
+                                <RepeatButton Command="Slider.DecreaseLarge"
+                                              Style="{StaticResource SliderTrackFill}"
+                                              Background="{DynamicResource AppAccent}"/>
+                            </Track.DecreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Style="{StaticResource SliderThumb}"/>
+                            </Track.Thumb>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Command="Slider.IncreaseLarge"
+                                              Style="{StaticResource SliderTrackFill}"/>
+                            </Track.IncreaseRepeatButton>
+                        </Track>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
 </ResourceDictionary>

--- a/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
@@ -75,7 +75,8 @@ public partial class RealtimeBlockWindow : Window
         string sourceLanguage,
         string targetLanguage,
         string textColor,
-        string scrimColor)
+        string scrimColor,
+        int scrimOpacity)
     {
         InitializeComponent();
 
@@ -83,7 +84,8 @@ public partial class RealtimeBlockWindow : Window
         _physBounds = physBounds;
         _latinSourceToCjkTarget = IsLatinToCjk(sourceLanguage, targetLanguage);
         _textBrush = Freeze(new SolidColorBrush(RealtimeSubtitleColors.Text(textColor)));
-        _scrimBrush = Freeze(new SolidColorBrush(RealtimeSubtitleColors.Scrim(scrimColor)));
+        _scrimBrush = Freeze(new SolidColorBrush(
+            RealtimeSubtitleColors.Scrim(scrimColor, scrimOpacity)));
 
         Loaded += (_, _) =>
         {

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml
@@ -229,6 +229,34 @@
                                     AutomationProperties.Name="{DynamicResource S.Realtime.ResetColorsName}"
                                     Click="ResetColorsBtn_Click"/>
                         </Grid>
+
+                        <!-- Full width rather than beside the colours, because it is the one control
+                             here the user sets by watching something else: the preview above is what
+                             tells them when the band is right, and a short slider makes that a
+                             fiddle. It also has a number, since "somewhere near three quarters" is
+                             not a thing anyone can write down and come back to. -->
+                        <Grid Margin="0,16,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0"
+                                       Text="{DynamicResource S.Realtime.ScrimOpacity}"
+                                       Style="{StaticResource FieldLabel}"/>
+                            <TextBlock Grid.Column="1"
+                                       x:Name="ScrimOpacityValue"
+                                       Style="{StaticResource FieldLabel}"
+                                       Margin="0"/>
+                        </Grid>
+                        <Slider x:Name="ScrimOpacitySlider"
+                                Style="{StaticResource AppSlider}"
+                                Margin="0,4,0,0"
+                                Minimum="0"
+                                Maximum="100"
+                                TickFrequency="1"
+                                IsSnapToTickEnabled="True"
+                                AutomationProperties.Name="{DynamicResource S.Realtime.ScrimOpacity}"
+                                ValueChanged="ScrimOpacitySlider_ValueChanged"/>
                     </StackPanel>
                 </Border>
 

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Interop;
 using OverTranslate.Models;
 using OverTranslate.Services;
@@ -21,20 +22,24 @@ public sealed record ScreenItem(
 /// <remarks>
 /// The page holds two kinds of value, and the line between them is the rule to keep:
 ///
-/// <para><b>Parameters of one sitting</b> — screen, block count and source language — are not read
-/// from or written to the settings file. Reopening the window must not restore a screen that may
-/// have been unplugged, blocks that no longer frame the same content, or a source language the next
-/// programme may not use.</para>
+/// <para><b>Parameters of one sitting</b> — screen and block count — are not read from or written to
+/// the settings file. Reopening the window must not restore a screen that may have been unplugged,
+/// or blocks that no longer frame the same content.</para>
 ///
-/// <para><b>Translation preferences</b> — target language and service — are stored independently
+/// <para><b>Translation preferences</b> — both languages and the service — are stored independently
 /// from screenshot and text translation. Watching a game and translating a document are different
-/// jobs with different latency and quality requirements, but choosing the same realtime target and
-/// service on every launch is needless repetition.</para>
+/// jobs with different latency and quality requirements, but choosing the same realtime pair and
+/// service on every launch is needless repetition. The source language joined them late, and it is
+/// the one with a cost: someone who watched Japanese yesterday and English today starts on the wrong
+/// one, and realtime recognition gives no sign of a mismatch beyond reading badly. It is offered
+/// back anyway because it is a language the user picked, not one guessed for them — 自動 is not in
+/// this page's picker at all — and re-picking it every sitting is the repetition this group exists
+/// to remove.</para>
 ///
-/// <para><b>Appearance preferences</b> — the subtitle's two colours, in 顯示外觀 — are stored and
-/// restored. A reader who needs yellow on dark blue needs it every session, and re-picking it each
-/// time is the same failure as forgetting a theme. They live here rather than in 設定 so the control
-/// sits beside what it changes.</para>
+/// <para><b>Appearance preferences</b> — the subtitle's two colours and how opaque its band is, in
+/// 顯示外觀 — are stored and restored. A reader who needs yellow on dark blue needs it every session,
+/// and re-picking it each time is the same failure as forgetting a theme. They live here rather than
+/// in 設定 so the control sits beside what it changes.</para>
 ///
 /// <para>Nothing on screen currently marks which card is which; 翻譯區塊 states that its value is not
 /// kept, and 顯示外觀 says nothing either way. That is a deliberate trade for a shorter card, not an
@@ -73,6 +78,15 @@ public partial class RealtimePage : UserControl
 
     private int _blockCount = MinBlocks;
 
+    // True while this page is writing the opacity slider rather than the user, so that restoring a
+    // stored value does not read as a change and write it straight back.
+    private bool _syncingOpacity;
+
+    // True between the thumb being picked up and put down. The preview follows every step of a drag;
+    // the settings file waits for the end of it, because a drag across the track is one decision and
+    // would otherwise be a hundred writes.
+    private bool _draggingOpacity;
+
     public RealtimePage()
     {
         InitializeComponent();
@@ -84,8 +98,22 @@ public partial class RealtimePage : UserControl
         // Attached after the initial value is set, so initialisation does not fire the handler
         ProviderBox.SelectionChanged += ProviderBox_SelectionChanged;
         TgtLangBox.SelectionChanged += TgtLangBox_SelectionChanged;
-        SrcLangBox.SelectionChanged += (_, _) => RenderState();
+        SrcLangBox.SelectionChanged += SrcLangBox_SelectionChanged;
 
+        // The slider's own drag events, which it forwards from its thumb rather than surfacing as
+        // properties of its own.
+        ScrimOpacitySlider.AddHandler(
+            Thumb.DragStartedEvent,
+            new DragStartedEventHandler((_, _) => _draggingOpacity = true));
+        ScrimOpacitySlider.AddHandler(
+            Thumb.DragCompletedEvent,
+            new DragCompletedEventHandler((_, _) =>
+            {
+                _draggingOpacity = false;
+                PersistScrimOpacity();
+            }));
+
+        SyncScrimOpacity();
         RenderColours();
         RenderPauseHint();
 
@@ -100,14 +128,19 @@ public partial class RealtimePage : UserControl
     /// Applies this page's independent translation preferences and per-session defaults.
     /// </summary>
     /// <remarks>
-    /// 原文語言 is left unset on purpose. Realtime recognition offers no retry once the frame has
-    /// passed, so the user has to make the source language explicit before starting a session. An
-    /// empty field asks that question instead of silently choosing an unreliable automatic mode.
+    /// 原文語言 comes back only if the user has ever set it. Empty is the state that asks the question
+    /// rather than answering it badly: realtime recognition gets one look at a frame and no retry, so
+    /// there is no silent automatic mode to fall back on here — which is why 自動 is cleared rather
+    /// than offered. <see cref="LanguageData.GetValidOcrSourceCode"/> answers 自動 for anything it
+    /// cannot place, so that one branch covers a never-set value, a hand-edited one and a code
+    /// retired since.
     /// </remarks>
     private void ApplyPageDefaults()
     {
         var settings = SettingsService.Instance.Current;
-        SrcLangBox.SelectedIndex = -1;
+        var storedSource = LanguageData.GetValidOcrSourceCode(settings.RealtimeSourceLanguage);
+        SrcLangBox.SelectedValue =
+            LanguageData.IsAutomaticSource(storedSource) ? null : storedSource;
         TgtLangBox.SelectedValue = LanguageData.GetValidTargetCode(
             settings.RealtimeTargetLanguage);
         if (TgtLangBox.SelectedValue == null)
@@ -131,8 +164,9 @@ public partial class RealtimePage : UserControl
     /// Re-run on every <see cref="Reload"/> rather than only at construction, because the item
     /// labels come from the string dictionary and the shell keeps this page for its lifetime —
     /// built once, it would still be showing the language the app started in. The selections are
-    /// carried across by hand: rebinding drops them, and unlike the other pages nothing here
-    /// restores them afterwards, because this page's choices are deliberately not persisted.
+    /// carried across by hand, because rebinding the items drops them — and dropping them here would
+    /// read as this page forgetting what the user chose the moment they changed the interface
+    /// language.
     /// </remarks>
     private void BindPickers()
     {
@@ -157,6 +191,7 @@ public partial class RealtimePage : UserControl
     {
         BindPickers();
         LoadScreens();
+        SyncScrimOpacity();
         RenderColours();
         RenderPauseHint();
         RenderState();
@@ -194,6 +229,20 @@ public partial class RealtimePage : UserControl
         if (ProviderBox.SelectedValue is TranslationProvider provider)
             SaveTranslationPreference(settings => settings.RealtimeProvider = provider);
         RenderProviderHint();
+    }
+
+    /// <remarks>
+    /// Only a real selection is written, never the momentary null that rebinding the items produces
+    /// — see <see cref="BindPickers"/>. Without that guard, changing the interface language would
+    /// blank this preference on its way past.
+    /// </remarks>
+    private void SrcLangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (SrcLangBox.SelectedValue is string sourceLanguage)
+            SaveTranslationPreference(settings =>
+                settings.RealtimeSourceLanguage = LanguageData.GetValidOcrSourceCode(sourceLanguage));
+
+        RenderState();
     }
 
     private void TgtLangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -318,7 +367,8 @@ public partial class RealtimePage : UserControl
             LanguageData.GetValidTargetCode(TgtLangBox.SelectedValue as string),
             ProviderBox.SelectedValue as TranslationProvider? ?? DefaultProvider,
             settings.RealtimeTextColor,
-            settings.RealtimeScrimColor);
+            settings.RealtimeScrimColor,
+            settings.RealtimeScrimOpacity);
 
         // The shell is handed over to be hidden: it is almost certainly sitting on the screen the
         // user is about to frame blocks on, and it comes back when the session ends.
@@ -337,12 +387,54 @@ public partial class RealtimePage : UserControl
             SettingsService.Instance.Current.RealtimeScrimColor,
             picked => Persist(s => s.RealtimeScrimColor = picked));
 
-    private void ResetColorsBtn_Click(object sender, RoutedEventArgs e) =>
+    private void ResetColorsBtn_Click(object sender, RoutedEventArgs e)
+    {
         Persist(s =>
         {
             s.RealtimeTextColor = RealtimeSubtitleColors.DefaultText;
             s.RealtimeScrimColor = RealtimeSubtitleColors.DefaultScrim;
+            s.RealtimeScrimOpacity = RealtimeSubtitleColors.DefaultScrimOpacity;
         });
+
+        // The slider is the one control here that holds its own value rather than reading it back
+        // from the settings on every render, so it has to be told.
+        SyncScrimOpacity();
+        RenderColours();
+    }
+
+    /// <summary>
+    /// Follows the thumb: the label and the preview on every step, the settings file at the end of a
+    /// drag — or immediately, when the value moved by keyboard or by a click on the track, neither of
+    /// which has an end to wait for.
+    /// </summary>
+    private void ScrimOpacitySlider_ValueChanged(
+        object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (_syncingOpacity) return;
+
+        // Persist renders on its way through, so only the held-back case has to render for itself.
+        if (_draggingOpacity) RenderColours();
+        else PersistScrimOpacity();
+    }
+
+    /// <summary>Puts the stored opacity on the slider without that reading as the user setting it.</summary>
+    private void SyncScrimOpacity()
+    {
+        _syncingOpacity = true;
+        ScrimOpacitySlider.Value = RealtimeSubtitleColors.ClampOpacity(
+            SettingsService.Instance.Current.RealtimeScrimOpacity);
+        _syncingOpacity = false;
+    }
+
+    private void PersistScrimOpacity() =>
+        Persist(s => s.RealtimeScrimOpacity = CurrentScrimOpacity);
+
+    /// <summary>
+    /// What the slider is showing, which is what the preview draws — not what is stored, because
+    /// mid-drag those are deliberately different.
+    /// </summary>
+    private int CurrentScrimOpacity =>
+        RealtimeSubtitleColors.ClampOpacity((int)Math.Round(ScrimOpacitySlider.Value));
 
     /// <summary>
     /// Opens the system colour picker on the current value and reports what came back.
@@ -380,13 +472,20 @@ public partial class RealtimePage : UserControl
     }
 
     /// <summary>
-    /// Paints the two swatches, their hex labels and the preview from what is currently stored.
+    /// Paints the two swatches, their hex labels, the opacity reading and the preview.
     /// </summary>
+    /// <remarks>
+    /// The colours come from what is stored; the opacity comes from the slider, which during a drag
+    /// is deliberately ahead of it — see <see cref="ScrimOpacitySlider_ValueChanged"/>.
+    /// </remarks>
     private void RenderColours()
     {
         var settings = SettingsService.Instance.Current;
+        var opacity = CurrentScrimOpacity;
         var text = RealtimeSubtitleColors.Text(settings.RealtimeTextColor);
-        var scrim = RealtimeSubtitleColors.Scrim(settings.RealtimeScrimColor);
+        var scrim = RealtimeSubtitleColors.Scrim(settings.RealtimeScrimColor, opacity);
+
+        ScrimOpacityValue.Text = $"{opacity}%";
 
         // The swatch shows the colour the user picked, so it is drawn opaque even for the scrim —
         // the preview below is where its translucency is on display.
@@ -402,7 +501,8 @@ public partial class RealtimePage : UserControl
 
         ResetColorsBtn.IsEnabled =
             settings.RealtimeTextColor != RealtimeSubtitleColors.DefaultText ||
-            settings.RealtimeScrimColor != RealtimeSubtitleColors.DefaultScrim;
+            settings.RealtimeScrimColor != RealtimeSubtitleColors.DefaultScrim ||
+            opacity != RealtimeSubtitleColors.DefaultScrimOpacity;
     }
 
     private void BlockCountDown_Click(object sender, RoutedEventArgs e) => StepBlockCount(-1);

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -21,6 +21,10 @@ namespace OverTranslate.Views.Realtime;
 /// arrive on the request, because a session cannot be asked to change them halfway: reaching the
 /// page that sets them means the shell window, and a running session has hidden it.
 /// </param>
+/// <param name="ScrimOpacity">
+/// How opaque the band behind the text is, 0–100. Travels with the colours for the same reason and
+/// under the same rule.
+/// </param>
 public sealed record RealtimeStartRequest(
     System.Drawing.Rectangle ScreenBounds,
     int MaxBlocks,
@@ -28,7 +32,8 @@ public sealed record RealtimeStartRequest(
     string TargetLanguage,
     Models.TranslationProvider Provider,
     string TextColor,
-    string ScrimColor);
+    string ScrimColor,
+    int ScrimOpacity);
 
 /// <summary>
 /// Owns a realtime session end to end: the edit layer, the per-block overlays, the floating control
@@ -355,7 +360,7 @@ internal sealed class RealtimeSessionController
         {
             var window = new RealtimeBlockWindow(
                 region.Id, region.Bounds, request.SourceLanguage, request.TargetLanguage,
-                request.TextColor, request.ScrimColor);
+                request.TextColor, request.ScrimColor, request.ScrimOpacity);
             _blockWindows[region.Id] = window;
             window.Show();
         }

--- a/tests/OverTranslate.Tests/RealtimeSubtitleColorsTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeSubtitleColorsTests.cs
@@ -9,6 +9,9 @@ namespace OverTranslate.Tests;
 /// </summary>
 public class RealtimeSubtitleColorsTests
 {
+    /// <summary>Any opacity will do where the test is about the colour rather than the band.</summary>
+    private const int Opacity = RealtimeSubtitleColors.DefaultScrimOpacity;
+
     [Theory]
     [InlineData("#FF8800", 0xFF, 0x88, 0x00)]
     [InlineData("#ff8800", 0xFF, 0x88, 0x00)]   // lower case
@@ -40,8 +43,9 @@ public class RealtimeSubtitleColorsTests
         // The point is that a typo costs the user their colour, not their subtitles.
         Assert.Equal(RealtimeSubtitleColors.Text(RealtimeSubtitleColors.DefaultText),
                      RealtimeSubtitleColors.Text(hex));
-        Assert.Equal(RealtimeSubtitleColors.Scrim(RealtimeSubtitleColors.DefaultScrim),
-                     RealtimeSubtitleColors.Scrim(hex));
+        Assert.Equal(
+            RealtimeSubtitleColors.Scrim(RealtimeSubtitleColors.DefaultScrim, Opacity),
+            RealtimeSubtitleColors.Scrim(hex, Opacity));
     }
 
     [Fact]
@@ -53,12 +57,34 @@ public class RealtimeSubtitleColorsTests
     }
 
     [Fact]
-    public void Scrim_always_carries_the_fixed_alpha()
+    public void Scrim_carries_the_opacity_it_is_given_whatever_the_colour_is()
     {
-        // Whatever the user picked, the band has to stay sheer enough to see through and opaque
-        // enough to hide the line underneath — that is not theirs to set.
         foreach (var hex in new[] { "#000000", "#FFFFFF", "#1E3A5F", "not a colour" })
-            Assert.Equal(RealtimeSubtitleColors.ScrimAlpha, RealtimeSubtitleColors.Scrim(hex).A);
+            Assert.Equal(
+                RealtimeSubtitleColors.ScrimAlpha(40),
+                RealtimeSubtitleColors.Scrim(hex, 40).A);
+    }
+
+    [Fact]
+    public void The_default_opacity_is_the_alpha_the_band_was_fixed_at()
+    {
+        // 0xB8 is what every session drew before this was offered, so a settings file written by an
+        // older build — which has no opacity key at all — has to come back looking the same.
+        Assert.Equal(
+            0xB8,
+            RealtimeSubtitleColors.ScrimAlpha(RealtimeSubtitleColors.DefaultScrimOpacity));
+    }
+
+    [Theory]
+    [InlineData(0, 0x00)]
+    [InlineData(100, 0xFF)]
+    [InlineData(-40, 0x00)]     // hand-edited out of range, below
+    [InlineData(150, 0xFF)]     // and above
+    public void Opacity_spans_the_whole_alpha_range_and_clamps_outside_it(int opacity, byte alpha)
+    {
+        // Clamped rather than refused for the same reason an unreadable colour falls back: a typo in
+        // a file the user is invited to edit should cost them the value, not the session.
+        Assert.Equal(alpha, RealtimeSubtitleColors.ScrimAlpha(opacity));
     }
 
     [Fact]
@@ -77,9 +103,11 @@ public class RealtimeSubtitleColorsTests
     {
         // Round-tripping the scrim is how the picker writes back what it was shown; if Format kept
         // the alpha, each save would add another set of digits for Parse to strip.
-        var stored = RealtimeSubtitleColors.Format(RealtimeSubtitleColors.Scrim("#1E3A5F"));
+        var stored = RealtimeSubtitleColors.Format(RealtimeSubtitleColors.Scrim("#1E3A5F", Opacity));
 
         Assert.Equal("#1E3A5F", stored);
-        Assert.Equal(RealtimeSubtitleColors.Scrim("#1E3A5F"), RealtimeSubtitleColors.Scrim(stored));
+        Assert.Equal(
+            RealtimeSubtitleColors.Scrim("#1E3A5F", Opacity),
+            RealtimeSubtitleColors.Scrim(stored, Opacity));
     }
 }

--- a/tests/OverTranslate.Tests/SettingsParsingTests.cs
+++ b/tests/OverTranslate.Tests/SettingsParsingTests.cs
@@ -29,6 +29,10 @@ public class SettingsParsingTests
 
         Assert.Equal(LanguageData.DefaultTargetLanguage, settings.RealtimeTargetLanguage);
         Assert.Equal(TranslationProvider.Microsoft, settings.RealtimeProvider);
+
+        // Empty rather than 自動: the realtime picker does not offer that mode, so a default here
+        // would put a value in the box that the user cannot have chosen and cannot see is wrong.
+        Assert.Equal("", settings.RealtimeSourceLanguage);
         Assert.Equal("JA", settings.TargetLanguage);
         Assert.Equal(TranslationProvider.DeepL, settings.Provider);
     }
@@ -43,6 +47,40 @@ public class SettingsParsingTests
         Assert.Equal(TranslationProvider.OpenAI, settings.RealtimeProvider);
         Assert.Equal(LanguageData.DefaultTargetLanguage, settings.TargetLanguage);
         Assert.Equal(TranslationProvider.Microsoft, settings.Provider);
+    }
+
+    [Fact]
+    public void TheRealtimeSourceLanguageIsItsOwnKey()
+    {
+        // 即時翻譯 and 截圖翻譯 read different things at different times, so what one was last pointed
+        // at says nothing about the other.
+        var settings = SettingsService.Parse(
+            """{"RealtimeSourceLanguage":"JA","SourceLanguage":"EN"}""");
+
+        Assert.Equal("JA", settings.RealtimeSourceLanguage);
+        Assert.Equal("EN", settings.SourceLanguage);
+    }
+
+    [Fact]
+    public void AFileFromBeforeTheOpacityKey_KeepsTheBandItAlwaysHad()
+    {
+        // Every build before this one drew the scrim at a fixed alpha, so a settings file carried
+        // across must not arrive at a different-looking overlay.
+        var settings = SettingsService.Parse("""{"RealtimeScrimColor":"#1E3A5F"}""");
+
+        Assert.Equal(
+            OverTranslate.Services.Realtime.RealtimeSubtitleColors.DefaultScrimOpacity,
+            settings.RealtimeScrimOpacity);
+    }
+
+    [Fact]
+    public void TheOpacityIsItsOwnKey_AndDoesNotDisturbTheScrimColour()
+    {
+        var settings = SettingsService.Parse(
+            """{"RealtimeScrimColor":"#1E3A5F","RealtimeScrimOpacity":0}""");
+
+        Assert.Equal(0, settings.RealtimeScrimOpacity);
+        Assert.Equal("#1E3A5F", settings.RealtimeScrimColor);
     }
 
     [Fact]


### PR DESCRIPTION
## 內容

### 1. 記住即時翻譯的原文語言

新增 `AppSettings.RealtimeSourceLanguage`（獨立 key，預設空字串）。

- 空字串代表「還沒選過」。不用 `AUTO` 當預設 —— 即時翻譯的下拉本來就把自動模式排除掉了，塞一個使用者選不到的值進去只會讓欄位顯示錯的東西
- 讀回來若是 `AUTO` 或認不得的碼，明確清空選取，不依賴 WPF 對「SelectedValue 找不到對應項目」的行為（猜錯的後果是「開始」按鈕在沒選語言時亮著）
- 存檔時擋掉重繫結產生的瞬間 null，否則切換介面語言會把這個偏好洗掉

**取捨**：原本刻意不記，是怕昨天看日文、今天看英文卻沒發現 —— 即時 OCR 對語言選錯不會報錯，只會讀得爛。改為記住後這個風險存在，理由已寫進 `RealtimePage` 的類別註解。

（目標語言 `RealtimeTargetLanguage` 本來就有存，本 PR 未動。）

### 2. 底色不透明度開放調整

新增 `AppSettings.RealtimeScrimOpacity`（獨立 key，0–100，預設 **72**）。

- 72 就是原本寫死的 `0xB8`，舊設定檔升上來畫面完全不變（有測試釘住）
- 存百分比而非 alpha byte：設定檔是使用者會開來改的，`72` 比 `184` 好懂
- 不跟 `RealtimeScrimColor` 合併成 `#AARRGGBB`：顏色是系統對話框選的，那個框不回傳 alpha，兩個值不是同時到齊的
- 範圍給滿 0–100 不設下限。0% 等於關掉底色，影片字幕會透出來 —— 但預覽當場看得到，而設下限會連「遊戲對話框本來就有底板」那個情境一起擋掉

UI 在「顯示外觀」兩個顏色底下：整排寬的滑桿，左標籤右百分比。拖曳時預覽與數字即時跟隨，**寫檔等放開滑鼠**（不然拖一次等於上百次寫檔）；鍵盤與點軌道則立即寫入。還原按鈕一併還原不透明度。

WPF 內建 Slider 無樣式會畫成 Win95 灰軌，因此在 `SharedStyles.xaml` 補了 `AppSlider`（沿用標準 Track / RepeatButton / Thumb 結構，鍵盤與拖曳行為不變，只換外觀）。

中文用「底色**不**透明度」而非「透明度」—— 滑桿往右是底色變厚，用「透明度」數字方向會相反。

## 驗證

- `dotnet test` 431 passed / 2 skipped（新增 8 個測試）
- `SharedStyles.xaml` 以 `XamlReader` 實際 parse 過，三個新 style 都解得到（XAML 錯誤編譯期抓不到）
- **未驗證**：滑桿在實機上的視覺與版面比例