### PR TITLE
docs: #69 OCR 行首掉字定性為已知限制，並補上偵測器的量測入口

### DIFF
--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -10,6 +10,32 @@ using SkiaSharp;
 
 namespace OverTranslate.Services.Ocr;
 
+/// <summary>
+/// KNOWN LIMITATION: the detector sometimes returns a box that starts part way along a line, and the
+/// characters before it are lost with nothing in the log to say they existed. Closed as unfixable in
+/// #69; do not spend another round looking for the setting that causes it, because it is not one.
+/// </summary>
+/// <remarks>
+/// Ruled out, each with a measurement rather than an argument: the recognition confidence floor (the
+/// leading box is never returned, so nothing filters it), all three detector box thresholds
+/// (<see cref="DetectorThresholdOverride"/> — dropping BoxScoreThresh to 0.10, which discards
+/// nothing, changes not one character), the border (<see cref="DetectorPaddingOverride"/>, 0 to 96),
+/// the normalisation statistics (<see cref="ShippedDetector"/>), the detector size
+/// (<c>--scale-sweep</c>), and how tightly the user framed the capture (<c>--margin-series</c> over
+/// 27 whole screens: 1.1% apart, and the tightest framing is the worst of them).
+///
+/// What it actually is: the response is knife-edge, and only along the short axis. On the reported
+/// frame, cropping one pixel off the top takes the reading from 5 characters to 6, and four pixels
+/// takes it to 10 — while cropping up to eight pixels off the side changes nothing at all. Appending
+/// blank rows below the picture, which touches no content whatsoever, walks the reading between 5 and
+/// 10 characters with no pattern: +4px reads 10, +20px reads 6, +24px reads 9. The capture the user
+/// happened to draw lands where it lands.
+///
+/// So a frame either reads or does not, and the deciding factor is a few pixels of height that
+/// nobody chose. Replacing the detector is the only lever left and #33 already measured that
+/// trade — PP-OCRv6_det_medium costs 90ms per recognition and 62MB to save roughly one line every
+/// two and a half minutes — and rejected it.
+/// </remarks>
 internal sealed class OnnxOcrEngine : IOcrEngine
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -414,6 +414,23 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     internal static float[] HalfNormalization => [127.5f, 127.5f, 127.5f];
 
     /// <summary>
+    /// The shipped detector and the statistics to read it with.
+    /// </summary>
+    /// <remarks>
+    /// Re-measured on PP-OCRv6_det_tiny after the detector was swapped under the choice recorded on
+    /// <see cref="HalfNormalization"/>, which had been made on PP-OCRv6_small. ImageNet looked like
+    /// the better pair on the six fixtures in this repository and read one reported failure at twice
+    /// the characters — and then lost on 137 real dumped frames: it read four of them as completely
+    /// empty that 127.5 read fine ("It's bright.", "Let's pay CiRCLE a visit on the way home.",
+    /// "ここは…？" twice), against one frame the other way whose reading was a misread anyway. The
+    /// leading-character loss that started the investigation happens under both, at about the same
+    /// rate. So 127.5 stays, and the fixtures in this repository are now known to be too small a
+    /// sample to move this on. See issue #69.
+    /// </remarks>
+    private static DetectorModel ShippedDetector(string detPath) =>
+        new(detPath, HalfNormalization, HalfNormalization);
+
+    /// <summary>
     /// Detector to load in place of the shipped one. Null — the shipped detector — everywhere but
     /// <c>OcrHarness</c>.
     /// </summary>
@@ -462,7 +479,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         EnsureModelFile(recPath);
         EnsureModelFile(dictPath);
 
-        var detector = DetectorOverride ?? new DetectorModel(detPath, HalfNormalization, HalfNormalization);
+        var detector = DetectorOverride ?? ShippedDetector(detPath);
         if (DetectorOverride is not null)
         {
             EnsureModelFile(detector.Path);
@@ -558,13 +575,61 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// </remarks>
     internal static int? DetectorPaddingOverride { get; set; }
 
-    private static RapidOcrOptions CreateOptions(int? maxDetectSize) =>
-        RapidOcrOptions.Default with
+    /// <summary>
+    /// The three thresholds that turn the detector's probability map into boxes.
+    /// </summary>
+    /// <param name="BoxThresh">
+    /// Where the probability map is cut into "text" and "not text". Higher leaves weakly answered
+    /// strokes out of the component, which is what puts a box edge inside a glyph.
+    /// </param>
+    /// <param name="BoxScoreThresh">
+    /// The mean probability a finished box must reach to be returned at all. A box under it is
+    /// dropped inside the library, before anything this class can see or count.
+    /// </param>
+    /// <param name="UnClipRatio">
+    /// How far the shrunken polygon is expanded back out. Too small and every box loses a little at
+    /// each end.
+    /// </param>
+    internal readonly record struct DetectorThresholds(
+        float BoxThresh,
+        float BoxScoreThresh,
+        float UnClipRatio);
+
+    /// <summary>
+    /// Detector post-processing thresholds to use instead of the library's, or null for the
+    /// library's own.
+    /// </summary>
+    /// <remarks>
+    /// A measurement seam for <c>OcrHarness</c>, like <see cref="DetectorPaddingOverride"/>. Nothing
+    /// in the application sets this.
+    ///
+    /// These three have never been chosen: <see cref="CreateOptions"/> overrides the detector size,
+    /// the angle classifier and the border, and everything else has been whatever
+    /// <c>RapidOcrOptions.Default</c> happened to carry. They are worth a seam because they are the
+    /// only part of the pipeline that can lose text without leaving a trace — <c>rawBlocks</c> is
+    /// counted after the library has already applied <see cref="DetectorThresholds.BoxScoreThresh"/>,
+    /// so a box it dropped is indistinguishable in the log from a box that was never found.
+    /// </remarks>
+    internal static DetectorThresholds? DetectorThresholdOverride { get; set; }
+
+    private static RapidOcrOptions CreateOptions(int? maxDetectSize)
+    {
+        var options = RapidOcrOptions.Default with
         {
             ImgResize = maxDetectSize ?? ScreenshotDetectSize,
             DoAngle = false,
             Padding = DetectorPaddingOverride ?? RapidOcrOptions.Default.Padding,
         };
+
+        return DetectorThresholdOverride is { } thresholds
+            ? options with
+            {
+                BoxThresh = thresholds.BoxThresh,
+                BoxScoreThresh = thresholds.BoxScoreThresh,
+                UnClipRatio = thresholds.UnClipRatio,
+            }
+            : options;
+    }
 
     private static List<OcrTextBlock> ConvertBlocks(TextBlock[] textBlocks)
     {

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -18,6 +18,8 @@ if (args.Length == 0)
     Console.Error.WriteLine("                  (same frame and size, cjk vs korean recognition model)");
     Console.Error.WriteLine("       OcrHarness --scale-sweep [--det <det.onnx>[:imagenet|:half]] <image.png> [...]");
     Console.Error.WriteLine("                  (reads each frame at every detector size, no translation)");
+    Console.Error.WriteLine("       OcrHarness --margin-series <wholescreen.png> [more.png ...]");
+    Console.Error.WriteLine("                  (whole screens: the same subtitle framed at a range of margins)");
     Console.Error.WriteLine("       OcrHarness --thresh-sweep <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (same frame, detector box thresholds moved one axis at a time)");
     Console.Error.WriteLine("       OcrHarness --pad-sweep <image.png> [more.png ...]");
@@ -180,6 +182,133 @@ if (args[0] == "--compare-models")
                 }
             }
         }
+    }
+
+    return 0;
+}
+
+// Margin series: one whole screen, cropped around its subtitle at a range of margins, read at each.
+//
+// The question is what the user's own framing costs. Every other sweep here starts from a region
+// somebody already drew and can only change what is done to it; this one starts from the picture the
+// region was drawn on, so the framing itself is the variable. It needs whole screens rather than
+// region dumps for that reason — a dump has already had its margin chosen.
+//
+// The subtitle is located rather than given: reading a full screen finds it along with whatever else
+// is on the picture, and the boxes in the bottom third of a video frame are the subtitle. The union
+// of those is then re-read once with room around it, because the first pass is subject to the very
+// effect being measured and its box may already be short at one end.
+if (args[0] == "--margin-series")
+{
+    using var marginOcr = new OcrService();
+
+    // Where a subtitle lives, as a fraction of the frame's height. Deliberately generous: a two-line
+    // subtitle on a 16:9 frame starts around 0.82, and a frame with the line higher up is better
+    // skipped by the character floor below than caught by a boundary drawn tightly here.
+    const double SubtitleBandTop = 0.62;
+
+    // Frames whose best reading is shorter than this are not carrying a subtitle to measure, and a
+    // series over one of them reports noise moving around rather than framing.
+    const int MinChars = 8;
+
+    int[] margins = [0, 10, 20, 30, 40, 60, 80, 120];
+    var totals = new int[margins.Length];
+    var perfect = new int[margins.Length];
+    var measured = 0;
+
+    async Task<List<OcrTextBlock>> ReadAsync(Bitmap source, System.Windows.Rect area)
+    {
+        var x = (int)Math.Max(0, area.X);
+        var y = (int)Math.Max(0, area.Y);
+        var w = (int)Math.Min(source.Width - x, area.Width);
+        var h = (int)Math.Min(source.Height - y, area.Height);
+        if (w <= 1 || h <= 1) return [];
+
+        using var crop = source.Clone(new Rectangle(x, y, w, h), source.PixelFormat);
+        return await marginOcr.TryRecognizeAsync(crop, "AUTO") ?? [];
+    }
+
+    static System.Windows.Rect Union(IEnumerable<OcrTextBlock> blocks, double offsetX, double offsetY)
+    {
+        var union = System.Windows.Rect.Empty;
+        foreach (var block in blocks)
+        {
+            var bounds = block.Bounds;
+            bounds.Offset(offsetX, offsetY);
+            union.Union(bounds);
+        }
+
+        return union;
+    }
+
+    static System.Windows.Rect Grow(System.Windows.Rect area, int margin) => new(
+        area.X - margin, area.Y - margin, area.Width + margin * 2, area.Height + margin * 2);
+
+    foreach (var path in args.Skip(1))
+    {
+        if (!File.Exists(path)) { Console.WriteLine($"(missing) {path}"); continue; }
+
+        using var image = new Bitmap(path);
+        var name = Path.GetFileName(path);
+
+        // Pass one: the whole screen, keeping only what sits in the subtitle band.
+        var whole = await ReadAsync(image, new System.Windows.Rect(0, 0, image.Width, image.Height));
+        var band = whole.Where(b => b.Bounds.Y + b.Bounds.Height / 2 > image.Height * SubtitleBandTop).ToList();
+        if (band.Count == 0) { Console.WriteLine($"{name}: no subtitle found, skipped"); continue; }
+
+        // The widest line in the band and whatever else belongs to the same subtitle — the second
+        // line of a two-line one — and nothing else. The union of the whole band would swallow the
+        // interface along the bottom of a game screen, and then the series would be measuring how
+        // well a row of buttons reads rather than the subtitle it was pointed at.
+        var anchor = band.MaxBy(b => b.Bounds.Width)!.Bounds;
+        band = band.Where(b =>
+        {
+            var bounds = b.Bounds;
+            var overlap = Math.Min(bounds.Right, anchor.Right) - Math.Max(bounds.Left, anchor.Left);
+            var near = Math.Abs(bounds.Y - anchor.Y) < anchor.Height * 2.5;
+            return near && overlap > Math.Min(bounds.Width, anchor.Width) * 0.5;
+        }).ToList();
+
+        // Pass two: the same text with room around it, which is where this box is most likely to be
+        // the whole line rather than part of one.
+        var rough = Grow(Union(band, 0, 0), 60);
+        var refinedRead = await ReadAsync(image, rough);
+        var refined = refinedRead.Count > 0 ? Union(refinedRead, rough.X, rough.Y) : Union(band, 0, 0);
+
+        var readings = new string[margins.Length];
+        var chars = new int[margins.Length];
+        for (var index = 0; index < margins.Length; index++)
+        {
+            var blocks = await ReadAsync(image, Grow(refined, margins[index]));
+            readings[index] = string.Join(" | ", blocks.Select(b => b.Text.Replace("\n", " ")));
+            chars[index] = blocks.Sum(b => b.Text.Count(c => !char.IsWhiteSpace(c)));
+        }
+
+        var best = chars.Max();
+        if (best < MinChars) { Console.WriteLine($"{name}: nothing worth measuring, skipped"); continue; }
+
+        measured++;
+        Console.WriteLine(new string('=', 78));
+        Console.WriteLine($"{name}  {image.Width}x{image.Height}  best={best} chars");
+        for (var index = 0; index < margins.Length; index++)
+        {
+            totals[index] += chars[index];
+            if (chars[index] == best) perfect[index]++;
+
+            Console.WriteLine(
+                $"  +{margins[index],3}px : {chars[index],3}/{best,-3} {readings[index]}");
+        }
+    }
+
+    if (measured > 0)
+    {
+        Console.WriteLine(new string('=', 78));
+        Console.WriteLine($"SUMMARY over {measured} frames");
+        var bestTotal = totals.Max();
+        for (var index = 0; index < margins.Length; index++)
+            Console.WriteLine(
+                $"  +{margins[index],3}px : {totals[index],5} chars ({totals[index] * 100.0 / bestTotal,5:0.0}% of best)  " +
+                $"read best on {perfect[index],3}/{measured} frames");
     }
 
     return 0;

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -18,6 +18,8 @@ if (args.Length == 0)
     Console.Error.WriteLine("                  (same frame and size, cjk vs korean recognition model)");
     Console.Error.WriteLine("       OcrHarness --scale-sweep [--det <det.onnx>[:imagenet|:half]] <image.png> [...]");
     Console.Error.WriteLine("                  (reads each frame at every detector size, no translation)");
+    Console.Error.WriteLine("       OcrHarness --thresh-sweep <image.png> [more.png ...]");
+    Console.Error.WriteLine("                  (same frame, detector box thresholds moved one axis at a time)");
     Console.Error.WriteLine("       OcrHarness --pad-sweep <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (same frame and size, a range of borders around it)");
     Console.Error.WriteLine("       OcrHarness --margin-sweep <image.png> [more.png ...]");
@@ -178,6 +180,72 @@ if (args[0] == "--compare-models")
                 }
             }
         }
+    }
+
+    return 0;
+}
+
+// Threshold sweep: the same frame read at the shipped detector size, with the three detector
+// post-processing thresholds moved one at a time around the library's defaults.
+//
+// This is the one sweep whose answer cannot be read out of the application's log. rawBlocks is
+// counted after the library has already dropped every box below BoxScoreThresh, so a subtitle whose
+// leading characters went missing looks identical to one where the detector never found them. The
+// only way to tell those apart is to move the threshold and see whether the text comes back.
+//
+// Reads as a screenshot (detect size null -> the shipped ScreenshotDetectSize) and in AUTO, which is
+// what the failing captures were: the point is to reproduce a specific report, not to re-measure the
+// realtime sizes that --scale-sweep already covers.
+if (args[0] == "--thresh-sweep")
+{
+    using var threshOcr = new OcrService();
+
+    var shipped = new OnnxOcrEngine.DetectorThresholds(
+        RapidOcrNet.RapidOcrOptions.Default.BoxThresh,
+        RapidOcrNet.RapidOcrOptions.Default.BoxScoreThresh,
+        RapidOcrNet.RapidOcrOptions.Default.UnClipRatio);
+
+    Console.WriteLine(
+        $"library defaults: boxThresh={shipped.BoxThresh:0.00} " +
+        $"boxScore={shipped.BoxScoreThresh:0.00} unclip={shipped.UnClipRatio:0.00}");
+
+    // One axis at a time, each stepping through its own range with the other two left shipped. A
+    // grid would be three times the passes for an answer nobody could read: what is being asked
+    // first is which of the three is even involved.
+    var runs = new List<(string Axis, OnnxOcrEngine.DetectorThresholds Value)>();
+    foreach (var boxThresh in new[] { 0.10f, 0.15f, 0.20f, 0.25f, 0.30f, 0.40f, 0.50f })
+        runs.Add(($"boxThresh={boxThresh:0.00}", shipped with { BoxThresh = boxThresh }));
+    foreach (var boxScore in new[] { 0.10f, 0.20f, 0.30f, 0.40f, 0.50f, 0.60f })
+        runs.Add(($"boxScore ={boxScore:0.00}", shipped with { BoxScoreThresh = boxScore }));
+    foreach (var unclip in new[] { 1.5f, 1.75f, 2.0f, 2.25f, 2.5f, 3.0f })
+        runs.Add(($"unclip   ={unclip:0.00}", shipped with { UnClipRatio = unclip }));
+
+    foreach (var path in args.Skip(1))
+    {
+        if (!File.Exists(path)) { Console.WriteLine($"(missing) {path}"); continue; }
+
+        using var image = new Bitmap(path);
+        Console.WriteLine(new string('=', 78));
+        Console.WriteLine($"{Path.GetFileName(path)}  {image.Width}x{image.Height}  detect=screenshot");
+
+        foreach (var (axis, thresholds) in runs)
+        {
+            OnnxOcrEngine.DetectorThresholdOverride = thresholds;
+
+            List<OcrTextBlock>? blocks = null;
+            for (var attempt = 0; attempt < 20 && blocks is null; attempt++)
+                blocks = await threshOcr.TryRecognizeAsync(image, "AUTO");
+
+            var chars = blocks?.Sum(b => b.Text.Count(c => !char.IsWhiteSpace(c))) ?? 0;
+            var text = blocks is null || blocks.Count == 0
+                ? ""
+                : "  " + string.Join(" | ", blocks.Select(b => b.Text.Replace("\n", " ")));
+            var mark = thresholds == shipped ? " <- shipped" : "";
+
+            Console.WriteLine($"  {axis} : {blocks?.Count ?? -1} box chars={chars,3}{mark}{text}");
+        }
+
+        OnnxOcrEngine.DetectorThresholdOverride = null;
     }
 
     return 0;


### PR DESCRIPTION
## 這個 PR 不修任何使用者看得到的行為

出貨參數一項未動。回報的「OCR 漏掉行首文字」在合併後與合併前完全一樣。

交付的是**問題的定性、兩個量測工具，以及擋住重走成本的紀錄**。調查過程在 #69，已以「已知限制」結案。

## 為什麼不修

問題不是設錯的參數，是偵測器的刀鋒式行為，而且只發生在垂直軸。

同一張圖，只移動裁切邊界幾個像素，**文字本身完全沒變**：

| 水平裁掉 | 讀到 | 垂直裁掉 | 讀到 |
|---------|------|---------|------|
| 0 ~ 8 px | `ゃあ次はね` (5)，完全沒變 | 1 px | `じゃあ次はね` (6) |
| | | 3 px | `ん、じゃあ次はね` (8) |
| | | **4 px** | **`「うん、じゃあ次はね` (10)** |

只在下方補純黑列（不動任何內容）則在 5 到 10 字之間亂走，沒有單調性也沒有對齊格線的週期：`+4px → 10`、`+20px → 6`、`+24px → 9`、`+32px → 7`。

一張畫格會不會讀到行首，取決於幾個像素的高度差——而那是使用者隨手框出來的。這解釋了為什麼同一句要框好幾輪才重現、為什麼截圖與即時翻譯都有、以及為什麼所有參數都調不動它。

## 排除清單（每一項都有實測，不是推論）

| 變因 | 方法 | 結果 |
|------|------|------|
| 辨識信心門檻 | 程式路徑 | 行首那塊從未被回傳，沒有東西過濾它 |
| `BoxScoreThresh` | 0.10 ~ 0.60 | 降到 0.10（等於不丟）一個字都沒變 |
| `BoxThresh` | 0.10 ~ 0.50 | 無效 |
| `UnClipRatio` | 1.5 ~ 3.0 | 只多回標點 |
| 邊框 padding | 0 ~ 96 | 無效 |
| 正規化統計值 | 137 張實際畫格 | ImageNet 更糟（4 張全空 vs 1 張） |
| 偵測尺度 | 30% ~ 100% | 跳動，無穩定值 |
| 框選留白 | 27 張完整畫面 | 差 1.1%，且貼齊文字最差 |
| 裝飾線干擾 | 塗黑 | 無效 |
| 水平位移 | 0 ~ 8 px | 完全無感 |
| 垂直位移 / 補黑 | 0 ~ 48 px | 亂走，無規律 |

調查中途曾兩度以為找到解法（改用 ImageNet 正規化、修改框選指引），兩個都被後續較大樣本的量測推翻，過程完整記在 #69。

## 變更內容

### 1. `OcrHarness --thresh-sweep`
偵測器的三個後處理門檻先前沒有任何量測入口，而它們是 pipeline 中唯一能無痕跡吃掉文字的一層——`rawBlocks` 是在 library 套用 `BoxScoreThresh` **之後**才數的，所以被它丟掉的框在日誌裡與「從未偵測到」無法區分。新增 `OnnxOcrEngine.DetectorThresholdOverride` seam。

### 2. `OcrHarness --margin-series`
餵完整螢幕畫面，自動定位字幕後以遞增留白裁切再讀。其他 sweep 都是從已經框好的區域出發，只能改變「對它做什麼」；這個是從畫面出發，讓**框選方式本身**變成變因。

### 3. `OnnxOcrEngine` 類別註解
記下已知限制與完整排除清單，明講不要再花一輪找那個參數。

## 何時值得重開

出現體積與速度可接受的新偵測模型時。換偵測器是唯一剩下的槓桿，而 #33 已經量過並否決現有選項（PP-OCRv6_det_medium：每次辨識多 90ms、62MB，只換到「每 2.5 分鐘少漏一句」）。

不值得重開的：再調一次參數。

## 驗證
- `dotnet build`：0 warning、0 error
- 測試：450 passed / 2 skipped
- 出貨路徑無行為變更（`ShippedDetector()` 只是把原本那行抽成方法，參數仍是 `HalfNormalization`）
