### PR TITLE
test: #84 驗證 Panel 的第一個 fallback 由 0.5 改為 0.85 後未退步

### DIFF
--- a/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
@@ -188,6 +188,31 @@ internal static class RealtimeDetectorSize
     /// not the whole story — a subtitle block that also caught a line of interface text, say. Native
     /// goes last as the only size that can read text too small to survive any downscale — it
     /// recovered nine lines in a single measured session.
+    ///
+    /// That coupling has a cost worth knowing about: raising <see cref="StripFraction"/> for #81
+    /// silently moved a PANEL's first fallback from 0.50 to 0.85, and #81 measured nothing but
+    /// subtitles. The worry was specific — 0.68 and 0.85 sit on the same side of the primary, so the
+    /// escape route DOWNWARDS disappeared, and <see cref="PanelFraction"/> records that 0.5 read
+    /// only 3 of 9 boxes on the shape it was measured on. If some panel could be read at 0.5 and
+    /// nowhere else, nothing would reach it any more.
+    ///
+    /// Swept for #84 over the panel corpus — 18 Japanese/English screens plus 9 Korean ones, the
+    /// latter cut to 6 after dropping screens whose text never exceeds the harness's 10-character
+    /// noise floor at any size — no such panel exists in it, and the question turns out to be moot
+    /// from one step earlier:
+    ///
+    /// <code>
+    ///   primary (0.68) read nothing, so a fallback ran   0 of 24
+    ///   0.50 read materially more than 0.85              0 of 24
+    /// </code>
+    ///
+    /// One Korean screen looked like the case being hunted (0.50 → 72 characters, 0.85 → 58) until
+    /// its whole sweep was read across: 56–82 characters with no trend, 82 at 0.40 and 56 at 0.55.
+    /// That is jitter with scale, not a fraction the content prefers.
+    ///
+    /// So the chain is unharmed, but note what the sweep actually says — on this corpus a panel's
+    /// fallbacks never run at all, which means their value here is unmeasured rather than confirmed.
+    /// What would move this is a panel the primary size fails on, and the corpus has none.
     /// </remarks>
     public const double NativeFraction = 1.0;
 

--- a/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeDetectorSizeTests.cs
@@ -90,6 +90,24 @@ public class RealtimeDetectorSizeTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void APanelFallsBackToWhateverTheStripFractionCurrentlyIs()
+    {
+        // The direction issue #84 was opened about. A panel's first fallback is not a number of its
+        // own — it is StripFraction, so #81 moved it from 0.50 to 0.85 while measuring only
+        // subtitles. Stated against the constant rather than against 1568 so that this keeps saying
+        // what it means if the fraction moves again; what it pins is the coupling, which is the part
+        // that changes panel behaviour without anyone editing anything panel-shaped.
+        //
+        // Swept over 24 panel screens for #84, nothing regressed — and nothing could have, because
+        // the primary size read all 24, so no fallback ever ran. See NativeFraction's remarks: the
+        // chain is unharmed but unmeasured, not confirmed good.
+        var native = 1849;
+        var (_, fallbacks) = RealtimeDetectorSize.For(native, 1041, RealtimeBlockMode.Panel);
+
+        Assert.Equal([RoundToStride(native * RealtimeDetectorSize.StripFraction), native], fallbacks);
+    }
+
+    [Fact]
     public void ASizeThatWouldRepeatTheFirstAttemptIsNotTriedAgain()
     {
         var (primary, fallbacks) = RealtimeDetectorSize.For(1226, 196, RealtimeBlockMode.Subtitle);


### PR DESCRIPTION
Closes #84

#82 把 `StripFraction` 由 0.5 改成 0.85 時，因為 `For()` 用「另一個 mode 的 primary」當第一個 fallback，**連帶把 Panel 的 fallback 鏈從 `0.68 → 0.50 → native` 改成 `0.68 → 0.85 → native`**，而 #82 只量了字幕。這個 PR 補上那次缺的量測。

**結論：沒有退步。這個 PR 不改任何行為 —— 43 行純新增，全部是註解與一個新測試。**

## 擔心的是什麼

不是「0.85 比 0.50 差」這種泛泛的疑慮，而是一個具體的失效模式：0.68 和 0.85 **在 primary 的同一側**，所以「往下縮」那條退路整個消失了。而 `PanelFraction` 自己的註解記著 0.5 在它量測的那個形狀上讀到 9 個框中的 3 個 —— 兩者失敗方向相反正是它被選為 fallback 的理由。

**如果存在某個 panel 只有 0.5 讀得到，改動後就沒有任何尺寸救得了它**（native 只會更大）。

## 量了什麼

`OcrHarness --scale-sweep`，0.30–1.00 步進 0.05，走的是主專案的 `OnnxOcrEngine`，並套用即時翻譯真的會丟棄的塌陷框與過短讀取：

- `screen-panel-en-ja` 18 張
- `screen-panel-ko` 9 張（`--lang KO`）—— 扣掉 3 張在**任何**尺寸下字數都沒超過 harness 那條 10 字噪音地板的畫面，有效 6 張

```
primary (0.68) 讀不到、fallback 真的會觸發    0 / 24
0.50 比 0.85 明顯多讀                        0 / 24
```

有一張韓文畫面一度看起來就是要找的案例（0.50 → 72 字，0.85 → 58 字），但把它整條掃描讀完是 56–82 字**無趨勢跳動**，0.40 是 82、0.55 是 56。那是隨尺度的抖動，不是內容偏好某個 fraction。

## 這個量測沒有證明的事

**在這批樣本上 panel 的 fallback 從來不會被觸發**，因為 primary 讀到了全部 24 張。所以正確的結論是「這條鏈沒有受損」，而不是「這條鏈是好的」—— 它的價值在這裡是**未被量到**，不是被確認。

要推進這件事需要一張 primary 會失手的 panel，而現有 corpus 裡沒有。這點已寫進 `NativeFraction` 的 remarks，避免下一個人把「0 退步」誤讀成「已驗證」。

## 改了什麼

- `NativeFraction` 的 remarks：記錄這個耦合、#84 的量測、以及上面那個「未量到 ≠ 已確認」的但書。
- 新測試 `APanelFallsBackToWhateverTheStripFractionCurrentlyIs`：斷言的是 fallback **等於 `StripFraction` 這個常數**，不是等於 1568 這個數字 —— 釘住的是**耦合本身**，也就是「不必動任何 panel 相關的東西就能改變 panel 行為」的那條路徑。fraction 之後再變，這個測試仍然說得通。

## 順帶記錄一個量測陷阱

第一版解析器用 `chars=(\d+)`，但 harness 的欄位是右對齊補空白（`chars= 78`），於是**字數最低的列被整批漏掉** —— 少了 17 列與一整張圖，而那正是最可能出問題的一群。修正後結論相同，但第一版的數字是不能用的。

## 驗證

- 建置：0 警告 0 錯誤
- 測試：467 通過 / 0 失敗 / 2 略過（既有的 OCR 併發略過）
- `git diff`：src 端非註解變動行為 0
- CRLF 與無 BOM 已確認保留

> `detect_changes` 會把 `RoundToStride` 標成 touched 並報 medium —— 那是註解變長造成 hunk 邊界位移的誤判，該函式一個字元都沒動，已用 diff 過濾確認。
