### PR TITLE
fix: #74 換行續句的框重疊時不再被拆開翻譯

### DIFF
--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -158,8 +158,22 @@ internal static class OcrTextBlockGrouper
         if (heightRatio < 0.88)
             return false;
 
+        // The gap can be negative, for exactly the reason it can horizontally in CanJoinSameLine:
+        // the detector's unclip expansion grows every box a little past its glyphs, so two lines of
+        // one wrapped sentence routinely come back overlapping by a few pixels. A `< 0` guard threw
+        // those apart, and each half was then translated on its own — which is not a cosmetic
+        // problem, because half a sentence is not half a translation. A game panel reading "Shots
+        // deal more damage for each bullet remaining in the" / "magazine" overlapped by 3px, and
+        // came back as 「每發子彈在」 and 「雜誌」; the whole sentence gives 「彈匣內每發子彈的傷害會增加」.
+        //
+        // Half a line of overlap, from measuring 54 candidate pairs across the logged captures. The
+        // two populations do not touch: wrapped continuations land at -0.4 to -0.1 of a line, while
+        // boxes that share a row (an "E" beside "PICK UP", an "X" beside "HOLD TO SALVAGE") land at
+        // -0.9 to -1.0. Nothing at all falls between, so the threshold sits in empty space rather
+        // than on either edge. Those row-mates are what this really has to keep out; the same-line
+        // merge takes most of them first, and this is the backstop for the rest.
         var verticalGap = current.Bounds.Y - (previous.Bounds.Y + previous.Bounds.Height);
-        if (verticalGap < 0 || verticalGap > Math.Max(avgHeight * 0.8, 10))
+        if (verticalGap < -avgHeight * 0.5 || verticalGap > Math.Max(avgHeight * 0.8, 10))
             return false;
 
         var leftDelta = Math.Abs(previous.Bounds.X - current.Bounds.X);

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -280,4 +280,46 @@ public class OcrTextBlockGrouperTests
         var merged = Assert.Single(OcrTextBlockGrouper.Group(blocks));
         Assert.Null(merged.Confidence);
     }
+
+    /// <summary>
+    /// The real bounds of a game panel whose description wraps onto a second line. The detector's
+    /// unclip expansion leaves the two boxes overlapping by 3px, and while a `verticalGap &lt; 0`
+    /// guard stood there they were translated apart — "…remaining in the" came back as 「每發子彈在」
+    /// and "magazine" as 「雜誌」. See issue #74.
+    /// </summary>
+    [Fact]
+    public void GroupsAWrappedLineWhoseBoxesOverlapByTheDetectorsExpansion()
+    {
+        var blocks = new List<OcrTextBlock>
+        {
+            new("Shots deal more damage for each bullet remaining in the", new Rect(700, 280, 570, 34)),
+            new("magazine", new Rect(698, 311, 109, 31)),
+        };
+
+        var grouped = OcrTextBlockGrouper.Group(blocks);
+
+        var merged = Assert.Single(grouped);
+        Assert.Equal(
+            "Shots deal more damage for each bullet remaining in the magazine", merged.Text);
+    }
+
+    /// <summary>
+    /// What the tolerance above must not let through: two boxes sharing a row overlap almost
+    /// completely, and joining them as though the second wrapped from the first would read a button
+    /// as the continuation of its neighbour. Far enough apart that the same-line merge does not take
+    /// them first, so this reaches the next-line test the way the real ones did.
+    /// </summary>
+    [Fact]
+    public void KeepsBoxesThatShareARowOutOfTheNextLineJoin()
+    {
+        var blocks = new List<OcrTextBlock>
+        {
+            new("PICK UP", new Rect(10, 360, 67, 25)),
+            new("HOLD TO SALVAGE", new Rect(20, 361, 160, 25)),
+        };
+
+        var grouped = OcrTextBlockGrouper.Group(blocks);
+
+        Assert.Equal(2, grouped.Count);
+    }
 }


### PR DESCRIPTION
Closes #74

> 建議在 #76 之後合併。兩者檔案完全不重疊，已實際做過合併驗證（見下方）。

## 問題

遊戲面板裡一句被換行的說明，翻出來語意完全不對：

| 畫面上的原文 | 翻譯結果 |
|---|---|
| `Shots deal more damage for each bullet remaining in the magazine` | 每發子彈在（換行）雜誌 |

**排版沒有問題，也不是 #73 的截斷**——OCR 完整掃到了，畫面上也完整畫出來了。

## 成因

OCR 把這句拆成兩個 block，**分別送去翻譯**：

| 送進去 | Microsoft 回來 |
|---|---|
| `Shots deal more damage for each bullet remaining in the` | 每發子彈在 |
| `magazine` | 雜誌 |
| `…remaining in the magazine`（合併後） | **彈匣內每發子彈的傷害會增加** |

句子斷在 `the` 之後，引擎拿到殘句就吐殘譯。同一段貼到文字翻譯視窗（整段一起送）完全正常。

沒被合併的原因在 `CanJoinNextLine`：

```csharp
if (verticalGap < 0 || ...) return false;
```

這兩個框的 `verticalGap = 311 - (280 + 34) = -3`——**負的**。框會重疊是因為偵測器的 unclip 展開讓每個框都比字略大一圈。這件事在**水平**方向早就發現並修過，`CanJoinSameLine` 裡有一整段註解在講「gap 可以是負的」，但**垂直方向從來沒補**。

其餘條件全部通過：heightRatio 0.91、leftDelta 2px、overlapRate 0.98、續句證據成立。只差這一個。

## 修法

門檻從 `< 0` 放寬成 `< -avgHeight * 0.5`。

值不是猜的。把 log 裡 226 個辨識 pass 的原始框全部取出，篩出「垂直相鄰 + 左緣對齊 + 高度相近」的候選對共 54 組：

| gap / avgHeight | 組數 | 是什麼 |
|---|---|---|
| −1.0 ~ −0.9 | 10 | 同一列左右並排（`E`+`PICK UP`、`X`+`HOLD TO SALVAGE`）—— **不能併** |
| −0.4 ~ −0.1 | 30 | 換行續句 —— **該併** |

**−0.5 到 −0.9 之間一組都沒有。** 門檻落在空白帶正中間，不貼任何一邊。

## 影響範圍（實測，非估計）

把改動套回同一批真實資料重跑，新併進來的只有 2 個 distinct 句子，兩個都是真的換行續句：

- `Shots deal more damage for each bullet remaining in the` + `magazine`
- `I heard a bunch of experts` + `are there to study`

−0.5 以外的一組都沒有放行。

### 會不會讓字級變小？

合併後譯文要塞進兩行的聯集框，往英文轉（最長的目標語言）時可能吃虧。拿真實測試集實測，目標語言 EN：

| 測試集 | 圖 | blocks | grouped |
|---|---|---|---|
| region-subtitle-ja-card | 52 | 25 | **0** |
| region-subtitle-ja-video | 32 | 32 | **0** |
| screen-subtitle-ko | 14 | 106 | **0** |
| screen-panel-ko | 9 | 254 | 6 |

**字幕完全不會觸發分組**（98 張圖、163 個 block，0 個）。

那 6 個 grouped block 的 `gap` 全部是**正的**（0.33 ~ 0.75），代表它們在本次改動前就已經被合併——

> **本次改動新增的分組：0 / 6**

也就是說字級變小是既有的分組行為，與本 PR 無關。而且分界很清楚：真正的換行續句合併後是 −2.8% / +3.5% / +3.9%（幾乎沒代價），掉兩成以上的全是**不該被合併的堆疊選單標籤**——那是 #75，另外處理。

## 合併驗證

`fix/overlay-text-truncation`（#76）與本分支改動的檔案完全不重疊：

- #76：`OverlayWindow.xaml.cs`、`RealtimeBlockWindow.xaml.cs`、`Layout/OverlayBubbleHeight.cs` + 2 個測試檔
- 本 PR：`Services/Ocr/OcrTextBlockGrouper.cs` + 1 個測試檔

實際把兩個分支一起合到 main 上跑過：合併無衝突，**464 個測試全過**，截圖疊圖的掉字 probe 仍然全綠。

## 風險

`CanJoinNextLine` 的 impact 是 CRITICAL——截圖與即時翻譯的每一次辨識都會經過它。所以改動壓在單一門檻、用實測定值，既有 17 個 grouper 測試全部未動。仍建議實機多跑幾種畫面。
