### PR TITLE
fix: #81 即時字幕的偵測尺度由 0.5 提高到 0.85

### DIFF
--- a/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
@@ -52,11 +52,54 @@ internal static class RealtimeDetectorSize
     /// Fraction to read a wide, short block at — a subtitle strip.
     /// </summary>
     /// <remarks>
-    /// Text in a strip fills most of its height, so the glyphs are large: around 60px in the frames
-    /// swept above, which halving puts near the 30px the model was trained on. Everything in this
-    /// type's remarks about collapse comes from this shape.
+    /// <para>Was 0.5, on the reasoning that a strip's glyphs run around 60px and halving lands them
+    /// near the 30px the model was trained on. The number survived the move to PP-OCRv6 because the
+    /// sweep that checked it only ever looked at frames the primary size had FAILED to read — and a
+    /// fraction cannot be judged on those, because it is never asked about the frames it reads
+    /// wrongly rather than not at all. This type's own remarks said as much: "a sweep on the control
+    /// group (frames the primary size already read) is what would move them."</para>
+    ///
+    /// <para>That sweep, on the 109 primaryok frames of the corpus, comparing each size against what
+    /// the other sizes agreed the frame said:</para>
+    ///
+    /// <code>
+    ///   fraction   reads correctly   detector size   detection
+    ///     0.40        75/109  69%         736             63ms
+    ///     0.50        85/109  78%         928             79ms
+    ///     0.60        93/109  85%        1120            116ms
+    ///     0.68        94/109  86%        1248            122ms
+    ///     0.75        96/109  88%        1376            146ms
+    ///     0.85       102/109  94%        1568            163ms
+    ///     1.00        94/109  86%        1825            189ms
+    /// </code>
+    ///
+    /// <para>So a fifth of what the old size read, it read wrong — silently, because the fallback
+    /// chain only runs when a read finds nothing, and a wrong answer is still an answer. What it
+    /// lost was whole words: "Yay!" as "ay!", "I heard a bunch of experts" as "heard a bunch of
+    /// experts", "エピソードトーク強すぎ" as "エピンドク強すぎ", and the line that opened issue #81,
+    /// "…for a new song are…" as "…for a new so!g are…", cut mid-word and the cut recognised as
+    /// punctuation. Those two dropped leading words are also the symptom issue #69 was closed over
+    /// as a limitation of the detector; it was the size all along.</para>
+    ///
+    /// <para>Native is not the answer either, and that is the useful part: 1.00 reads worse than
+    /// 0.85. There is a scale the detector wants and both directions away from it cost accuracy,
+    /// which is why this is a fraction at all rather than "no downscale, like the screenshot flow".
+    /// PaddleOCR's own guidance is the same shape — a limit on the longest side, 960 by default and
+    /// 1216 when a larger detection scale is wanted, in multiples of 32. Nothing there says half.</para>
+    ///
+    /// <para>The cost is real: detection is about 85% of a pass, so this roughly doubles it, 79ms to
+    /// 163ms measured on the same frames. It is paid for accuracy on the one thing a subtitle
+    /// overlay does.</para>
+    ///
+    /// <para>One caveat worth writing down, because it bounds how far this generalises: the whole
+    /// corpus is regions about 1820 wide, so fraction and absolute size cannot be told apart in it.
+    /// Cropping those same frames tight to their text and sweeping again, every fraction from 0.40
+    /// up reads 88–95% — the size stops mattering. The sensitivity this number is compensating for
+    /// comes from the margin around the text, which is the framing the in-app guidance asks for.
+    /// A rule driven by the margin rather than by the block would be the better answer, and issue
+    /// #39 is where the last attempt at one was reverted.</para>
     /// </remarks>
-    public const double StripFraction = 0.5;
+    public const double StripFraction = 0.85;
 
     /// <summary>
     /// Fraction to read a chunkier block at — an interface panel, a tooltip, a dialogue box.

--- a/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
@@ -9,13 +9,13 @@ namespace OverTranslate.Tests;
 public class RealtimeDetectorSizeTests(ITestOutputHelper output)
 {
     [Fact]
-    public void ASubtitleStripIsReadAtHalfScale()
+    public void ASubtitleStripIsReadNearFullScale()
     {
-        // The text fills a strip's height, so the glyphs are large and halving lands them near the
-        // size the model was trained on.
+        // Halving was the old answer and it read a fifth of the control corpus wrongly — words cut
+        // in half, leading words dropped. See RealtimeDetectorSize for the sweep. #81
         var (primary, _) = RealtimeDetectorSize.For(1226, 196, RealtimeBlockMode.Subtitle);
 
-        Assert.Equal(640, primary); // 1226 * 0.5, rounded up onto the detector's grid
+        Assert.Equal(1056, primary); // 1226 * 0.85, rounded up onto the detector's grid
     }
 
     [Fact]
@@ -41,9 +41,15 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
         var strip = RealtimeDetectorSize.For(width, height, RealtimeBlockMode.Subtitle).Primary;
         var panel = RealtimeDetectorSize.For(width, height, RealtimeBlockMode.Panel).Primary;
 
-        Assert.True(strip <= native * 0.55, $"{width}x{height} as 字幕 should read at strip scale");
-        Assert.True(panel >= native * 0.6, $"{width}x{height} as 面板 should read at panel scale");
+        // Stated as the gap between the two answers rather than as a bound on each: what this test
+        // is about is that the same rectangle gets two different sizes depending on what the user
+        // says is in it, and that stays true however the two fractions are later retuned.
+        Assert.NotEqual(strip, panel);
+        Assert.Equal(RoundToStride(native * RealtimeDetectorSize.StripFraction), strip);
+        Assert.Equal(RoundToStride(native * RealtimeDetectorSize.PanelFraction), panel);
     }
+
+    private static int RoundToStride(double size) => Math.Max(320, ((int)size + 31) / 32 * 32);
 
     [Fact]
     public void TheUsersDraggingCannotChangeTheScaleAnyMore()
@@ -58,14 +64,18 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void BothFractionsStayInsideTheRangeSubtitlesSurvive()
+    public void BothFractionsStayInsideTheRangeTheSweepSupports()
     {
-        // The original sweep found 0.37–0.78 of native read both subtitle frames every time, and
-        // 0.84 and above collapsed them into one unreadable box. Either fraction can end up on a
-        // strip — the panel one as a fallback — so both have to stay inside that window. This fails
-        // the moment someone nudges one towards the collapse.
-        Assert.InRange(RealtimeDetectorSize.StripFraction, 0.37, 0.78);
-        Assert.InRange(RealtimeDetectorSize.PanelFraction, 0.37, 0.78);
+        // This used to read 0.37–0.78, the window PP-OCRv5_mobile_det read those subtitle frames in
+        // before collapsing above 0.84. That detector is gone and its collapse went with it — see
+        // the note in RealtimeDetectorSize, and SubtitleFramesTheDetectorCollapsedAreReadAtTheChosenSize
+        // below, which reads the very frames it collapsed on and is the guard that actually holds.
+        //
+        // What replaces it is the floor the control sweep measured: below 0.6 accuracy falls away
+        // (0.5 read 78% of the corpus correctly, 0.4 read 69%), and native is worse than 0.85, so
+        // neither fraction should sit outside that band. #81
+        Assert.InRange(RealtimeDetectorSize.StripFraction, 0.60, 0.95);
+        Assert.InRange(RealtimeDetectorSize.PanelFraction, 0.60, 0.95);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #81

## 問題

即時翻譯把一句字幕讀成 `No ideas for a new so!g are coming to me.`，正確是 `…for a new song are…`。截圖翻譯正常。

偵測器把一行切成三個框，切在 `song` 中間，被切斷的 `n` 被辨識成 `!`。同一張 frame 只換偵測尺寸：864（即時實際使用）錯，1216 / 1685 / 2048 全對。

## 為什麼 0.5 從來沒被驗證過

`StripFraction = 0.5` 的來源是「字幕字高約 60px，減半接近模型訓練的 30px」。它換到 PP-OCRv6 時沒有重新檢驗，而檢驗它的那次掃描**只看主要尺寸「讀不到」的 frame**——那批資料無法回答「主要尺寸讀到的，讀得對不對」。

這個型別自己的註解就寫著缺口：

> a sweep on the control group (frames the primary size already read) is what would move them.

而且救援鏈只在「完全讀不到」時才啟動，所以**錯誤的答案不會觸發任何補救**。

## 控制組掃描

109 張 primaryok frame，每張讀 7 種尺寸，以「其他尺寸一致同意的內容」作為該張的正確答案：

| fraction | 讀對 | 偵測尺寸 | 偵測耗時 |
|---|---|---|---|
| 0.40 | 75/109 69% | 736 | 63ms |
| **0.50（原值）** | **85/109 78%** | 928 | 79ms |
| 0.60 | 93/109 85% | 1120 | 116ms |
| 0.68 | 94/109 86% | 1248 | 122ms |
| 0.75 | 96/109 88% | 1376 | 146ms |
| **0.85（新值）** | **102/109 94%** | 1568 | 163ms |
| 1.00 | 94/109 86% | 1825 | 189ms |

**原本讀到的內容裡有兩成是錯的**，而且錯的方式是掉字：

| 0.50 | 0.85 |
|---|---|
| `ay!` | `Yay!` |
| `heard a bunch of experts` | `I heard a bunch of experts` |
| `エピンドク強すぎ` | `エピソードトーク強すぎ` |
| `そんな時は見なかったことにし` | `そんな時は見なかったことにして` |
| `That kind` | `That kind of song` |
| `何なんでg` | `何なんですか？何なんですか？` |

那兩個掉行首單字的，正是 **#69** 被收成「偵測器對垂直位置刀鋒級敏感」的症狀。**是尺寸，不是敏感度。**

## 前後對照

同一批 118 張，0.50 → 0.85：

```
  修好 21   弄壞 4   不變 84   無共識 9
  偵測耗時 77ms -> 160ms
```

那 4 個「弄壞」要看內容，其中**兩個其實是指標判錯**：

```
弄壞  "heard a bunch of experts are there to study it."
      -> "I heard a bunch of experts are there to study it."
```

多數尺寸都掉了行首的 `I`，所以共識本身是錯的，而 0.85 把它讀回來了。另一個是 `better` → `better—`（破折號本來就在畫面上）。真正的退步只有一個：撿到 `{0}2` 這種裝飾雜訊，而那在實際即時路徑上還會再被 `RejectShortReadings` 濾一層。

## native 不是答案

1.00 讀對 94，比 0.85 的 102 差。**兩個方向偏離最佳點都會掉準確率**，所以這裡仍然是一個比例而不是「跟截圖一樣不縮放」。

順帶查證了模型端：`shared/det.onnx` 的 input 是 `[?, 3, ?, ?]`，**完全動態**，所以任何縮放都是我們自己的選擇，模型沒有強制。動態不等於尺度不變——最佳點是感受野的性質。PaddleOCR 官方的做法也是同一個形狀：限制長邊，預設 960、要更大偵測尺度時 1216，32 倍數。沒有任何地方是「取一半」。

## 成本

偵測約佔一個 pass 的 85%，所以這大約讓它加倍：**77ms → 160ms**（同一批 frame 實測）。

這是這次唯一真正的代價，也是需要你實機判斷的部分——特別是多區塊 session，辨識槽是共用的。

## 一個界線（寫進註解了）

整個語料的區塊都約 1820 寬，所以**比例與絕對尺寸在這批資料裡分不開**。

把同一批 frame 裁緊到文字周圍 24px 再掃一次，情況完全改變：

| | 鬆框 native 1825 | 緊框 native 753 |
|---|---|---|
| 0.50 | 78% | **95%**（detect 384） |
| 0.85 | 94% | 95%（detect 640） |
| 1.00 | 86% | 95% |

緊框在任何尺寸下都好讀。**尺寸敏感度來自文字周圍的留白**，而留白正是應用內指引要使用者留的。真正更好的規則應該由留白（或量到的字高）推導，而不是由框的長邊——那是 #39 的方向，上一次嘗試因為額外做了「只掃上一幀文字區域」而被撤回，那個撤回理由不適用於單純的尺度推導。

## 測試

`BothFractionsStayInsideTheRangeSubtitlesSurvive` 守的是 0.37~0.78，來自 **PP-OCRv5 時代的 collapse 窗口**。那個偵測器已經換掉，型別註解也早已記載「There is no dead band left to steer around」。改成守控制組量到的下限。

真正的 collapse 護欄是 `SubtitleFramesTheDetectorCollapsedAreReadAtTheChosenSize`——它讀的正是當年塌掉的那兩張 frame，**在 0.85 下通過**。

全套 468 通過，0 warning。
