### PR TITLE
fix: #73 譯文不再被截斷成「…」，塞不下時改為換行

### DIFF
--- a/src/OverTranslate/Layout/OverlayBubbleHeight.cs
+++ b/src/OverTranslate/Layout/OverlayBubbleHeight.cs
@@ -1,0 +1,44 @@
+namespace OverTranslate.Layout;
+
+/// <summary>
+/// How tall a screenshot-overlay bubble is drawn once its translation has been wrapped.
+/// </summary>
+/// <remarks>
+/// Three things pull on the number and they disagree, which is why it is worth naming: the bubble
+/// has to cover its own source, it should not reach over the block below, and it must hold the text
+/// that was put in it. The bubble clips its contents, so the last of those is not a preference —
+/// losing to it is the truncation of issue #73 arriving by a second route, without even a "…" to
+/// show the reader that something went missing.
+/// </remarks>
+internal static class OverlayBubbleHeight
+{
+    /// <param name="sourceBorderHeight">The block's own height: what has to stay covered.</param>
+    /// <param name="preferredHeight">
+    /// What the bubble would be without a neighbour to consider — never below
+    /// <paramref name="sourceBorderHeight"/>.
+    /// </param>
+    /// <param name="wrappedTextHeight">What the wrapped translation needs, padding included.</param>
+    /// <param name="capHeight">
+    /// Room before the block below, or null when nothing is under this one.
+    /// </param>
+    public static double ForWrapped(
+        double sourceBorderHeight,
+        double preferredHeight,
+        double wrappedTextHeight,
+        double? capHeight)
+    {
+        var wanted = Math.Max(preferredHeight, wrappedTextHeight);
+        if (capHeight is not { } cap) return wanted;
+
+        // Never below the source's own height. When the next block sits right under a multi-line
+        // source the cap comes out slightly shorter than the source, and clamping to it left the
+        // last source line uncovered, with the original text bleeding through. Covering one's own
+        // source wins over not touching a neighbour — that neighbour draws its own opaque bubble
+        // over the overlap anyway.
+        //
+        // And never below the text. Reaching that floor means no size the caller tried fitted the
+        // cap, so the choice left is between a bubble that grows past its neighbour and a sentence
+        // that stops early. The bubble is the one the user can see and act on.
+        return Math.Max(wrappedTextHeight, Math.Min(wanted, Math.Max(cap, sourceBorderHeight)));
+    }
+}

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
@@ -321,6 +321,11 @@ public partial class OverlayWindow : Window
                     SingleLineReadableMinFontSize,
                     SingleLineAbsoluteMinFontSize));
 
+                // Kept because the wrapped fallback below starts its search from here rather than
+                // from what the single-line attempt narrowed the font to. Wrapping trades width for
+                // height, so the size that was too wide for one line is often perfectly fine on two.
+                var sourceMatchedFontSize = fontSize;
+
                 fontSize = layout.FontSize;
                 targetBorderW = layout.BorderWidth;
                 preferRightExpansion = layout.PreferRightExpansion;
@@ -328,25 +333,37 @@ public partial class OverlayWindow : Window
                 var finalSingleLineMeasure = MeasureText(block.TranslatedText, typeface, fontSize);
                 var singleLineInnerWidth = Math.Max(1, targetBorderW - BubbleHorizontalPadding);
                 var stillOverflowsSingleLine = finalSingleLineMeasure.Width > singleLineInnerWidth;
-                if (stillOverflowsSingleLine)
+                // Scaling the size by the width ratio treats text width as exactly proportional to
+                // font size, and it is not — hinting and rounding leave the result a fraction over
+                // often enough to matter. One pass therefore came back still overflowing by a pixel
+                // or two, which was enough for CharacterEllipsis to take the line's last character
+                // off a line that had every appearance of fitting. Converging instead keeps it, and
+                // keeps it on one line, which the wrapped fallback below would not.
+                var emergencyFloor = Math.Min(fontSize, SingleLineEmergencyMinFontSize);
+                for (var attempt = 0; attempt < 3 && stillOverflowsSingleLine; attempt++)
                 {
-                    var fittedFontSize = fontSize * singleLineInnerWidth / finalSingleLineMeasure.Width;
-                    if (fittedFontSize >= SingleLineEmergencyMinFontSize)
-                    {
-                        fontSize = fittedFontSize;
-                        finalSingleLineMeasure = MeasureText(block.TranslatedText, typeface, fontSize);
-                        stillOverflowsSingleLine = finalSingleLineMeasure.Width > singleLineInnerWidth;
-                    }
-                    else if (fontSize > SingleLineEmergencyMinFontSize)
-                    {
-                        fontSize = SingleLineEmergencyMinFontSize;
-                        finalSingleLineMeasure = MeasureText(block.TranslatedText, typeface, fontSize);
-                        stillOverflowsSingleLine = finalSingleLineMeasure.Width > singleLineInnerWidth;
-                    }
+                    var fitted = Math.Max(
+                        emergencyFloor, fontSize * singleLineInnerWidth / finalSingleLineMeasure.Width);
+                    if (fitted >= fontSize) break;
+
+                    fontSize = fitted;
+                    finalSingleLineMeasure = MeasureText(block.TranslatedText, typeface, fontSize);
+                    stillOverflowsSingleLine = finalSingleLineMeasure.Width > singleLineInnerWidth;
                 }
 
-                if (stillOverflowsSingleLine && !HasLowerOverlappingBlock(block, blocks))
+                if (stillOverflowsSingleLine)
                 {
+                    // Not even the emergency size fits this on one line, so it wraps. That used to
+                    // be conditional — nothing overlapping below, at most two lines, and the result
+                    // had to fit the gap — and every case that failed a condition fell through to
+                    // CharacterEllipsis, which threw the tail of the sentence away. A paragraph read
+                    // as separate lines failed the first condition on all but its last line, so the
+                    // commonest shape of text on a page was also the one that lost the most.
+                    //
+                    // Nothing here is worth losing text over. A bubble that grows too far is visible
+                    // and the user can re-select; a trimmed one reads as a finished sentence that
+                    // happens to say something else, and there is no sign anything went missing.
+                    wrap = true;
                     var maxBorderHeight = GetBottomAvailableHeight(
                         block,
                         blocks,
@@ -356,23 +373,19 @@ public partial class OverlayWindow : Window
                         selScreenY,
                         selScreenHeight,
                         canvasHeight);
-                    var wrappedLineCount = EstimateWrappedLineCount(
-                        block.TranslatedText,
-                        typeface,
-                        fontSize,
-                        singleLineInnerWidth);
-                    var wrappedMeasure = MeasureText(
-                        block.TranslatedText,
-                        typeface,
-                        fontSize,
-                        singleLineInnerWidth);
-                    var wrappedBorderHeight = wrappedMeasure.Height + BubbleVerticalPadding;
+                    maxWrapBorderHeight = maxBorderHeight;
 
-                    if (wrappedLineCount <= 2 && wrappedBorderHeight <= maxBorderHeight)
-                    {
-                        wrap = true;
-                        maxWrapBorderHeight = maxBorderHeight;
-                    }
+                    // Largest size whose wrapped form still fits the gap. The line count is left
+                    // unbounded because the gap is the real constraint: this bubble replaces one
+                    // source line, so every extra line is height borrowed from what sits below.
+                    fontSize = FindLargestGroupedFontSize(
+                        block.TranslatedText,
+                        typeface,
+                        sourceMatchedFontSize,
+                        SingleLineAbsoluteMinFontSize,
+                        singleLineInnerWidth,
+                        int.MaxValue,
+                        maxBorderHeight);
                 }
             }
             else
@@ -383,6 +396,22 @@ public partial class OverlayWindow : Window
                     if (scaledFont >= minFontSize)
                     {
                         fontSize = scaledFont;
+
+                        // The same non-proportionality the single-line path above converges around,
+                        // and this branch never re-measured at all: the size it settled on was taken
+                        // on trust, and whatever it was over by came off the end of the line. Wrap
+                        // only if converging cannot close the gap.
+                        var fitted = MeasureText(block.TranslatedText, typeface, fontSize);
+                        for (var attempt = 0; attempt < 3 && fitted.Width > innerW; attempt++)
+                        {
+                            var next = Math.Max(minFontSize, fontSize * innerW / fitted.Width);
+                            if (next >= fontSize) break;
+
+                            fontSize = next;
+                            fitted = MeasureText(block.TranslatedText, typeface, fontSize);
+                        }
+
+                        if (fitted.Width > innerW) wrap = true;
                     }
                     else
                     {
@@ -392,20 +421,26 @@ public partial class OverlayWindow : Window
                 }
             }
 
+            // A translation can arrive with a line break already in it: a local model that answered
+            // over two lines, an engine echoing a break out of the source. NoWrap does not ignore
+            // one — the TextBlock still breaks there — and the bubble was only ever built one line
+            // tall, so everything after the break was outside it. That is what CharacterEllipsis
+            // showed as a "…" at the end of the first line, and it is the shape of the report that
+            // opened #73: not a word missing, the rest of the sentence missing.
+            //
+            // Wrapping is what makes the height below count every line the text really has.
+            if (!wrap && HasLineBreak(block.TranslatedText)) wrap = true;
+
             double actualBorderH = Math.Max(borderH, fontSize + BubbleVerticalPadding);
             if (wrap)
             {
                 innerW = Math.Max(1, targetBorderW - BubbleHorizontalPadding);
                 var wrapMeasured = MeasureText(block.TranslatedText, typeface, fontSize, innerW);
-                actualBorderH = Math.Max(actualBorderH, wrapMeasured.Height + BubbleVerticalPadding);
-                if (maxWrapBorderHeight.HasValue)
-                    // Cap growth so a longer translation does not spill over the block below — but
-                    // never below borderH (the source's own height). When the next block sits right
-                    // under a multi-line source, maxWrapBorderHeight is slightly shorter than the
-                    // source, and clamping to it left the last source line uncovered (original text
-                    // bleeding through). Covering one's own source wins over not touching a neighbour;
-                    // that neighbour's own opaque bubble covers it.
-                    actualBorderH = Math.Min(actualBorderH, Math.Max(maxWrapBorderHeight.Value, borderH));
+                actualBorderH = OverlayBubbleHeight.ForWrapped(
+                    borderH,
+                    actualBorderH,
+                    wrapMeasured.Height + BubbleVerticalPadding,
+                    maxWrapBorderHeight);
             }
 
             var backgroundBorder = new Border
@@ -431,7 +466,10 @@ public partial class OverlayWindow : Window
                     FontWeight = FontWeights.SemiBold,
                     Foreground = textBrush,
                     TextWrapping = wrap ? TextWrapping.Wrap : TextWrapping.NoWrap,
-                    TextTrimming = wrap ? TextTrimming.None : TextTrimming.CharacterEllipsis,
+                    // Never trimmed. Every path that cannot fit the text on one line now wraps, so
+                    // reaching here without wrap means it already fits; leaving CharacterEllipsis on
+                    // would only mean that a measurement being a pixel out costs the user a word.
+                    TextTrimming = TextTrimming.None,
                     VerticalAlignment = VerticalAlignment.Center,
                     FontFamily = new System.Windows.Media.FontFamily("Microsoft JhengHei, Segoe UI, Sans-Serif"),
                 }
@@ -457,6 +495,8 @@ public partial class OverlayWindow : Window
         BubbleBackgroundCanvas.Visibility = visibility;
         BubbleTextCanvas.Visibility = visibility;
     }
+
+    private static bool HasLineBreak(string text) => text.Contains('\n') || text.Contains('\r');
 
     private static bool IsSingleLineSource(string originalText, double sourceHeight) =>
         !originalText.Contains('\n') &&

--- a/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
@@ -237,10 +237,18 @@ public partial class RealtimeBlockWindow : Window
         // on its source grows in both directions, so what bounds it is the block, and RealtimeBandPlacement
         // is what keeps it inside. Leaving the scrim's own padding out means the band fits exactly.
         double maxWidth = Math.Max(20, canvasWidth - ScrimPaddingX * 2);
+
+        // This window is exactly the block the user drew, so a band taller than this is not merely
+        // untidy — the part past the edge is not rendered at all. Only the wrapped fallback below
+        // needs it; a single line is bounded by its source's own height long before it gets close.
+        double maxTextHeight = Math.Max(lineHeight, canvasHeight - ScrimPaddingY * 2);
         var typeface = new Typeface(TextFont, FontStyles.Normal, FontWeights.SemiBold, FontStretches.Normal);
 
         double textWidth;
         double textHeight;
+        // A grouped block wraps by definition; a single source line only wraps when it has run out
+        // of every other way to stay whole, which the branch below decides.
+        bool wrapped = isGrouped;
         if (isGrouped)
         {
             // Keep the group's own width and let the translation wrap inside it, shrinking only if
@@ -258,16 +266,49 @@ public partial class RealtimeBlockWindow : Window
             // buys legibility with the picture.
             fontSize = Math.Max(MinFontSize, Math.Min(fontSize, lineHeight * MaxHeightOverSource / LineHeightRatio));
 
+            // Kept because the wrapped fallback searches from here, not from whatever the width
+            // shrink below left behind: wrapping buys width back, so a size that was too wide for
+            // one line is often comfortable across two.
+            double sourceMatchedFontSize = fontSize;
+
             var measured = Measure(line.TranslatedText, typeface, fontSize, null);
             if (measured.Width > maxWidth)
             {
                 // Shrink to fit the room to the right of the source, down to the readability floor.
-                // Past that the line is trimmed instead: an unreadable full line helps nobody.
                 fontSize = Math.Max(MinFontSize, fontSize * maxWidth / measured.Width);
                 measured = Measure(line.TranslatedText, typeface, fontSize, null);
             }
-            textWidth = Math.Min(maxWidth, measured.Width);
-            textHeight = measured.Height;
+
+            if (measured.Width > maxWidth)
+            {
+                // At the readability floor and still wider than the block. This used to be where the
+                // line was trimmed, on the reasoning that an unreadable full line helps nobody — but
+                // the line that got trimmed was readable, just too long, and what it turned into was
+                // a sentence that ends early with nothing to say so. Over live video there is no
+                // still to go back to and no way to notice, which makes it the worse of the two.
+                //
+                // So it wraps instead. The band grows, bounded by the block the user drew.
+                wrapped = true;
+                fontSize = FitWrapped(
+                    line.TranslatedText, typeface, sourceMatchedFontSize, maxWidth, maxTextHeight);
+
+                // The band is only as wide as the widest line the wrap actually produced, not the
+                // whole block — the same reason a single line is not stretched to fill it. One pixel
+                // of slack so rounding cannot leave the TextBlock a hair narrower than the measure.
+                var acrossTheBlock = Measure(line.TranslatedText, typeface, fontSize, maxWidth);
+                textWidth = Math.Min(maxWidth, acrossTheBlock.Width + 1);
+
+                // Measured again at the width the TextBlock is actually given. Narrowing the band to
+                // the widest line can change where a line breaks, and a height taken from the wider
+                // measurement would then be one line short — with the box clipping, that is the
+                // trimmed tail back again by another route.
+                textHeight = Measure(line.TranslatedText, typeface, fontSize, textWidth).Height;
+            }
+            else
+            {
+                textWidth = Math.Min(maxWidth, measured.Width);
+                textHeight = measured.Height;
+            }
         }
 
         double scrimWidth = textWidth + ScrimPaddingX * 2;
@@ -306,8 +347,11 @@ public partial class RealtimeBlockWindow : Window
                 FontSize = fontSize,
                 FontWeight = FontWeights.SemiBold,
                 Foreground = _textBrush,
-                TextWrapping = isGrouped ? TextWrapping.Wrap : TextWrapping.NoWrap,
-                TextTrimming = isGrouped ? TextTrimming.None : TextTrimming.CharacterEllipsis,
+                TextWrapping = wrapped ? TextWrapping.Wrap : TextWrapping.NoWrap,
+                // Never trimmed. A line that cannot fit on one line has already been switched to
+                // wrapping above, so getting here without it means the text fits; leaving
+                // CharacterEllipsis on would only mean a measurement a pixel out costs a word.
+                TextTrimming = TextTrimming.None,
                 VerticalAlignment = VerticalAlignment.Center,
             }
         };
@@ -321,8 +365,14 @@ public partial class RealtimeBlockWindow : Window
         return new LineVisual(scrim, text);
     }
 
-    // Largest size at which the wrapped translation still fits the height its source occupied, so a
-    // grouped block does not push its scrim over whatever sits below it.
+    // Largest size at which the wrapped translation still fits the height it is allowed. For a
+    // grouped block that is the height its source occupied, so its scrim does not push over
+    // whatever sits below; for a single line forced to wrap it is the whole block, which is this
+    // window, so anything taller is cut off by the window edge.
+    //
+    // Returning MinFontSize when nothing fits is deliberate. The floor is where text stops being
+    // readable, and going under it to win back a few pixels trades one unreadable result for
+    // another; a band that overflows a block drawn too tight is at least visibly that.
     private double FitWrapped(
         string text, Typeface typeface, double preferredFontSize, double width, double maxHeight)
     {

--- a/tests/OverTranslate.Tests/OverlayBubbleHeightTests.cs
+++ b/tests/OverTranslate.Tests/OverlayBubbleHeightTests.cs
@@ -1,0 +1,67 @@
+using OverTranslate.Layout;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The screenshot overlay's half of issue #73: a bubble is never shorter than the text inside it.
+/// </summary>
+/// <remarks>
+/// The visible symptom was <c>TextTrimming.CharacterEllipsis</c>, and removing it was only half the
+/// fix — the bubble clips its contents, so a height capped to the gap above the next block dropped
+/// the tail just as thoroughly, and silently. Both halves have to hold for a translation to survive.
+/// </remarks>
+public class OverlayBubbleHeightTests
+{
+    // A one-line source and a translation that wrapped onto three: the shape the bug needed.
+    private const double SourceHeight = 30;
+    private const double PreferredHeight = 30;
+    private const double WrappedTextHeight = 74;
+
+    [Fact]
+    public void With_nothing_below_it_the_bubble_grows_to_the_text()
+    {
+        Assert.Equal(
+            WrappedTextHeight,
+            OverlayBubbleHeight.ForWrapped(SourceHeight, PreferredHeight, WrappedTextHeight, null));
+    }
+
+    [Fact]
+    public void A_gap_that_the_text_fits_in_is_respected()
+    {
+        // 74 of text with 90 of room: the bubble takes what it needs and leaves the rest.
+        Assert.Equal(
+            WrappedTextHeight,
+            OverlayBubbleHeight.ForWrapped(SourceHeight, PreferredHeight, WrappedTextHeight, 90));
+    }
+
+    [Fact]
+    public void A_gap_too_small_for_the_text_does_not_cut_it_off()
+    {
+        // The old clamp returned 40 here and the bubble clipped the third line away. Reaching this
+        // means no font size the caller tried fitted the gap, so the bubble grows past its
+        // neighbour — which the reader can see, unlike the missing half of a sentence.
+        Assert.Equal(
+            WrappedTextHeight,
+            OverlayBubbleHeight.ForWrapped(SourceHeight, PreferredHeight, WrappedTextHeight, 40));
+    }
+
+    [Fact]
+    public void A_bubble_never_shrinks_below_the_source_it_covers()
+    {
+        // A block sitting directly under a multi-line source makes the gap shorter than the source
+        // itself. Clamping to it left the last source line showing through from underneath.
+        Assert.Equal(
+            SourceHeight,
+            OverlayBubbleHeight.ForWrapped(SourceHeight, PreferredHeight, 24, 18));
+    }
+
+    [Fact]
+    public void Room_beyond_what_the_bubble_wants_is_left_alone()
+    {
+        // The cap is a ceiling, not a target: a bubble does not cover picture it has no text for.
+        Assert.Equal(
+            PreferredHeight,
+            OverlayBubbleHeight.ForWrapped(SourceHeight, PreferredHeight, 22, 400));
+    }
+}

--- a/tests/OverTranslate.Tests/OverlayTextFittingTests.cs
+++ b/tests/OverTranslate.Tests/OverlayTextFittingTests.cs
@@ -1,0 +1,198 @@
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using OverTranslate.Services;
+using OverTranslate.Services.Realtime;
+using OverTranslate.Views.Realtime;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The one promise both overlays make about the text they draw: all of it is on screen.
+/// </summary>
+/// <remarks>
+/// <para>Both used to finish a line that would not fit with <c>TextTrimming.CharacterEllipsis</c>,
+/// which is the worst failure available to them — the reader is shown a sentence that ends, and
+/// nothing tells them it ended early. See issue #73.</para>
+///
+/// <para>These build the real window and read back the visual tree it produced rather than
+/// re-deriving its arithmetic. What is in question is whether the numbers agree with the box WPF
+/// actually lays out, and a test that recomputed them would agree with itself whatever shipped.</para>
+///
+/// <para>Realtime only. The screenshot overlay resolves <c>{StaticResource AppFont}</c> as its XAML
+/// loads, so constructing it needs an <see cref="Application"/> — process-wide state this suite
+/// deliberately keeps out, for the reasons in AssemblyInfo. Its half of the same fix is covered by
+/// <see cref="OverlayBubbleHeightTests"/> and by running it.</para>
+/// </remarks>
+public class OverlayTextFittingTests
+{
+    // Roughly a subtitle band: wide, and tall enough for the line plus the air the in-app guidance
+    // asks the user to leave.
+    private static readonly System.Drawing.Rectangle SubtitleBlock = new(200, 800, 900, 70);
+
+    // Long enough that the readability floor cannot squeeze it onto one line of a 900px block:
+    // ~160 CJK glyphs against the ~105 that fit at 8.5px. Below that the shrink absorbs everything
+    // and the trimming this file is about never came up.
+    private const string RunOnTranslation =
+        "嗯，那麼接下來呢，我們就照著剛才已經討論好的順序，一項一項慢慢地把它處理完畢吧，這樣一來應該就不會有" +
+        "任何遺漏了，也比較不會浪費彼此的時間，你覺得這樣安排可以嗎，如果沒有問題的話我們現在就開始動手，有任" +
+        "何想法都可以隨時提出來一起討論";
+
+    [Fact]
+    public void A_translation_that_fits_is_still_drawn_on_one_line()
+    {
+        var drawn = Draw(Line("そうだね", "說得也是", new Rect(20, 15, 300, 34)));
+
+        Assert.False(drawn.Wrapped);
+    }
+
+    [Fact]
+    public void A_translation_too_long_for_one_line_wraps_instead_of_being_trimmed()
+    {
+        var drawn = Draw(Line("うん、じゃあ次はね", RunOnTranslation, new Rect(20, 15, 860, 34)));
+
+        Assert.True(drawn.Wrapped);
+
+        // Wrapping buys width back, so the size it settles on is well above the floor a single line
+        // would have been ground down to. Getting the floor here would mean the search below the
+        // wrap is picking up the shrunken size instead of the source-matched one.
+        Assert.True(drawn.FontSize > 10, $"wrapped at {drawn.FontSize:0.##}px");
+    }
+
+    /// <summary>
+    /// A block drawn too tight for the translation at any readable size. The band overflows it,
+    /// which is visible and the user can redraw; the text itself stays whole.
+    /// </summary>
+    [Fact]
+    public void A_block_too_small_for_any_readable_size_still_keeps_the_whole_sentence()
+    {
+        var drawn = Draw(
+            Line("Hi", RunOnTranslation, new Rect(2, 2, 160, 18)),
+            block: new System.Drawing.Rectangle(0, 0, 170, 40));
+
+        Assert.True(drawn.Wrapped);
+        Assert.True(drawn.BandHeight > 40, "the band is expected to outgrow a block this tight");
+    }
+
+    /// <summary>
+    /// A model that answered over two lines. Nothing strips the break, and NoWrap does not ignore
+    /// one — the TextBlock still breaks there — so the band has to be built tall enough for what is
+    /// really in it. On the screenshot overlay this was the whole of the reported bug.
+    /// </summary>
+    [Fact]
+    public void A_translation_that_arrives_with_a_line_break_keeps_both_lines()
+    {
+        var drawn = Draw(Line(
+            "Hello there",
+            "你好，很高興見到你\n今天過得還好嗎",
+            new Rect(20, 15, 300, 34)));
+
+        Assert.True(drawn.BandHeight > 40, $"band is {drawn.BandHeight:0.#}px, too short for two lines");
+    }
+
+    [Fact]
+    public void A_grouped_block_is_drawn_whole_too()
+    {
+        var drawn = Draw(Line(
+            "Are you sure about this?\nThere is no way back.",
+            RunOnTranslation,
+            new Rect(20, 5, 800, 60),
+            sourceLines: [new Rect(20, 5, 800, 28), new Rect(20, 35, 700, 28)]));
+
+        Assert.True(drawn.Wrapped);
+    }
+
+    private readonly record struct DrawnLine(bool Wrapped, double FontSize, double BandHeight);
+
+    /// <summary>
+    /// Builds the block window for real, checks the box it produced against the text put inside it,
+    /// and returns what the calling test is specifically about.
+    /// </summary>
+    private static DrawnLine Draw(TranslatedBlock line, System.Drawing.Rectangle? block = null) =>
+        OnStaThread(() =>
+        {
+            var window = new RealtimeBlockWindow(
+                0, block ?? SubtitleBlock, "JA", "ZH-TW",
+                RealtimeSubtitleColors.DefaultText,
+                RealtimeSubtitleColors.DefaultScrim,
+                RealtimeSubtitleColors.DefaultScrimOpacity);
+
+            // The window is never shown, so nothing raises Loaded and nothing reads a DPI off a real
+            // presentation source. The 1.0 it starts at is what an unscaled display would have given.
+            typeof(RealtimeBlockWindow)
+                .GetField("_isLoaded", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(window, true);
+
+            window.SetLines([line]);
+
+            var canvas = (Canvas)window.FindName("TextCanvas");
+            var container = Assert.IsType<Border>(Assert.Single(canvas.Children));
+            var text = Assert.IsType<TextBlock>(container.Child);
+
+            Assert.Equal(TextTrimming.None, text.TextTrimming);
+
+            var innerWidth = container.Width - container.Padding.Left - container.Padding.Right;
+            var innerHeight = container.Height - container.Padding.Top - container.Padding.Bottom;
+            var wrapped = text.TextWrapping == TextWrapping.Wrap;
+
+            var laidOut = new FormattedText(
+                text.Text,
+                CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(text.FontFamily, text.FontStyle, text.FontWeight, text.FontStretch),
+                text.FontSize,
+                Brushes.Black,
+                1.0);
+
+            // Half a pixel of tolerance: the box was built from measurements of this same text, so
+            // anything past rounding is text the reader would not get.
+            if (wrapped)
+            {
+                laidOut.MaxTextWidth = innerWidth;
+                Assert.True(
+                    laidOut.Height <= innerHeight + 0.5,
+                    $"wrapped text needs {laidOut.Height:0.##}px of height, box gives {innerHeight:0.##}px");
+            }
+            else
+            {
+                Assert.True(
+                    laidOut.Width <= innerWidth + 0.5,
+                    $"one line needs {laidOut.Width:0.##}px of width, box gives {innerWidth:0.##}px");
+                Assert.True(
+                    laidOut.Height <= innerHeight + 0.5,
+                    $"one line needs {laidOut.Height:0.##}px of height, box gives {innerHeight:0.##}px");
+            }
+
+            return new DrawnLine(wrapped, text.FontSize, container.Height);
+        });
+
+    private static TranslatedBlock Line(
+        string original, string translated, Rect bounds, IReadOnlyList<Rect>? sourceLines = null) =>
+        new(original, translated, bounds, sourceLines);
+
+    /// <summary>
+    /// Runs the work on a fresh STA thread, which WPF elements require and xunit's own worker is
+    /// not. Nothing built there outlives the call, so no state reaches the rest of the suite.
+    /// </summary>
+    private static T OnStaThread<T>(Func<T> work)
+    {
+        T result = default!;
+        ExceptionDispatchInfo? failure = null;
+
+        var thread = new Thread(() =>
+        {
+            try { result = work(); }
+            catch (Exception exception) { failure = ExceptionDispatchInfo.Capture(exception); }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        failure?.Throw();
+        return result;
+    }
+}


### PR DESCRIPTION
Closes #73

## 問題

譯文的後半段被截掉，尾端出現 `…`。截圖翻譯與即時翻譯都會發生。

## 主因跟直覺不同：譯文自己帶了換行

`StripThinking` 只做 `Trim()`，中間的 `\n` 完全保留。本地模型分兩行回答、或引擎把來源的換行原樣吐回來，譯文就會含換行。

而 `TextWrapping.NoWrap` **不會忽略明確換行**——TextBlock 照樣斷行——但氣泡高度是照「一行」算出來的：

```csharp
double actualBorderH = Math.Max(borderH, fontSize + BubbleVerticalPadding);
```

第二行以後整個在框外，配上 `CharacterEllipsis`，畫面上就是第一行後面接一個「…」。這正是回報的樣子：不是少一兩個字，是後面整句不見。

## 一併修掉的另外四條掉字路徑

1. **單行塞不下就截斷**。換行原本有三道閘（下方不能有區塊、最多兩行、要塞得進空隙），任一不成立就走截斷。整段文字被逐行辨識時第一條必定不成立——最常見的版面也是掉最多的。現在換行不再有前置條件。
2. **換行後高度被下方空隙夾住**。框是 `ClipToBounds`，夾過頭就是無聲裁掉尾巴，連「…」都沒有。抽成 `OverlayBubbleHeight`，永遠不低於文字所需。
3. **縮放後沒有重新量測**。`fontSize * innerW / measured.Width` 假設文字寬度與字級完全成正比，實際上不是；差一兩 px 就足夠讓 `CharacterEllipsis` 吃掉最後一個字（還要再挪出「…」的位置，等於掉兩個）。改成收斂式重量。高來源那條分支原本**完全沒有重新量測**。
4. **即時翻譯**單行縮到 `MinFontSize = 8.5` 仍太寬時直接截斷，沒有任何後路。改為換行，字級以使用者框的區塊高度為上限來挑。

兩處 `TextTrimming` 都改成 `None`：現在每條塞不下的路徑都會換行，留著只代表「量測差一個 px 就讓使用者少一個字」。

## 驗證

修復前後各跑一次同一組情境，對照真正的 `OverlayWindow` 產生的框：

| 情境 | 修復前 | 修復後 |
|---|---|---|
| `你好，很高興見到你\n今天過得還好嗎` | 需要 62px 高，框只給 25.3px → **掉字** | 62 / 64 ok |
| `第二段\n第三段\n第四段` | 需要 93.1px，框只給 25.3px → **掉字** | 93.1 / 95.1 ok |

其餘所有情境**修復前後的字級與尺寸逐項相同**，只有 `trim=` 從 `CharacterEllipsis` 變成 `None`——沒有順帶改到任何原本正常的畫面。

新增 12 個測試：

- `OverlayTextFittingTests` 建真正的 `RealtimeBlockWindow`、讀回視覺樹，比對 WPF 實際拿到的框與放進去的文字。即時翻譯這半是端到端驗證的。
- `OverlayBubbleHeightTests` 釘住截圖氣泡的高度取捨。

截圖疊圖的 XAML 用 `{StaticResource AppFont}`，建構它需要 `Application`，那是測試套件刻意不引入的行程層級狀態（見 AssemblyInfo），所以那半用一支拋棄式 WPF probe 驗，不進版控。

全套 462 通過，0 warning。

## 已知界線（沒有改）

即時翻譯的視窗**就是使用者框的那塊區域**。換行後的字幕帶若超過區塊高度，超出的部分會被視窗邊界裁掉。要解得動視窗尺寸與座標基準，牽連擷取遮蔽與版面定位。觸發條件比原本的截斷極端得多（900px 寬的區塊要 105 個以上的中文字才會走到換行），而且畫面上看得出來。
