### PR TITLE
fix: #75 堆疊的選單標籤不再被誤判為換行續句

### DIFF
--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -208,8 +208,34 @@ internal static class OcrTextBlockGrouper
         // A much shorter following line is a common natural wrap shape.
         // Similar-width lines without linguistic evidence are kept separate
         // so title/body pairs are not merged just because they align.
-        return previous.Bounds.Width >= current.Bounds.Width * 1.35;
+        //
+        // Guarded by the length test below, because on its own that shape is also what a stack of
+        // menu entries looks like — a longer label above a shorter one, aligned, evenly spaced. It
+        // read 「アビリティ」over「召喚石」and 「캐릭터강화」over「소지품」as wrapped sentences, glued
+        // each pair into one string for the translator, and squeezed both into one bubble. See #75.
+        return IsLongEnoughToHaveWrapped(previous) &&
+               previous.Bounds.Width >= current.Bounds.Width * 1.35;
     }
+
+    /// <summary>
+    /// Whether a line is long enough that running out of room — and so wrapping — is plausible.
+    /// </summary>
+    /// <remarks>
+    /// <para>Measured in line heights rather than characters so that one number serves every script:
+    /// a CJK line runs about one character per line height, a Latin one about two. So this asks for
+    /// roughly eight CJK characters, or sixteen Latin ones.</para>
+    ///
+    /// <para>Across the 329-image corpus the two populations are far apart: every genuinely wrapped
+    /// sentence reached 16.6 and every stacked label stopped at 6.8, with nothing in between. The
+    /// threshold sits at the low end of that empty band on purpose. Letting a label through costs
+    /// two crowded words in one bubble; keeping a real wrapped sentence apart costs the translator
+    /// half a sentence, which is the far worse failure — it is the whole of #74.</para>
+    /// </remarks>
+    private const double WrappedLineMinAspect = 8.0;
+
+    private static bool IsLongEnoughToHaveWrapped(OcrTextBlock line) =>
+        line.Bounds.Height > 0 &&
+        line.Bounds.Width / line.Bounds.Height >= WrappedLineMinAspect;
 
     private static bool HasUnclosedDelimiter(string text) =>
         Count(text, '「') > Count(text, '」') ||

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -304,6 +304,45 @@ public class OcrTextBlockGrouperTests
     }
 
     /// <summary>
+    /// A stack of menu entries has the shape the width rule looks for — a longer label above a
+    /// shorter one, aligned, evenly spaced — without being a sentence at all. These are the real
+    /// bounds of 「キャラクター強化」over「所持品」in a game menu; joining them handed the translator
+    /// one invented phrase and squeezed both labels into a single bubble. See issue #75.
+    /// </summary>
+    [Fact]
+    public void KeepsStackedMenuLabelsSeparate()
+    {
+        var blocks = new List<OcrTextBlock>
+        {
+            new("キャラクター強化", new Rect(166, 476, 233, 36)),
+            new("所持品", new Rect(165, 539, 94, 38)),
+        };
+
+        var grouped = OcrTextBlockGrouper.Group(blocks);
+
+        Assert.Equal(2, grouped.Count);
+    }
+
+    /// <summary>
+    /// And what that must not cost: a real wrapped sentence, whose first line is long because it
+    /// ran out of room. Real bounds from the same corpus as the menu above.
+    /// </summary>
+    [Fact]
+    public void StillGroupsASentenceLongEnoughToHaveWrapped()
+    {
+        var blocks = new List<OcrTextBlock>
+        {
+            new("그랑 사이퍼의 갑판에 있는 연습용 더미를 조사하면", new Rect(354, 427, 564, 30)),
+            new("플레이할 수 있습니다", new Rect(355, 478, 248, 29)),
+        };
+
+        var grouped = OcrTextBlockGrouper.Group(blocks);
+
+        var merged = Assert.Single(grouped);
+        Assert.Equal(2, merged.Lines.Count);
+    }
+
+    /// <summary>
     /// What the tolerance above must not let through: two boxes sharing a row overlap almost
     /// completely, and joining them as though the second wrapped from the first would read a button
     /// as the continuation of its neighbour. Far enough apart that the same-line merge does not take


### PR DESCRIPTION
Closes #75

## 問題

垂直堆疊的選單標籤被當成同一句話合併，送去翻譯後變成一個不存在的詞組，而且兩個標籤被擠進同一個氣泡。

先把整個測試語料（329 張圖）裡**目前會被合併**的 block 全部倒出來逐一分類：

| 前行 ar | 後行 ar | 內容 | 該併? |
|---|---|---|---|
| **18.0** | 8.9 | `新しい仲間が加わったら…` + `戦い方を学んでみましょう。` | ✓ |
| **18.6** | 8.5 | `그랑 사이퍼의…조사하면` + `플레이할 수 있습니다.` | ✓ |
| **16.6** | 9.3 | `새로운 동료가…트레이닝에서` + `전투 방식을 익혀 보세요!` | ✓ |
| 17.4 | 3.2 | `後章 ENDLESS RAGNAROK/辺境の街…` + `ACTION` | ✗ |
| 6.8 | 4.2 | `※지키세요그 땅을.` + `폐쇄섬폰담`（OCR 亂碼） | ✗ |
| 6.5 | 2.5 | `キャラクター強化` + `所持品` | ✗ |
| 5.1 | 2.4 | `플레이어 설정` + `시스템` | ✗ |
| 4.4 | 2.5 | `캐릭터강화` + `소지품` | ✗ |
| 3.6 | 2.4 | `アビリティ` + `召喚石` | ✗ |
| 3.4 | 1.7 | `이어하기` + `옵션` | ✗ |

**10 個裡只有 3 個是對的。** 誤判率 70%。

## 成因

`HasSentenceContinuationEvidence` 的最後一條，在沒有標點證據時：

```csharp
// A much shorter following line is a common natural wrap shape.
return previous.Bounds.Width >= current.Bounds.Width * 1.35;
```

「上面比下面長」確實是換行的形狀——但**也正是一疊選單項目的形狀**：長標籤在上、短標籤在下、左緣對齊、間距平均。這條規則完全沒有問「上面那行有沒有長到會換行」。

## 修法

補上這個缺的前提：**一行之所以會換行，是因為它塞不下了，所以換行的那一行必然很長。**

```csharp
return IsLongEnoughToHaveWrapped(previous) &&
       previous.Bounds.Width >= current.Bounds.Width * 1.35;
```

長度用**長寬比**而非字數，一個數字就能跨語系：CJK 一行大約每個字一個行高，拉丁文大約兩個字一個行高。門檻 8.0 ≈ 8 個中日韓字，或 16 個拉丁字母。

值由上表決定：真正的換行續句最低 16.6，堆疊標籤最高 6.8，中間完全是空的。門檻刻意壓在空白帶的**低端**——放進一個標籤的代價是兩個詞擠在一個氣泡裡，擋掉一個真續句的代價是翻譯只拿到半句話，那正是 #74 修好的東西，不能再賠回去。

## 實測效果

同一套語料重跑：

| | 修復前 | 修復後 |
|---|---|---|
| grouped blocks | 10 | **4** |
| 其中該併的 | 3 | **3** |
| 其中誤併的 | 7 | **1** |

三個真正的換行續句一個都沒少，六個誤併消失。字幕測試集本來就是 0 grouped，前後不變。

## 沒有解掉的一個

`後章 ENDLESS RAGNAROK/辺境の街フォル力` + `ACTION`（ar 17.4）仍會合併——它的第一行是真的長，只是下面那個 `ACTION` 不是它的續行。

幾何上其實看得出來：它是**置中**的（Δx=23），而三個真續句都是左對齊（Δx=1）。但沒有採用這個判準，因為**置中的兩行字幕是真正的換行**，加上左對齊要求會把字幕的合併永久堵死。以一個標題誤併換掉整類字幕的可能性，不划算。

## 相關

- 三個既有的邊界測試（不同欄位／不同字級／標題與內文）行為未變。
- 新增 2 個測試，皆使用語料裡的真實座標。
- 全套 466 通過，0 warning。

## 風險

`HasSentenceContinuationEvidence` 的 impact 是 CRITICAL——截圖與即時翻譯的每一次辨識都會經過它。所以改動壓在單一條件、值由 329 張圖的實測分布決定，既有 grouper 測試全部未動。仍建議實機多跑幾種遊戲介面。
