### PR TITLE
chore: #83 修正 RealtimeDetectorSize 中已被 0.85 取代的偵測尺度敘述

### DIFF
--- a/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
@@ -15,11 +15,12 @@ namespace OverTranslate.Services.Realtime;
 /// okay?".</item>
 /// </list>
 ///
-/// The glyphs in those frames are around 60px tall; halving puts them near 30px, which is where the
-/// model was trained. That is why a subtitle strip is read at half scale — but only a strip: an
-/// interface panel holds much smaller text and needs the opposite correction. Which of the two a
-/// block is comes from <see cref="RealtimeBlockMode"/>, i.e. from the user; see
-/// <see cref="StripFraction"/> and <see cref="PanelFraction"/>.
+/// The glyphs in those frames are around 60px tall; halving puts them near 30px, which is where that
+/// model was trained. That was why a subtitle strip was read at half scale — but only a strip: an
+/// interface panel holds much smaller text and needs the opposite correction. That last part still
+/// holds, and which of the two a block is comes from <see cref="RealtimeBlockMode"/>, i.e. from the
+/// user; see <see cref="StripFraction"/> and <see cref="PanelFraction"/>. The halving itself is
+/// gone — see the closing paragraph.
 ///
 /// None of this reaches the screenshot flow, which asks for no downscale at all and is right to:
 /// its text is interface-sized, already inside the detector's range, and downscaling it would
@@ -32,21 +33,46 @@ namespace OverTranslate.Services.Realtime;
 /// at 0.40, 4 at 0.50, 6 at 0.55 and 8 at 0.60, while PP-OCRv6_det_tiny reads 9 across that whole
 /// band and 9 at native. There is no dead band left to steer around.
 ///
-/// The fractions below did not change with it, and the reason they are still here changed
-/// completely: they are now a cost decision, not an avoidance. A strip read at 0.50 and at native
-/// reads the same 9 of those 15 frames, for 89ms against 186ms — so halving buys the same answer
-/// for half the work. That is why the numbers stayed put; it is not evidence that they are still
-/// optimal, and a sweep on the control group (frames the primary size already read) is what would
-/// move them.
+/// The fractions did not change when the model did, and for a while the reason given for keeping
+/// them was cost: a strip read at 0.50 and at native read the same 9 of those 15 frames, for 89ms
+/// against 186ms, so halving looked like the same answer for half the work. That reasoning was
+/// unsound, and this type's own remarks said why at the time — every one of those 15 frames was one
+/// the primary size had FAILED to read, and a fraction cannot be judged on those, because it is
+/// never asked about the frames it reads WRONGLY rather than not at all. The note ended: "a sweep on
+/// the control group (frames the primary size already read) is what would move them."
+///
+/// That sweep is issue #81, and it moved them. On 109 frames the primary size did read, 0.50 got 78%
+/// of them right and 0.85 got 94%, so a fifth of what halving read, it read wrong — silently, since
+/// the fallback chain only runs when a read finds NOTHING and a wrong answer is still an answer.
+/// <see cref="StripFraction"/> carries the full table and what the losses looked like.
+///
+/// Two things there are worth keeping in mind before touching these numbers again. Native is not the
+/// answer either — 1.00 reads worse than 0.85, so both directions away from the detector's preferred
+/// scale cost accuracy, which is why these are fractions at all rather than "no downscale, like the
+/// screenshot flow". And the whole corpus is regions about 1820 wide, so fraction and absolute size
+/// cannot be told apart in it; cropping the same frames tight to their text makes every fraction
+/// from 0.40 up read 88–95%, which says the sensitivity comes from the margin around the text rather
+/// than from the block. A rule driven by that would be the better answer, and issue #39 is where the
+/// last attempt at one was reverted.
 /// </remarks>
 internal static class RealtimeDetectorSize
 {
     /// <summary>
-    /// Below this, halving would take the text out of range from the other side, so the region is
-    /// read at native size and only retried at half if that finds nothing. A region this small
-    /// cannot hold 60px subtitles and much text besides.
+    /// Below this, a region is read at native size with no fallbacks at all.
     /// </summary>
-    public const int HalfScaleMinSide = 800;
+    /// <remarks>
+    /// Downscaling only helps text the detector finds too large. A region this small cannot hold
+    /// 60px subtitles and much text besides, so anything in it is already at or below the scale the
+    /// detector wants, and shrinking it further could only take it out of range from the other side
+    /// — which is also why there is nothing to fall back TO here, and why
+    /// <see cref="WhileNothingIsShown"/> has nothing to save.
+    ///
+    /// Was named HalfScaleMinSide, from the era when the downscale was a halving. The 800 itself is
+    /// unchanged and predates PP-OCRv6: it has never been re-measured against this detector, and a
+    /// sweep over small regions — small subtitles, small dialogue boxes, small tooltips — is what
+    /// would move it. Renaming it does not make it measured.
+    /// </remarks>
+    public const int DownscaleMinSide = 800;
 
     /// <summary>
     /// Fraction to read a wide, short block at — a subtitle strip.
@@ -184,7 +210,7 @@ internal static class RealtimeDetectorSize
         var native = Math.Max(width, height);
 
         // ImgResize only ever downscales, so passing the longest side asks for the image as it is.
-        if (native < HalfScaleMinSide)
+        if (native < DownscaleMinSide)
             return (native, []);
 
         // The mode decides where to start; the other mode's fraction is then the first thing to try

--- a/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
@@ -100,8 +100,8 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     [Fact]
     public void ASmallRegionIsReadAtNativeSizeWithNothingToFallBackTo()
     {
-        // 60px subtitles do not fit in a region this size, so halving could only take small text
-        // further out of range.
+        // 60px subtitles do not fit in a region this size, so any downscale could only take small
+        // text further out of range. See DownscaleMinSide.
         var (primary, fallbacks) = RealtimeDetectorSize.For(400, 120, RealtimeBlockMode.Subtitle);
 
         Assert.Equal(400, primary);
@@ -154,7 +154,7 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     [Fact]
     public void ARegionTooSmallToDownscaleHasNothingToDrop()
     {
-        // Below HalfScaleMinSide there are no fallbacks at all, so there is nothing here to save
+        // Below DownscaleMinSide there are no fallbacks at all, so there is nothing here to save
         // and nothing to lose either.
         var (_, fallbacks) = RealtimeDetectorSize.For(400, 120, RealtimeBlockMode.Subtitle);
 
@@ -173,10 +173,15 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
         // in that flow (it has no fallback size to fall back to, so a subtitle framed there was
         // simply lost).
         //
-        // Halving is still what a strip is read at, and now for a plain reason rather than a
-        // detector quirk: swept over the same 15 frames, the new detector reads 9 at 0.50 and 9 at
-        // native, for 89ms against 186ms. Same result, half the cost. If a later measurement shows
-        // native reading materially more, this test is where the evidence for changing that starts.
+        // Halving was still what a strip was read at when this was written, on the reasoning that
+        // the new detector read 9 of those same 15 frames at 0.50 and 9 at native, for 89ms against
+        // 186ms — same result, half the cost. That reasoning was unsound: all 15 were frames the
+        // primary size had FAILED to read, and a fraction is never asked there about the frames it
+        // reads WRONGLY rather than not at all. Issue #81 swept the control group instead and found
+        // 0.50 reading a fifth of it wrong, so a strip is now read at 0.85. See RealtimeDetectorSize.
+        //
+        // What this test asserts is unaffected either way: it is about the screenshot size, which
+        // has never downscaled and still does not.
         using var engine = new OcrService();
         using var frame = new Bitmap(Path.Combine(AppContext.BaseDirectory, "Fixtures", fixture));
 


### PR DESCRIPTION
Closes #83

#82 把 `StripFraction` 由 0.5 改成 0.85，但只在 `StripFraction` 自己的 remarks 寫了新量測，沒有回頭清掉上層與測試裡的舊敘述。這個 PR 只改敘述與一個常數名稱，**沒有動任何門檻值或邏輯**。

## 改了什麼

### 類別最上方的 remarks

三處已經與現況矛盾的說法：

| 原本 | 問題 |
|---|---|
| 「That is why a subtitle strip **is** read at half scale」 | 已經不是 half scale |
| 「The fractions below **did not change** with it」 | 之後就變了，正是 #81 改的 |
| 「A strip read at 0.50 and at native reads the same 9 of those 15 frames… halving buys the same answer for half the work」 | 已被 #81 的 control sweep 推翻 |

改寫時保留了**為什麼那個舊結論是錯的**，因為那才是真正該傳下去的東西：那 15 個 frame 全是 primary **讀不到**的，而 fraction 的失敗模式是**讀到但讀錯** —— 在那批資料上，fraction 永遠不會被問到它讀錯的那些 frame。這個檔案當時自己就寫了「a sweep on the control group is what would move them」，#81 就是那個 sweep。

同時把兩個仍然成立、但容易被下一個人重新踩到的結論搬到上層：

- `1.00` 讀得比 `0.85` 差 —— 離開最佳點的**兩個方向**都會掉準度，這才是它是 fraction 而不是「不縮放」的理由。
- 整個 corpus 都是約 1820 寬的區塊，所以 **fraction 與絕對尺寸在這批資料裡分不開**；同一批圖裁緊到文字附近後 0.40–1.00 全部讀對 88–95%，代表敏感度來自**留白**而不是區塊本身。那是 #39 的方向。

### `HalfScaleMinSide` → `DownscaleMinSide`

名稱停留在 0.5 時代。它的 summary 還有第二個錯誤，跟 fraction 無關：

> 「the region is read at native size and **only retried at half if that finds nothing**」

實際上 `native < 門檻` 是 `return (native, [])` —— **完全沒有 fallback**，`ASmallRegionIsReadAtNativeSizeWithNothingToFallBackTo` 也是這樣斷言的。已改成正確敘述，並寫清楚為什麼這裡本來就沒有東西可退（往下縮只會讓小字更出範圍）。

**800 這個數字沒有動**，並在註解裡標明它從未對 PP-OCRv6 重新量過 —— 改名不會讓它變成量過的。要動它需要一輪小區塊 sweep，不屬於這個 PR。

共 3 處使用，全部在這 2 個檔案內，已逐一列舉確認。

### 測試註解

`TheSameFramesAlsoReadAtTheScreenshotSizeNow` 的「Halving is still what a strip is read at」與 0.50 vs native 的舊結論一併修正，並點明**這個測試斷言的東西不受影響** —— 它測的是截圖尺寸，那條路徑從來沒有縮放過。

`ASmallRegionIsReadAtNativeSizeWithNothingToFallBackTo` 裡的「halving」改成中性的「any downscale」。

## 驗證

- 建置：0 警告 0 錯誤
- 測試：466 通過 / 0 失敗 / 2 略過（既有的 OCR 併發略過）
- `detect_changes`：2 檔案、風險 low、0 個受影響執行流程
- CRLF 與無 BOM 編碼已確認保留（`git diff --ignore-all-space` 與原始 diff 行數一致）
