### PR TITLE
feat: 新增即時翻譯區塊快捷鍵，並重整設定頁快捷鍵區與衝突處理

### DIFF
--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -71,6 +71,17 @@ public class AppSettings
     /// </remarks>
     public string RealtimeSourceLanguage { get; set; } = "";
     public string RealtimeTargetLanguage { get; set; } = LanguageData.DefaultTargetLanguage;
+
+    /// <summary>
+    /// How many blocks a session is set up to frame, 1–3.
+    /// </summary>
+    /// <remarks>
+    /// Kept, unlike everything else about a sitting, because the shortcut has to answer the same
+    /// question the page's stepper does and cannot read it off a page that is not open. Without this
+    /// the shortcut would always offer one block while the button offered three, which is the same
+    /// control giving two different answers.
+    /// </remarks>
+    public int RealtimeBlockCount { get; set; } = 1;
     public TranslationProvider RealtimeProvider { get; set; } = TranslationProvider.Microsoft;
     public string ApiKey { get; set; } = "";
     /// <summary>

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -60,16 +60,25 @@ public class AppSettings
     public string TargetLanguage { get; set; } = "ZH-HANT";
     public TranslationProvider Provider { get; set; } = TranslationProvider.Microsoft;
     /// <summary>
-    /// The language 即時翻譯 reads from, or empty for "not chosen yet".
+    /// The language 即時翻譯 reads from.
     /// </summary>
     /// <remarks>
-    /// Empty rather than <see cref="LanguageData.DefaultOcrSourceLanguage"/>, which is 自動 — a mode
-    /// the realtime picker deliberately does not offer, because recognition there gets one look at a
-    /// frame and no retry. A blank field asks the question; a default would answer it badly. Only a
-    /// language the user picked themselves is ever written here, so what comes back is always an
-    /// answer they gave once.
+    /// English rather than <see cref="LanguageData.DefaultOcrSourceLanguage"/>, which is 自動: the
+    /// realtime picker does not offer that mode, because recognition there gets one look at a frame
+    /// and no retry.
+    ///
+    /// This was deliberately blank once, on the reasoning that a guessed source language is worse
+    /// than a question — a blank field asks, a default answers badly. It was changed because the
+    /// question had to be asked from somewhere, and the shortcut that opens block framing has no
+    /// page to ask from; the alternative was a notification refusing to start, which is friction on
+    /// every first use to protect against a setting one trip to the page fixes.
+    ///
+    /// The cost is real and worth writing down: someone whose content is not English, who never
+    /// opens the realtime page and starts from the shortcut, gets English recognition over it and
+    /// nothing says why. See <see cref="LanguageData.GetValidRealtimeSourceCode"/>, which is where a
+    /// blank from before this default is resolved.
     /// </remarks>
-    public string RealtimeSourceLanguage { get; set; } = "";
+    public string RealtimeSourceLanguage { get; set; } = LanguageData.DefaultRealtimeSourceLanguage;
     public string RealtimeTargetLanguage { get; set; } = LanguageData.DefaultTargetLanguage;
 
     /// <summary>

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -25,6 +25,37 @@ public class AppSettings
     public uint TranslationWindowHotkeyVirtualKey { get; set; } = 0x57;
 
     public string TranslationWindowHotkeyDisplay { get; set; } = "Ctrl+Alt+W";
+
+    /// <summary>
+    /// Whether the translation-window shortcut is registered at all.
+    /// </summary>
+    /// <remarks>
+    /// There is no matching field for the capture shortcut, and deliberately not: that one is the
+    /// feature the application exists for, so its checkbox is ticked and disabled rather than backed
+    /// by a value. A stored flag that must always be true is a way to end up with it false.
+    /// </remarks>
+    public bool TranslationWindowHotkeyEnabled { get; set; } = true;
+
+    /// <summary>
+    /// The shortcut that adds an 即時翻譯 block. Ctrl+Alt+S by default.
+    /// </summary>
+    /// <remarks>
+    /// Stored as the same three fields as the two shortcuts above — the modifiers and key Windows is
+    /// given, plus the text the settings page shows — because the display string cannot be derived
+    /// from the other two without a key-name table, and the recorder already has the user's own
+    /// spelling of it at the moment they press the combination.
+    /// </remarks>
+    public uint RealtimeHotkeyModifiers { get; set; } = 3;
+
+    /// <inheritdoc cref="RealtimeHotkeyModifiers"/>
+    public uint RealtimeHotkeyVirtualKey { get; set; } = 0x53;
+
+    /// <inheritdoc cref="RealtimeHotkeyModifiers"/>
+    public string RealtimeHotkeyDisplay { get; set; } = "Ctrl+Alt+S";
+
+    /// <inheritdoc cref="TranslationWindowHotkeyEnabled"/>
+    public bool RealtimeHotkeyEnabled { get; set; } = true;
+
     public string SourceLanguage { get; set; } = LanguageData.DefaultOcrSourceLanguage;
     public string TargetLanguage { get; set; } = "ZH-HANT";
     public TranslationProvider Provider { get; set; } = TranslationProvider.Microsoft;

--- a/src/OverTranslate/Models/LanguageData.cs
+++ b/src/OverTranslate/Models/LanguageData.cs
@@ -70,6 +70,12 @@ public static class LanguageData
     public const string DefaultOcrSourceLanguage = AutomaticSourceLanguage;
     public const string DefaultTargetLanguage = "ZH-HANT";
 
+    /// <summary>
+    /// What 即時翻譯 reads from until the user says otherwise — see
+    /// <see cref="GetValidRealtimeSourceCode"/> for why it cannot be 自動 like the screenshot flow's.
+    /// </summary>
+    public const string DefaultRealtimeSourceLanguage = "EN";
+
     public static readonly List<LangItem> SourceLanguages =
     [
         new(AutomaticSourceLanguage, "自動", "Automatic"),
@@ -224,6 +230,25 @@ public static class LanguageData
         var match = OcrSourceLanguages.FirstOrDefault(l =>
             l.Code.Equals(sourceCode, StringComparison.OrdinalIgnoreCase));
         return match?.Code ?? DefaultOcrSourceLanguage;
+    }
+
+    /// <summary>
+    /// What 即時翻譯 reads from, for a setting that may be blank, invalid, or 自動.
+    /// </summary>
+    /// <remarks>
+    /// Its own resolver rather than <see cref="GetValidOcrSourceCode"/> because the two fall back to
+    /// different places: 自動 is a fine answer for a screenshot, which can be read again, and not one
+    /// realtime can use — its picker does not offer it, recognition there gets one look at a frame,
+    /// and a mode that guesses per frame makes a subtitle track flicker between languages.
+    ///
+    /// So everything that is not a real language lands on <see cref="DefaultRealtimeSourceLanguage"/>:
+    /// a blank from before this had a default, 自動 from a hand-edited file, and a code retired since.
+    /// One branch covers all three, and the result is always something the session can actually read.
+    /// </remarks>
+    public static string GetValidRealtimeSourceCode(string? sourceCode)
+    {
+        var resolved = GetValidOcrSourceCode(sourceCode);
+        return IsAutomaticSource(resolved) ? DefaultRealtimeSourceLanguage : resolved;
     }
 
     public static string GetValidTargetCode(string? targetCode)

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -241,7 +241,7 @@ Leave a little room around the whole area; box several areas separately rather t
     <!-- The checkbox carries no text, so this is its ToolTip rather than a label -->
     <sys:String x:Key="S.Settings.HotkeyEnable">Enable this shortcut</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkey">Realtime block</sys:String>
-    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">Press this shortcut to enter realtime block editing mode</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">Press this shortcut to enter realtime [[block selection mode]]</sys:String>
     <sys:String x:Key="S.Settings.HotkeyShadowed">✗ Same as "{0}" above, so it is off</sys:String>
 
     <sys:String x:Key="S.Settings.General">General</sys:String>
@@ -251,7 +251,7 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.WindowHotkeyHint">While [[realtime translation]] is running, brings the [[floating bar]] to the front instead</sys:String>
     <sys:String x:Key="S.Settings.SourceLanguage">Source</sys:String>
     <sys:String x:Key="S.Settings.AutoTranslate">Auto</sys:String>
-    <sys:String x:Key="S.Settings.AutoTranslateCheck">Screenshot translation: translate as soon as a region is selected, with nothing left to click.</sys:String>
+    <sys:String x:Key="S.Settings.AutoTranslateCheck">Translate as soon as a screen capture region is selected, with nothing left to click.</sys:String>
     <sys:String x:Key="S.Settings.Startup">Startup</sys:String>
     <sys:String x:Key="S.Settings.StartupCheck">Launch when Windows starts</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -237,6 +237,13 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.Title">Settings</sys:String>
     <sys:String x:Key="S.Settings.Subtitle">Shortcuts, translation services, screenshots and appearance</sys:String>
 
+    <sys:String x:Key="S.Settings.Hotkeys">Shortcuts</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyEnable">Enabled</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyAlwaysOnTip">Capture is the core feature; its shortcut cannot be turned off</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkey">Realtime block</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">Press this shortcut to add a [[realtime translation]] block</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyShadowed">✗ Same as "{0}" above, so it is off</sys:String>
+
     <sys:String x:Key="S.Settings.General">General</sys:String>
     <sys:String x:Key="S.Settings.CaptureHotkey">Capture</sys:String>
     <sys:String x:Key="S.Settings.CaptureHotkeyHint">Press this shortcut to start a screen capture translation; while [[realtime translation]] is running it [[pauses / resumes]] the realtime translation instead</sys:String>
@@ -248,7 +255,7 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.Startup">Startup</sys:String>
     <sys:String x:Key="S.Settings.StartupCheck">Launch when Windows starts</sys:String>
 
-    <sys:String x:Key="S.Settings.TranslationApi">Translation API</sys:String>
+    <sys:String x:Key="S.Settings.Translation">Translation</sys:String>
     <sys:String x:Key="S.Settings.Provider">Provider</sys:String>
     <sys:String x:Key="S.Settings.ApiBaseUrl">API URL</sys:String>
     <sys:String x:Key="S.Settings.ModelName">Model</sys:String>
@@ -266,7 +273,6 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.TemperatureHint" xml:space="preserve">Temperature controls how random the output is; 0 keeps it as predictable as possible, and higher values allow more variation.
 The parameter is left out of the request when this is off. Models differ — follow whatever the model recommends.</sys:String>
 
-    <sys:String x:Key="S.Settings.Screenshot">Screenshots</sys:String>
     <sys:String x:Key="S.Settings.SaveScreenshot">Save</sys:String>
     <sys:String x:Key="S.Settings.SaveScreenshotCheck">Save a copy of every capture</sys:String>
     <sys:String x:Key="S.Settings.SavePath">Location</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -238,10 +238,10 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.Subtitle">Shortcuts, translation services, screenshots and appearance</sys:String>
 
     <sys:String x:Key="S.Settings.Hotkeys">Shortcuts</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyEnable">Enabled</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyAlwaysOnTip">Capture is the core feature; its shortcut cannot be turned off</sys:String>
+    <!-- The checkbox carries no text, so this is its ToolTip rather than a label -->
+    <sys:String x:Key="S.Settings.HotkeyEnable">Enable this shortcut</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkey">Realtime block</sys:String>
-    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">Press this shortcut to add a [[realtime translation]] block</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">Press this shortcut to enter realtime block editing mode</sys:String>
     <sys:String x:Key="S.Settings.HotkeyShadowed">✗ Same as "{0}" above, so it is off</sys:String>
 
     <sys:String x:Key="S.Settings.General">General</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -252,6 +252,13 @@
     <sys:String x:Key="S.Settings.Title">設定</sys:String>
     <sys:String x:Key="S.Settings.Subtitle">管理快捷鍵、翻譯服務、截圖與外觀</sys:String>
 
+    <sys:String x:Key="S.Settings.Hotkeys">快捷鍵</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyEnable">啟用</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyAlwaysOnTip">截圖翻譯是核心功能，快捷鍵無法停用</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkey">即時翻譯區塊</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">按下快捷鍵即可新增一個[[即時翻譯]]區塊</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyShadowed">✗ 與上方的「{0}」重複，已停用</sys:String>
+
     <sys:String x:Key="S.Settings.General">一般設定</sys:String>
     <sys:String x:Key="S.Settings.CaptureHotkey">截圖翻譯</sys:String>
     <!-- [[…]] 內的字會以主題色強調，見 Views/Controls/HighlightedText。兩種語言的標記數量必須一致，
@@ -265,7 +272,7 @@
     <sys:String x:Key="S.Settings.Startup">開機啟動</sys:String>
     <sys:String x:Key="S.Settings.StartupCheck">開機時自動啟動</sys:String>
 
-    <sys:String x:Key="S.Settings.TranslationApi">翻譯 API</sys:String>
+    <sys:String x:Key="S.Settings.Translation">翻譯</sys:String>
     <sys:String x:Key="S.Settings.Provider">翻譯服務</sys:String>
     <sys:String x:Key="S.Settings.ApiBaseUrl">API 位址</sys:String>
     <sys:String x:Key="S.Settings.ModelName">模型名稱</sys:String>
@@ -283,7 +290,6 @@
     <sys:String x:Key="S.Settings.TemperatureHint" xml:space="preserve">Temperature 會影響輸出的隨機程度；0 代表盡量降低隨機性，提高數值則會增加輸出變化。
 未啟用時不傳送此參數。不同模型適合的設定不同，建議依模型建議值設定。</sys:String>
 
-    <sys:String x:Key="S.Settings.Screenshot">截圖</sys:String>
     <sys:String x:Key="S.Settings.SaveScreenshot">儲存截圖</sys:String>
     <sys:String x:Key="S.Settings.SaveScreenshotCheck">截圖時自動儲存</sys:String>
     <sys:String x:Key="S.Settings.SavePath">儲存位置</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -253,10 +253,10 @@
     <sys:String x:Key="S.Settings.Subtitle">管理快捷鍵、翻譯服務、截圖與外觀</sys:String>
 
     <sys:String x:Key="S.Settings.Hotkeys">快捷鍵</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyEnable">啟用</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyAlwaysOnTip">截圖翻譯是核心功能，快捷鍵無法停用</sys:String>
+    <!-- 勾選框沒有文字，所以這是它的 ToolTip，不是標籤 -->
+    <sys:String x:Key="S.Settings.HotkeyEnable">啟用此快捷鍵</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkey">即時翻譯區塊</sys:String>
-    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">按下快捷鍵即可新增一個[[即時翻譯]]區塊</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">按下快捷鍵即可進入即時翻譯區塊編輯模式</sys:String>
     <sys:String x:Key="S.Settings.HotkeyShadowed">✗ 與上方的「{0}」重複，已停用</sys:String>
 
     <sys:String x:Key="S.Settings.General">一般設定</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -256,7 +256,7 @@
     <!-- 勾選框沒有文字，所以這是它的 ToolTip，不是標籤 -->
     <sys:String x:Key="S.Settings.HotkeyEnable">啟用此快捷鍵</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkey">即時翻譯區塊</sys:String>
-    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">按下快捷鍵即可進入即時翻譯區塊編輯模式</sys:String>
+    <sys:String x:Key="S.Settings.RealtimeHotkeyHint">按下快捷鍵即可進入即時[[翻譯區塊選取模式]]</sys:String>
     <sys:String x:Key="S.Settings.HotkeyShadowed">✗ 與上方的「{0}」重複，已停用</sys:String>
 
     <sys:String x:Key="S.Settings.General">一般設定</sys:String>
@@ -268,7 +268,7 @@
     <sys:String x:Key="S.Settings.WindowHotkeyHint">[[即時翻譯]]進行中時，改為將[[浮動視窗列]]移至最上層</sys:String>
     <sys:String x:Key="S.Settings.SourceLanguage">來源語言</sys:String>
     <sys:String x:Key="S.Settings.AutoTranslate">自動翻譯</sys:String>
-    <sys:String x:Key="S.Settings.AutoTranslateCheck">截圖翻譯：框選完成後立即翻譯，不需要再手動點擊。</sys:String>
+    <sys:String x:Key="S.Settings.AutoTranslateCheck">截圖翻譯框選完成時立即翻譯，不需要再手動點擊。</sys:String>
     <sys:String x:Key="S.Settings.Startup">開機啟動</sys:String>
     <sys:String x:Key="S.Settings.StartupCheck">開機時自動啟動</sys:String>
 

--- a/src/OverTranslate/Services/GlobalHotkey.cs
+++ b/src/OverTranslate/Services/GlobalHotkey.cs
@@ -25,6 +25,9 @@ public class GlobalHotkey : IDisposable
     /// <summary>The shortcut that opens the translation window.</summary>
     public const int TranslationWindowId = 9002;
 
+    /// <summary>The shortcut that drops straight into 即時翻譯 block framing.</summary>
+    public const int RealtimeId = 9003;
+
     public GlobalHotkey(int id) => _id = id;
 
     [DllImport("user32.dll", SetLastError = true)]

--- a/src/OverTranslate/Services/HotkeyBindings.cs
+++ b/src/OverTranslate/Services/HotkeyBindings.cs
@@ -1,0 +1,90 @@
+using OverTranslate.Models;
+
+namespace OverTranslate.Services;
+
+/// <summary>The three global shortcuts, in priority order — see <see cref="HotkeyBindings"/>.</summary>
+public enum HotkeyAction
+{
+    Capture,
+    TranslationWindow,
+    Realtime,
+}
+
+/// <param name="ShadowedBy">
+/// The higher-priority action holding this combination, or null when this one gets it. Carried so the
+/// settings page can say which shortcut took it rather than only that this one is off.
+/// </param>
+public readonly record struct HotkeyBinding(
+    HotkeyAction Action,
+    uint Modifiers,
+    uint VirtualKey,
+    bool Enabled,
+    HotkeyAction? ShadowedBy)
+{
+    /// <summary>Whether this one should actually be registered with Windows.</summary>
+    public bool IsActive => Enabled && ShadowedBy is null;
+}
+
+/// <summary>
+/// Works out which shortcuts are live when two of them want the same combination.
+/// </summary>
+/// <remarks>
+/// Windows keys a registration by window and combination, so the second claim on one is simply
+/// refused: <c>RegisterHotKey</c> returns false and nothing else happens. Which of the two loses is
+/// then whichever happened to be registered second, i.e. an ordering nobody chose.
+///
+/// The settings page already refuses to RECORD a combination another shortcut holds, so a user
+/// cannot create the clash by hand. Stored settings can still arrive in one anyway, and that is what
+/// this exists for: adding <see cref="HotkeyAction.Realtime"/> gave every existing installation a
+/// Ctrl+Alt+S it never agreed to, and anyone who had already put Ctrl+Alt+S on the translation
+/// window would have had one of the two stop working with no explanation.
+///
+/// So the order is declared rather than discovered, and it runs from the feature the application is
+/// for down to the most recently added: capture, then the translation window, then realtime. A
+/// shortcut shadowed by a higher one is reported rather than silently dropped.
+/// </remarks>
+public static class HotkeyBindings
+{
+    /// <summary>
+    /// Every shortcut, in priority order, each marked with whether it is live and what took it.
+    /// </summary>
+    public static IReadOnlyList<HotkeyBinding> Resolve(AppSettings settings)
+    {
+        // Declaration order IS the priority order; nothing else encodes it.
+        var declared = new (HotkeyAction Action, uint Modifiers, uint Key, bool Enabled)[]
+        {
+            (HotkeyAction.Capture, settings.HotkeyModifiers, settings.HotkeyVirtualKey, true),
+            (HotkeyAction.TranslationWindow,
+                settings.TranslationWindowHotkeyModifiers,
+                settings.TranslationWindowHotkeyVirtualKey,
+                settings.TranslationWindowHotkeyEnabled),
+            (HotkeyAction.Realtime,
+                settings.RealtimeHotkeyModifiers,
+                settings.RealtimeHotkeyVirtualKey,
+                settings.RealtimeHotkeyEnabled),
+        };
+
+        var claimed = new Dictionary<(uint, uint), HotkeyAction>();
+        var resolved = new List<HotkeyBinding>(declared.Length);
+
+        foreach (var (action, modifiers, key, enabled) in declared)
+        {
+            // A disabled shortcut does not claim its combination, so turning one off hands the
+            // combination to whatever was shadowed by it rather than leaving it reserved.
+            HotkeyAction? shadowedBy = null;
+            if (enabled)
+            {
+                if (claimed.TryGetValue((modifiers, key), out var holder)) shadowedBy = holder;
+                else claimed[(modifiers, key)] = action;
+            }
+
+            resolved.Add(new HotkeyBinding(action, modifiers, key, enabled, shadowedBy));
+        }
+
+        return resolved;
+    }
+
+    /// <summary>The shortcuts to register, in priority order.</summary>
+    public static IEnumerable<HotkeyBinding> Active(AppSettings settings) =>
+        Resolve(settings).Where(binding => binding.IsActive);
+}

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -73,6 +73,27 @@ public partial class MainWindow : Window
         };
     }
 
+    /// <summary>
+    /// Binds the shortcuts the settings say should be live, highest priority first.
+    /// </summary>
+    /// <remarks>
+    /// Through <see cref="HotkeyBindings"/> rather than one <c>Register</c> call per shortcut,
+    /// because two of them can want the same combination and Windows resolves that badly: it keys a
+    /// registration by window and combination, so the second claim is refused, <c>RegisterHotKey</c>
+    /// returns false, and nothing else happens — one shortcut stops working and no code here would
+    /// know which. Which one lost would also be whichever happened to be registered second, an
+    /// ordering nobody chose.
+    ///
+    /// The settings page refuses to RECORD a combination another shortcut holds, so this is not
+    /// reachable by editing. It is reachable two other ways, and both are the point: settings.json is
+    /// a text file someone can edit, and shipping a new shortcut hands every existing installation a
+    /// default it never agreed to — anyone already using that combination for something else would
+    /// have had one of the two go quiet.
+    ///
+    /// A shortcut with no action yet is simply absent from the table below rather than registered
+    /// against nothing: claiming a combination globally takes it away from every other application,
+    /// which is a real cost to pay for a key that would do nothing.
+    /// </remarks>
     private void RegisterHotkey()
     {
         var settings = SettingsService.Instance.Current;
@@ -80,17 +101,41 @@ public partial class MainWindow : Window
 
         _hotkey = new GlobalHotkey(GlobalHotkey.CaptureId);
         _hotkey.HotkeyPressed += OnHotkeyPressed;
-        _hotkey.Register(hwnd, settings.HotkeyModifiers, settings.HotkeyVirtualKey);
 
         // Deliberately quiet, unlike the one above: no startup notification and nothing in the
         // interface naming it. It saves a trip to the tray for a user who already knows it is
         // there, and a user who does not loses nothing by never finding it.
         _windowHotkey = new GlobalHotkey(GlobalHotkey.TranslationWindowId);
         _windowHotkey.HotkeyPressed += OnTranslationWindowHotkeyPressed;
-        _windowHotkey.Register(
-            hwnd,
-            settings.TranslationWindowHotkeyModifiers,
-            settings.TranslationWindowHotkeyVirtualKey);
+
+        var hooks = new Dictionary<HotkeyAction, GlobalHotkey>
+        {
+            [HotkeyAction.Capture] = _hotkey,
+            [HotkeyAction.TranslationWindow] = _windowHotkey,
+        };
+
+        foreach (var binding in HotkeyBindings.Resolve(settings))
+        {
+            if (!hooks.TryGetValue(binding.Action, out var hook)) continue;
+
+            if (binding.ShadowedBy is { } holder)
+            {
+                // Warn rather than Debug: the user pressed a key and nothing happened, and this line
+                // is the only place that says why.
+                Log.Warn(
+                    "Hotkey {Action} not registered: {Holder} already claims that combination",
+                    binding.Action, holder);
+                continue;
+            }
+
+            if (!binding.Enabled)
+            {
+                Log.Info("Hotkey {Action} is switched off in settings", binding.Action);
+                continue;
+            }
+
+            hook.Register(hwnd, binding.Modifiers, binding.VirtualKey);
+        }
     }
 
     private void ShowStartupBalloon()

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -23,6 +23,7 @@ public partial class MainWindow : Window
     private TrayMenuWindow? _trayMenu;
     private GlobalHotkey? _hotkey;
     private GlobalHotkey? _windowHotkey;
+    private GlobalHotkey? _realtimeHotkey;
     private OverlayWindow? _overlayWindow;
     private ScreenCaptureWindow? _captureWindow;
     private ToolbarWindow? _toolbarWindow;
@@ -90,9 +91,9 @@ public partial class MainWindow : Window
     /// default it never agreed to — anyone already using that combination for something else would
     /// have had one of the two go quiet.
     ///
-    /// A shortcut with no action yet is simply absent from the table below rather than registered
-    /// against nothing: claiming a combination globally takes it away from every other application,
-    /// which is a real cost to pay for a key that would do nothing.
+    /// A shortcut with no action would be absent from the table below rather than registered against
+    /// nothing: claiming a combination globally takes it away from every other application, which is
+    /// a real cost to pay for a key that would do nothing.
     /// </remarks>
     private void RegisterHotkey()
     {
@@ -108,10 +109,14 @@ public partial class MainWindow : Window
         _windowHotkey = new GlobalHotkey(GlobalHotkey.TranslationWindowId);
         _windowHotkey.HotkeyPressed += OnTranslationWindowHotkeyPressed;
 
+        _realtimeHotkey = new GlobalHotkey(GlobalHotkey.RealtimeId);
+        _realtimeHotkey.HotkeyPressed += OnRealtimeHotkeyPressed;
+
         var hooks = new Dictionary<HotkeyAction, GlobalHotkey>
         {
             [HotkeyAction.Capture] = _hotkey,
             [HotkeyAction.TranslationWindow] = _windowHotkey,
+            [HotkeyAction.Realtime] = _realtimeHotkey,
         };
 
         foreach (var binding in HotkeyBindings.Resolve(settings))
@@ -182,7 +187,49 @@ public partial class MainWindow : Window
     {
         _hotkey?.Unregister();
         _windowHotkey?.Unregister();
+        _realtimeHotkey?.Unregister();
         RegisterHotkey();
+    }
+
+    /// <summary>
+    /// Drops straight into 即時翻譯 block framing, the thing the page's 開始 button does.
+    /// </summary>
+    /// <remarks>
+    /// Inert once any realtime stage is running — framing or translating. The session covers the
+    /// screen and carries its own controls at that point, so a second press has nothing to mean, and
+    /// the alternative reading (start another one) is refused by the controller anyway.
+    ///
+    /// The refusals are notifications rather than silence because the user pressed a key and is owed
+    /// an answer, and rather than the page's status line because there may be no page open — the
+    /// shortcut's whole point is not needing one. See ShowTrayNotification for why the tray and not
+    /// the application's own toast.
+    /// </remarks>
+    private void OnRealtimeHotkeyPressed(object? sender, EventArgs e)
+    {
+        if (RealtimeSessionController.Instance.IsActive) return;
+
+        // The same rule the page enforces in both directions: one OCR engine, one pool of inference
+        // slots, and neither feature is any use with the other competing for them.
+        if (IsCapturing)
+        {
+            ShowTrayNotification(
+                LocalizationService.Get("S.Realtime.Title"),
+                LocalizationService.Get("S.Realtime.CaptureInProgress"));
+            return;
+        }
+
+        var quickStart = RealtimeQuickStart.From(SettingsService.Instance.Current);
+        if (quickStart.Request is not { } request)
+        {
+            ShowTrayNotification(
+                LocalizationService.Get("S.Realtime.Title"),
+                LocalizationService.Get(quickStart.BlockedReasonKey!));
+            return;
+        }
+
+        // Null when the shell is closed to the tray, which is the common case for a shortcut and
+        // means there is nothing to put away.
+        RealtimeSessionController.Instance.Start(request, ShellWindow.Current);
     }
 
     /// <summary>
@@ -932,6 +979,7 @@ public partial class MainWindow : Window
         DisposeEscapeHook();
         _hotkey?.Dispose();
         _windowHotkey?.Dispose();
+        _realtimeHotkey?.Dispose();
         if (_notifyIcon != null)
         {
             _notifyIcon.Visible = false;

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
@@ -139,9 +139,11 @@ public partial class RealtimePage : UserControl
     private void ApplyPageDefaults()
     {
         var settings = SettingsService.Instance.Current;
-        var storedSource = LanguageData.GetValidOcrSourceCode(settings.RealtimeSourceLanguage);
+        // Never null any more: the picker used to be left blank so that only a language the user
+        // chose was ever used, and the shortcut has no page on which to ask. Anything unusable —
+        // blank from an older settings file, 自動 from a hand-edited one — resolves to the default.
         SrcLangBox.SelectedValue =
-            LanguageData.IsAutomaticSource(storedSource) ? null : storedSource;
+            LanguageData.GetValidRealtimeSourceCode(settings.RealtimeSourceLanguage);
         TgtLangBox.SelectedValue = LanguageData.GetValidTargetCode(
             settings.RealtimeTargetLanguage);
         if (TgtLangBox.SelectedValue == null)

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml.cs
@@ -73,8 +73,9 @@ public partial class RealtimePage : UserControl
     /// </summary>
     private const TranslationProvider DefaultProvider = TranslationProvider.Microsoft;
 
-    private const int MinBlocks = 1;
-    private const int MaxBlocks = 3;
+    // Shared with the shortcut path, which has to offer the same range without this page open.
+    private const int MinBlocks = RealtimeQuickStart.MinBlocks;
+    private const int MaxBlocks = RealtimeQuickStart.MaxBlocks;
 
     private int _blockCount = MinBlocks;
 
@@ -151,6 +152,10 @@ public partial class RealtimePage : UserControl
             ProviderBox.SelectedValue = DefaultProvider;
         if (ProviderBox.SelectedValue == null) ProviderBox.SelectedIndex = 0;
         RenderProviderHint();
+
+        // Clamped rather than trusted: this is a settings-file value and the stepper's range is the
+        // one that has to hold. RenderBlockCount runs later, from Reload.
+        _blockCount = Math.Clamp(settings.RealtimeBlockCount, MinBlocks, MaxBlocks);
     }
 
     /// <summary>
@@ -515,6 +520,10 @@ public partial class RealtimePage : UserControl
         if (next == _blockCount) return;
 
         _blockCount = next;
+
+        // Kept, unlike the rest of a sitting: the shortcut has to offer the same number of blocks as
+        // this stepper and cannot read it off a page that is not open. See AppSettings.
+        SaveTranslationPreference(settings => settings.RealtimeBlockCount = next);
 
         // The blocks kept from the last sitting were drawn to fill a different count, so they are
         // no longer an answer to the question being asked. Dropped as the count moves rather than

--- a/src/OverTranslate/Views/Realtime/RealtimeQuickStart.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeQuickStart.cs
@@ -1,0 +1,65 @@
+using OverTranslate.Models;
+using Screen = System.Windows.Forms.Screen;
+
+namespace OverTranslate.Views.Realtime;
+
+/// <summary>
+/// Whether a shortcut press can drop straight into block framing, and what to say when it cannot.
+/// </summary>
+/// <remarks>
+/// The page's 開始 button asks the same questions, but it asks them of its own pickers. A shortcut has
+/// no page — it can be pressed with the shell closed to the tray — so the answers have to come from
+/// the settings file, and the ones that are not stored have to have somewhere to come from.
+///
+/// The source language is the one that actually stops people: 即時翻譯 deliberately does not offer 自動
+/// (recognition there gets one look at a frame and no retry), so a first run has nothing in it and a
+/// shortcut pressed then would otherwise open a framing layer that cannot translate anything. That is
+/// what <see cref="BlockedReasonKey"/> exists to say, out loud, through a notification.
+/// </remarks>
+internal readonly record struct RealtimeQuickStart(
+    RealtimeStartRequest? Request,
+    string? BlockedReasonKey)
+{
+    /// <summary>Fewest and most blocks a session may frame — the page's stepper obeys the same pair.</summary>
+    public const int MinBlocks = 1;
+
+    /// <inheritdoc cref="MinBlocks"/>
+    public const int MaxBlocks = 3;
+
+    public bool CanStart => Request is not null;
+
+    /// <summary>
+    /// Reads the settings and either builds a request or names the first thing that is missing.
+    /// </summary>
+    /// <remarks>
+    /// Checked in the same order as the button, so the two paths refuse for the same reason when more
+    /// than one thing is wrong. Whether a capture or another session is already running is not asked
+    /// here: those are facts about the moment rather than about the settings, and the caller holds
+    /// them.
+    /// </remarks>
+    public static RealtimeQuickStart From(AppSettings settings)
+    {
+        var source = LanguageData.GetValidOcrSourceCode(settings.RealtimeSourceLanguage);
+        if (string.IsNullOrWhiteSpace(source) || LanguageData.IsAutomaticSource(source))
+            return new RealtimeQuickStart(null, "S.Realtime.ChooseSourceFirst");
+
+        // Primary first, then whatever exists. The page prefers the monitor its own window sits on,
+        // which is a better answer and one a shortcut cannot have — there may be no window open.
+        var screens = Screen.AllScreens;
+        var screen = Array.Find(screens, candidate => candidate.Primary) ?? screens.FirstOrDefault();
+        if (screen is null)
+            return new RealtimeQuickStart(null, "S.Realtime.NoScreens");
+
+        return new RealtimeQuickStart(
+            new RealtimeStartRequest(
+                screen.Bounds,
+                Math.Clamp(settings.RealtimeBlockCount, MinBlocks, MaxBlocks),
+                source,
+                LanguageData.GetValidTargetCode(settings.RealtimeTargetLanguage),
+                settings.RealtimeProvider,
+                settings.RealtimeTextColor,
+                settings.RealtimeScrimColor,
+                settings.RealtimeScrimOpacity),
+            null);
+    }
+}

--- a/src/OverTranslate/Views/Realtime/RealtimeQuickStart.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeQuickStart.cs
@@ -11,10 +11,10 @@ namespace OverTranslate.Views.Realtime;
 /// no page — it can be pressed with the shell closed to the tray — so the answers have to come from
 /// the settings file, and the ones that are not stored have to have somewhere to come from.
 ///
-/// The source language is the one that actually stops people: 即時翻譯 deliberately does not offer 自動
-/// (recognition there gets one look at a frame and no retry), so a first run has nothing in it and a
-/// shortcut pressed then would otherwise open a framing layer that cannot translate anything. That is
-/// what <see cref="BlockedReasonKey"/> exists to say, out loud, through a notification.
+/// Only one thing can still refuse, and it is not a setting: with no monitor attached there is
+/// nowhere to frame anything. Everything else resolves to a default rather than stopping the user,
+/// including a source language left blank by a version that had no default for it — see
+/// <see cref="LanguageData.GetValidRealtimeSourceCode"/>.
 /// </remarks>
 internal readonly record struct RealtimeQuickStart(
     RealtimeStartRequest? Request,
@@ -32,17 +32,11 @@ internal readonly record struct RealtimeQuickStart(
     /// Reads the settings and either builds a request or names the first thing that is missing.
     /// </summary>
     /// <remarks>
-    /// Checked in the same order as the button, so the two paths refuse for the same reason when more
-    /// than one thing is wrong. Whether a capture or another session is already running is not asked
-    /// here: those are facts about the moment rather than about the settings, and the caller holds
-    /// them.
+    /// Whether a capture or another session is already running is not asked here: those are facts
+    /// about the moment rather than about the settings, and the caller holds them.
     /// </remarks>
     public static RealtimeQuickStart From(AppSettings settings)
     {
-        var source = LanguageData.GetValidOcrSourceCode(settings.RealtimeSourceLanguage);
-        if (string.IsNullOrWhiteSpace(source) || LanguageData.IsAutomaticSource(source))
-            return new RealtimeQuickStart(null, "S.Realtime.ChooseSourceFirst");
-
         // Primary first, then whatever exists. The page prefers the monitor its own window sits on,
         // which is a better answer and one a shortcut cannot have — there may be no window open.
         var screens = Screen.AllScreens;
@@ -54,7 +48,7 @@ internal readonly record struct RealtimeQuickStart(
             new RealtimeStartRequest(
                 screen.Bounds,
                 Math.Clamp(settings.RealtimeBlockCount, MinBlocks, MaxBlocks),
-                source,
+                LanguageData.GetValidRealtimeSourceCode(settings.RealtimeSourceLanguage),
                 LanguageData.GetValidTargetCode(settings.RealtimeTargetLanguage),
                 settings.RealtimeProvider,
                 settings.RealtimeTextColor,

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -77,33 +77,33 @@
                         <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Hotkeys}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- Capture has no on/off tick at all: this is the feature the application
-                             is for. Its first column is empty and still here, so the three rows'
-                             labels and boxes line up — see SharedSizeGroup. -->
+                             is for. Its last column is empty and still here, so the three rows'
+                             shortcut boxes end at the same place — see SharedSizeGroup. -->
                         <Grid Grid.Row="1" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{DynamicResource S.Settings.CaptureHotkey}"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.CaptureHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="2" Grid.Row="0" x:Name="HotkeyBox"
+                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="HotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
                                        IsReadOnly="True"
                                        Margin="0,0,8,0"
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="3" Grid.Row="0" x:Name="RecordBtn" Content="{DynamicResource S.Common.Record}"
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="RecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <TextBlock Grid.Column="2" Grid.Row="1" Grid.ColumnSpan="2"
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.CaptureHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
                         </Grid>
@@ -113,40 +113,40 @@
                              tray click away, so it is not announced at startup. -->
                         <Grid Grid.Row="2" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <CheckBox  Grid.Column="0" Grid.Row="0" x:Name="WindowHotkeyEnabledCheckBox"
-                                       Style="{StaticResource ModernCheckBox}"
-                                       VerticalAlignment="Center"
-                                       Margin="0,0,10,0"
-                                       ToolTip="{DynamicResource S.Settings.HotkeyEnable}"
-                                       Checked="HotkeyEnabled_Toggled"
-                                       Unchecked="HotkeyEnabled_Toggled"/>
-                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{DynamicResource S.Settings.WindowHotkey}"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.WindowHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="2" Grid.Row="0" x:Name="WindowHotkeyBox"
+                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="WindowHotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
                                        IsReadOnly="True"
                                        Margin="0,0,8,0"
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="3" Grid.Row="0" x:Name="WindowRecordBtn" Content="{DynamicResource S.Common.Record}"
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="WindowRecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <TextBlock Grid.Column="2" Grid.Row="1" Grid.ColumnSpan="2"
+                            <CheckBox  Grid.Column="3" Grid.Row="0" x:Name="WindowHotkeyEnabledCheckBox"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="10,0,0,0"
+                                       ToolTip="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Checked="HotkeyEnabled_Toggled"
+                                       Unchecked="HotkeyEnabled_Toggled"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.WindowHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
-                            <TextBlock Grid.Column="2" Grid.Row="2" Grid.ColumnSpan="2"
+                            <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
                                        x:Name="WindowHotkeyShadowHint"
                                        Style="{StaticResource FieldHint}"
                                        Visibility="Collapsed"/>
@@ -155,40 +155,40 @@
                         <!-- Realtime block. -->
                         <Grid Grid.Row="3">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <CheckBox  Grid.Column="0" Grid.Row="0" x:Name="RealtimeHotkeyEnabledCheckBox"
-                                       Style="{StaticResource ModernCheckBox}"
-                                       VerticalAlignment="Center"
-                                       Margin="0,0,10,0"
-                                       ToolTip="{DynamicResource S.Settings.HotkeyEnable}"
-                                       Checked="HotkeyEnabled_Toggled"
-                                       Unchecked="HotkeyEnabled_Toggled"/>
-                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{DynamicResource S.Settings.RealtimeHotkey}"
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.RealtimeHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="2" Grid.Row="0" x:Name="RealtimeHotkeyBox"
+                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="RealtimeHotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
                                        IsReadOnly="True"
                                        Margin="0,0,8,0"
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="3" Grid.Row="0" x:Name="RealtimeRecordBtn" Content="{DynamicResource S.Common.Record}"
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="RealtimeRecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <TextBlock Grid.Column="2" Grid.Row="1" Grid.ColumnSpan="2"
+                            <CheckBox  Grid.Column="3" Grid.Row="0" x:Name="RealtimeHotkeyEnabledCheckBox"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="10,0,0,0"
+                                       ToolTip="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Checked="HotkeyEnabled_Toggled"
+                                       Unchecked="HotkeyEnabled_Toggled"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.RealtimeHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
-                            <TextBlock Grid.Column="2" Grid.Row="2" Grid.ColumnSpan="2"
+                            <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
                                        x:Name="RealtimeHotkeyShadowHint"
                                        Style="{StaticResource FieldHint}"
                                        Visibility="Collapsed"/>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -61,7 +61,10 @@
                     </Grid>
                 </Border>
 
-                <!-- ── 一般設定 ── -->
+                <!-- ── 快捷鍵 ──
+                     Order is priority order: a combination claimed by a row above turns the row
+                     below off rather than one of the two silently failing to register. See
+                     Services/HotkeyBindings. -->
                 <Border Style="{StaticResource CardBorder}">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -69,18 +72,19 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.General}" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Hotkeys}" Style="{StaticResource SectionHeader}"/>
 
-                        <!-- Hotkey row -->
+                        <!-- Capture. Its checkbox is ticked and disabled rather than bound to a
+                             setting: this is the feature the application is for, and a stored flag
+                             that must always be true is a way to end up with it false. -->
                         <Grid Grid.Row="1" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
@@ -99,22 +103,32 @@
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
+                            <CheckBox  Grid.Column="3" Grid.Row="0"
+                                       Content="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="10,0,0,0"
+                                       IsChecked="True"
+                                       IsEnabled="False"
+                                       ToolTipService.ShowOnDisabled="True"
+                                       ToolTip="{DynamicResource S.Settings.HotkeyAlwaysOnTip}"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.CaptureHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
                         </Grid>
 
-                        <!-- Translation-window hotkey row. Same editing controls as the capture
-                             shortcut above and deliberately nothing else: this one is a shortcut to
-                             a window that is already one tray click away, so it is not announced at
-                             startup and nothing in the interface names it. -->
+                        <!-- Translation window. Same editing controls as the capture shortcut and
+                             deliberately nothing else: this one opens a window that is already one
+                             tray click away, so it is not announced at startup. -->
                         <Grid Grid.Row="2" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
@@ -131,26 +145,81 @@
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="2"
+                            <CheckBox  Grid.Column="3" Grid.Row="0" x:Name="WindowHotkeyEnabledCheckBox"
+                                       Content="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="10,0,0,0"
+                                       Checked="HotkeyEnabled_Toggled"
+                                       Unchecked="HotkeyEnabled_Toggled"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.WindowHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
+                            <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
+                                       x:Name="WindowHotkeyShadowHint"
+                                       Style="{StaticResource FieldHint}"
+                                       Visibility="Collapsed"/>
                         </Grid>
 
-                        <!-- Source language row -->
-                        <Grid Grid.Row="3" Margin="0,0,0,10">
+                        <!-- Realtime block. -->
+                        <Grid Grid.Row="3">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SourceLanguage}" Style="{StaticResource FieldLabel}"/>
-                            <ComboBox  Grid.Column="1" x:Name="SourceLangBox"
-                                       Style="{StaticResource ModernComboBox}"
-                                       SelectedValuePath="Code"
-                                       SelectionChanged="SourceLangBox_SelectionChanged"/>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.RealtimeHotkey}"
+                                       Style="{StaticResource FieldLabel}"/>
+                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="RealtimeHotkeyBox"
+                                       Style="{StaticResource ModernTextBox}"
+                                       IsReadOnly="True"
+                                       Margin="0,0,8,0"
+                                       PreviewKeyDown="HotkeyBox_PreviewKeyDown"
+                                       GotFocus="HotkeyBox_GotFocus"
+                                       LostFocus="HotkeyBox_LostFocus"/>
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="RealtimeRecordBtn" Content="{DynamicResource S.Common.Record}"
+                                       Style="{StaticResource FlatButton}"
+                                       Height="34"
+                                       Click="RecordBtn_Click"/>
+                            <CheckBox  Grid.Column="3" Grid.Row="0" x:Name="RealtimeHotkeyEnabledCheckBox"
+                                       Content="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="10,0,0,0"
+                                       Checked="HotkeyEnabled_Toggled"
+                                       Unchecked="HotkeyEnabled_Toggled"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
+                                       controls:HighlightedText.Source="{DynamicResource S.Settings.RealtimeHotkeyHint}"
+                                       Style="{StaticResource FieldHint}"/>
+                            <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
+                                       x:Name="RealtimeHotkeyShadowHint"
+                                       Style="{StaticResource FieldHint}"
+                                       Visibility="Collapsed"/>
                         </Grid>
+                    </Grid>
+                </Border>
+
+                <!-- ── 一般設定 ── -->
+                <Border Style="{StaticResource CardBorder}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.General}" Style="{StaticResource SectionHeader}"/>
 
                         <!-- 框選完成自動翻譯 -->
-                        <Grid Grid.Row="4" Margin="0,10,0,0">
+                        <Grid Grid.Row="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
@@ -165,7 +234,7 @@
                         </Grid>
 
                         <!-- 開機自動啟動 -->
-                        <Grid Grid.Row="5" Margin="0,10,0,0">
+                        <Grid Grid.Row="2" Margin="0,10,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
@@ -178,10 +247,50 @@
                                        Checked="Startup_Toggled"
                                        Unchecked="Startup_Toggled"/>
                         </Grid>
+
+                        <!-- 同時儲存到本機. The save-path row travels with this checkbox rather than
+                             staying behind in a card of its own: it is the same decision, and it is
+                             only shown once the box is ticked. -->
+                        <Grid Grid.Row="3" Margin="0,10,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SaveScreenshot}" Style="{StaticResource FieldLabel}"/>
+                            <CheckBox  Grid.Column="1" x:Name="SaveScreenshotCheckBox"
+                                       Content="{DynamicResource S.Settings.SaveScreenshotCheck}"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Checked="SaveScreenshotCheckBox_Toggled"
+                                       Unchecked="SaveScreenshotCheckBox_Toggled"/>
+                        </Grid>
+
+                        <!-- 儲存位置（僅在開關開啟時顯示） -->
+                        <Grid Grid.Row="4" x:Name="ScreenshotPathRow" Margin="0,10,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SavePath}" Style="{StaticResource FieldLabel}"/>
+                            <TextBox   Grid.Column="1" x:Name="ScreenshotPathBox"
+                                       Style="{StaticResource ModernTextBox}"
+                                       IsReadOnly="True"
+                                       Cursor="Hand"
+                                       Margin="0,0,4,0"
+                                       ToolTip="{DynamicResource S.Settings.SavePathTip}"
+                                       PreviewMouseLeftButtonDown="ScreenshotPathBox_PreviewMouseLeftButtonDown"/>
+                            <Button    Grid.Column="2" x:Name="OpenScreenshotFolderBtn"
+                                       Content="📂"
+                                       Style="{StaticResource IconButton}"
+                                       Height="34"
+                                       ToolTip="{DynamicResource S.Settings.OpenFolderTip}"
+                                       Click="OpenScreenshotFolderBtn_Click"/>
+                        </Grid>
                     </Grid>
                 </Border>
 
-                <!-- ── 翻譯 API ── -->
+                <!-- ── 翻譯 ── -->
                 <Border Style="{StaticResource CardBorder}">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -189,12 +298,28 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.TranslationApi}" Style="{StaticResource SectionHeader}"/>
+                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Translation}" Style="{StaticResource SectionHeader}"/>
+
+                        <!-- Source language, above the service that will translate it: this is what
+                             the screenshot flow reads, so it belongs with the rest of translation
+                             rather than among the general toggles it used to sit with. -->
+                        <Grid Grid.Row="1" Margin="0,0,0,10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SourceLanguage}" Style="{StaticResource FieldLabel}"/>
+                            <ComboBox  Grid.Column="1" x:Name="SourceLangBox"
+                                       Style="{StaticResource ModernComboBox}"
+                                       SelectedValuePath="Code"
+                                       SelectionChanged="SourceLangBox_SelectionChanged"/>
+                        </Grid>
 
                         <!-- Provider row -->
-                        <Grid Grid.Row="1" Margin="0,0,0,10">
+                        <Grid Grid.Row="2" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
@@ -213,7 +338,7 @@
                         </Grid>
 
                         <!-- API Key row (conditionally visible) -->
-                        <Grid Grid.Row="2" x:Name="DeepLApiKeyRow">
+                        <Grid Grid.Row="3" x:Name="DeepLApiKeyRow">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
@@ -225,7 +350,7 @@
                         </Grid>
 
                         <!-- OpenAI Compatible settings (conditionally visible) -->
-                        <Grid Grid.Row="3" x:Name="OpenAiSettingsPanel">
+                        <Grid Grid.Row="4" x:Name="OpenAiSettingsPanel">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
@@ -497,57 +622,6 @@
                                                NavigateUri="https://github.com/asd880921/OverTranslate/blob/main/OLLAMA_GUIDE.md"><Run Text="{DynamicResource S.Settings.OllamaGuide}"/></Hyperlink>
                                 </TextBlock>
                             </StackPanel>
-                        </Grid>
-                    </Grid>
-                </Border>
-
-                <!-- ── 截圖 ── -->
-                <Border Style="{StaticResource CardBorder}">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-
-                        <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Screenshot}" Style="{StaticResource SectionHeader}"/>
-
-                        <!-- 同時儲存到本機 -->
-                        <Grid Grid.Row="1">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SaveScreenshot}" Style="{StaticResource FieldLabel}"/>
-                            <CheckBox  Grid.Column="1" x:Name="SaveScreenshotCheckBox"
-                                       Content="{DynamicResource S.Settings.SaveScreenshotCheck}"
-                                       Style="{StaticResource ModernCheckBox}"
-                                       VerticalAlignment="Center"
-                                       Checked="SaveScreenshotCheckBox_Toggled"
-                                       Unchecked="SaveScreenshotCheckBox_Toggled"/>
-                        </Grid>
-
-                        <!-- 儲存位置（僅在開關開啟時顯示） -->
-                        <Grid Grid.Row="2" x:Name="ScreenshotPathRow" Margin="0,10,0,0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.SavePath}" Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="1" x:Name="ScreenshotPathBox"
-                                       Style="{StaticResource ModernTextBox}"
-                                       IsReadOnly="True"
-                                       Cursor="Hand"
-                                       Margin="0,0,4,0"
-                                       ToolTip="{DynamicResource S.Settings.SavePathTip}"
-                                       PreviewMouseLeftButtonDown="ScreenshotPathBox_PreviewMouseLeftButtonDown"/>
-                            <Button    Grid.Column="2" x:Name="OpenScreenshotFolderBtn"
-                                       Content="📂"
-                                       Style="{StaticResource IconButton}"
-                                       Height="34"
-                                       ToolTip="{DynamicResource S.Settings.OpenFolderTip}"
-                                       Click="OpenScreenshotFolderBtn_Click"/>
                         </Grid>
                     </Grid>
                 </Border>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -76,43 +76,34 @@
 
                         <TextBlock Grid.Row="0" Text="{DynamicResource S.Settings.Hotkeys}" Style="{StaticResource SectionHeader}"/>
 
-                        <!-- Capture. Its checkbox is ticked and disabled rather than bound to a
-                             setting: this is the feature the application is for, and a stored flag
-                             that must always be true is a way to end up with it false. -->
+                        <!-- Capture has no on/off tick at all: this is the feature the application
+                             is for. Its first column is empty and still here, so the three rows'
+                             labels and boxes line up — see SharedSizeGroup. -->
                         <Grid Grid.Row="1" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
-                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.CaptureHotkey}"
+                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{DynamicResource S.Settings.CaptureHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="HotkeyBox"
+                            <TextBox   Grid.Column="2" Grid.Row="0" x:Name="HotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
                                        IsReadOnly="True"
                                        Margin="0,0,8,0"
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="2" Grid.Row="0" x:Name="RecordBtn" Content="{DynamicResource S.Common.Record}"
+                            <Button    Grid.Column="3" Grid.Row="0" x:Name="RecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <CheckBox  Grid.Column="3" Grid.Row="0"
-                                       Content="{DynamicResource S.Settings.HotkeyEnable}"
-                                       Style="{StaticResource ModernCheckBox}"
-                                       VerticalAlignment="Center"
-                                       Margin="10,0,0,0"
-                                       IsChecked="True"
-                                       IsEnabled="False"
-                                       ToolTipService.ShowOnDisabled="True"
-                                       ToolTip="{DynamicResource S.Settings.HotkeyAlwaysOnTip}"/>
-                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
+                            <TextBlock Grid.Column="2" Grid.Row="1" Grid.ColumnSpan="2"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.CaptureHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
                         </Grid>
@@ -122,40 +113,40 @@
                              tray click away, so it is not announced at startup. -->
                         <Grid Grid.Row="2" Margin="0,0,0,10">
                             <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
-                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.WindowHotkey}"
+                            <CheckBox  Grid.Column="0" Grid.Row="0" x:Name="WindowHotkeyEnabledCheckBox"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,10,0"
+                                       ToolTip="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Checked="HotkeyEnabled_Toggled"
+                                       Unchecked="HotkeyEnabled_Toggled"/>
+                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{DynamicResource S.Settings.WindowHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="WindowHotkeyBox"
+                            <TextBox   Grid.Column="2" Grid.Row="0" x:Name="WindowHotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
                                        IsReadOnly="True"
                                        Margin="0,0,8,0"
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="2" Grid.Row="0" x:Name="WindowRecordBtn" Content="{DynamicResource S.Common.Record}"
+                            <Button    Grid.Column="3" Grid.Row="0" x:Name="WindowRecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <CheckBox  Grid.Column="3" Grid.Row="0" x:Name="WindowHotkeyEnabledCheckBox"
-                                       Content="{DynamicResource S.Settings.HotkeyEnable}"
-                                       Style="{StaticResource ModernCheckBox}"
-                                       VerticalAlignment="Center"
-                                       Margin="10,0,0,0"
-                                       Checked="HotkeyEnabled_Toggled"
-                                       Unchecked="HotkeyEnabled_Toggled"/>
-                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
+                            <TextBlock Grid.Column="2" Grid.Row="1" Grid.ColumnSpan="2"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.WindowHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
-                            <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
+                            <TextBlock Grid.Column="2" Grid.Row="2" Grid.ColumnSpan="2"
                                        x:Name="WindowHotkeyShadowHint"
                                        Style="{StaticResource FieldHint}"
                                        Visibility="Collapsed"/>
@@ -164,40 +155,40 @@
                         <!-- Realtime block. -->
                         <Grid Grid.Row="3">
                             <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
                                 <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="70"/>
-                                <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.RealtimeHotkey}"
+                            <CheckBox  Grid.Column="0" Grid.Row="0" x:Name="RealtimeHotkeyEnabledCheckBox"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,10,0"
+                                       ToolTip="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Checked="HotkeyEnabled_Toggled"
+                                       Unchecked="HotkeyEnabled_Toggled"/>
+                            <TextBlock Grid.Column="1" Grid.Row="0" Text="{DynamicResource S.Settings.RealtimeHotkey}"
                                        Style="{StaticResource FieldLabel}"/>
-                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="RealtimeHotkeyBox"
+                            <TextBox   Grid.Column="2" Grid.Row="0" x:Name="RealtimeHotkeyBox"
                                        Style="{StaticResource ModernTextBox}"
                                        IsReadOnly="True"
                                        Margin="0,0,8,0"
                                        PreviewKeyDown="HotkeyBox_PreviewKeyDown"
                                        GotFocus="HotkeyBox_GotFocus"
                                        LostFocus="HotkeyBox_LostFocus"/>
-                            <Button    Grid.Column="2" Grid.Row="0" x:Name="RealtimeRecordBtn" Content="{DynamicResource S.Common.Record}"
+                            <Button    Grid.Column="3" Grid.Row="0" x:Name="RealtimeRecordBtn" Content="{DynamicResource S.Common.Record}"
                                        Style="{StaticResource FlatButton}"
                                        Height="34"
                                        Click="RecordBtn_Click"/>
-                            <CheckBox  Grid.Column="3" Grid.Row="0" x:Name="RealtimeHotkeyEnabledCheckBox"
-                                       Content="{DynamicResource S.Settings.HotkeyEnable}"
-                                       Style="{StaticResource ModernCheckBox}"
-                                       VerticalAlignment="Center"
-                                       Margin="10,0,0,0"
-                                       Checked="HotkeyEnabled_Toggled"
-                                       Unchecked="HotkeyEnabled_Toggled"/>
-                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
+                            <TextBlock Grid.Column="2" Grid.Row="1" Grid.ColumnSpan="2"
                                        controls:HighlightedText.Source="{DynamicResource S.Settings.RealtimeHotkeyHint}"
                                        Style="{StaticResource FieldHint}"/>
-                            <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
+                            <TextBlock Grid.Column="2" Grid.Row="2" Grid.ColumnSpan="2"
                                        x:Name="RealtimeHotkeyShadowHint"
                                        Style="{StaticResource FieldHint}"
                                        Visibility="Collapsed"/>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -52,21 +52,39 @@ public partial class SettingsPage : UserControl
     private int _promptSegment = PromptAutoSegment;
 
     /// <summary>
-    /// One editable shortcut: the two controls that edit it and the settings it reads and writes.
+    /// One editable shortcut: the controls that edit it and the settings it reads and writes.
     /// </summary>
+    /// <param name="Action">
+    /// Which shortcut this is, so the row can be matched against <see cref="HotkeyBindings.Resolve"/>
+    /// — the one place that decides which of two shortcuts sharing a combination stays on.
+    /// </param>
     /// <param name="AdvertisedInShell">
     /// Whether the shell's nav rail prints this combination beside a button, and so has to be told
     /// when it changes. True for the capture shortcut, which the interface names in three places;
-    /// false for the window one, which it names nowhere.
+    /// false for the other two, which it names nowhere.
+    /// </param>
+    /// <param name="EnabledBox">
+    /// The tick that turns this shortcut off, or null for the capture one — its box is ticked and
+    /// disabled in XAML with no setting behind it, because that shortcut is the feature the
+    /// application is for. Null here is what says "this row cannot be turned off".
+    /// </param>
+    /// <param name="ShadowHint">
+    /// Where to say that a higher-priority shortcut has taken this combination. Null for capture,
+    /// which is the highest priority and so can never be the one shadowed.
     /// </param>
     private sealed record HotkeyField(
+        HotkeyAction Action,
         string NameKey,
         TextBox Box,
         Button Record,
         Func<AppSettings, string> Display,
         Func<AppSettings, (uint Modifiers, uint Key)> Combination,
         Action<AppSettings, uint, uint, string> Apply,
-        bool AdvertisedInShell);
+        bool AdvertisedInShell,
+        // Fully qualified: WinForms is also referenced here and has its own CheckBox.
+        System.Windows.Controls.CheckBox? EnabledBox = null,
+        Action<AppSettings, bool>? SetEnabled = null,
+        TextBlock? ShadowHint = null);
 
     private HotkeyField[] _hotkeyFields = [];
 
@@ -83,6 +101,7 @@ public partial class SettingsPage : UserControl
         _hotkeyFields =
         [
             new HotkeyField(
+                HotkeyAction.Capture,
                 "S.Settings.CaptureHotkey",
                 HotkeyBox, RecordBtn,
                 s => s.HotkeyDisplay,
@@ -95,6 +114,7 @@ public partial class SettingsPage : UserControl
                 },
                 AdvertisedInShell: true),
             new HotkeyField(
+                HotkeyAction.TranslationWindow,
                 "S.Settings.WindowHotkey",
                 WindowHotkeyBox, WindowRecordBtn,
                 s => s.TranslationWindowHotkeyDisplay,
@@ -105,7 +125,26 @@ public partial class SettingsPage : UserControl
                     s.TranslationWindowHotkeyVirtualKey = vk;
                     s.TranslationWindowHotkeyDisplay = display;
                 },
-                AdvertisedInShell: false),
+                AdvertisedInShell: false,
+                WindowHotkeyEnabledCheckBox,
+                (s, on) => s.TranslationWindowHotkeyEnabled = on,
+                WindowHotkeyShadowHint),
+            new HotkeyField(
+                HotkeyAction.Realtime,
+                "S.Settings.RealtimeHotkey",
+                RealtimeHotkeyBox, RealtimeRecordBtn,
+                s => s.RealtimeHotkeyDisplay,
+                s => (s.RealtimeHotkeyModifiers, s.RealtimeHotkeyVirtualKey),
+                (s, mods, vk, display) =>
+                {
+                    s.RealtimeHotkeyModifiers = mods;
+                    s.RealtimeHotkeyVirtualKey = vk;
+                    s.RealtimeHotkeyDisplay = display;
+                },
+                AdvertisedInShell: false,
+                RealtimeHotkeyEnabledCheckBox,
+                (s, on) => s.RealtimeHotkeyEnabled = on,
+                RealtimeHotkeyShadowHint),
         ];
 
         _apiKeyDebounce = new DispatcherTimer { Interval = ApiKeyDebounce };
@@ -172,6 +211,13 @@ public partial class SettingsPage : UserControl
             ProviderHint.Text = (ProviderBox.SelectedItem as ProviderItem)?.Hint ?? "";
 
             foreach (var field in _hotkeyFields) field.Box.Text = field.Display(s);
+
+            // The ticks, then the "a shortcut above took this" lines the ticks can change.
+            foreach (var binding in HotkeyBindings.Resolve(s))
+                if (FieldFor(binding.Action)?.EnabledBox is { } box)
+                    box.IsChecked = binding.Enabled;
+
+            RefreshHotkeyShadowHints();
             ApiKeyBox.Secret = s.ApiKey;
             OpenAiBaseUrlBox.Text = s.OpenAiBaseUrl;
             OpenAiApiKeyBox.Secret = s.OpenAiApiKey;
@@ -836,6 +882,54 @@ public partial class SettingsPage : UserControl
         _hotkeyFields.FirstOrDefault(
             field => ReferenceEquals(field.Box, sender) || ReferenceEquals(field.Record, sender));
 
+    /// <summary>The row that edits one action.</summary>
+    private HotkeyField? FieldFor(HotkeyAction action) =>
+        _hotkeyFields.FirstOrDefault(field => field.Action == action);
+
+    private void HotkeyEnabled_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+
+        var field = _hotkeyFields.FirstOrDefault(f => ReferenceEquals(f.EnabledBox, sender));
+        if (field?.SetEnabled is not { } setEnabled || field.EnabledBox is not { } box) return;
+
+        Persist(s => setEnabled(s, box.IsChecked == true));
+
+        // Turning one off releases its combination, which can bring a shadowed row back — so the
+        // hints below are re-read from the resolver rather than only cleared for this row.
+        RefreshHotkeyShadowHints();
+    }
+
+    /// <summary>
+    /// Says, per row, that a higher-priority shortcut holds this combination.
+    /// </summary>
+    /// <remarks>
+    /// The recorder refuses to assign a combination another shortcut already holds, so this state
+    /// cannot be reached by editing. It is reached by upgrading: adding the realtime shortcut gave
+    /// every existing installation a Ctrl+Alt+S it never agreed to, and anyone who had already put
+    /// that on the translation window would otherwise have had one of the two stop working with
+    /// nothing said. Priority decides which, and this is where it is said out loud.
+    /// </remarks>
+    private void RefreshHotkeyShadowHints()
+    {
+        foreach (var binding in HotkeyBindings.Resolve(SettingsService.Instance.Current))
+        {
+            if (FieldFor(binding.Action)?.ShadowHint is not { } hint) continue;
+
+            if (binding.ShadowedBy is not { } holder)
+            {
+                hint.Visibility = Visibility.Collapsed;
+                continue;
+            }
+
+            var holderName = FieldFor(holder)?.NameKey;
+            hint.Text = LocalizationService.Format(
+                "S.Settings.HotkeyShadowed",
+                holderName is null ? "" : LocalizationService.Get(holderName));
+            hint.Visibility = Visibility.Visible;
+        }
+    }
+
     private void StartRecording(HotkeyField field)
     {
         // Only one at a time: two boxes both saying 請按下快捷鍵 would leave the next key press
@@ -915,9 +1009,18 @@ public partial class SettingsPage : UserControl
         // one is simply refused — RegisterHotKey returns false and nothing else happens. Left to
         // itself that reads as a shortcut that stopped working for no reason, so the clash is
         // refused here, where there is something to say about it.
+        // A shortcut that is switched off does not hold its combination — same rule as
+        // HotkeyBindings, so what the page refuses and what actually gets registered agree.
         var settings = SettingsService.Instance.Current;
+        var enabled = HotkeyBindings.Resolve(settings)
+            .Where(binding => binding.Enabled)
+            .Select(binding => binding.Action)
+            .ToHashSet();
+
         var taken = _hotkeyFields.FirstOrDefault(
-            field => !ReferenceEquals(field, recording) && field.Combination(settings) == (mods, vk));
+            field => !ReferenceEquals(field, recording) &&
+                     enabled.Contains(field.Action) &&
+                     field.Combination(settings) == (mods, vk));
 
         if (taken is not null)
         {
@@ -931,6 +1034,10 @@ public partial class SettingsPage : UserControl
 
         // After the write, so the box picks the new combination up out of the settings.
         StopRecording();
+
+        // Recording cannot create a clash — it is refused above — but it can clear one a stored
+        // setting arrived in, so the shadow lines are re-read rather than left as they were.
+        RefreshHotkeyShadowHints();
 
         // The global hook holds the old combination until it is rebound
         if (System.Windows.Application.Current.MainWindow is MainWindow main)

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -64,9 +64,9 @@ public partial class SettingsPage : UserControl
     /// false for the other two, which it names nowhere.
     /// </param>
     /// <param name="EnabledBox">
-    /// The tick that turns this shortcut off, or null for the capture one — its box is ticked and
-    /// disabled in XAML with no setting behind it, because that shortcut is the feature the
-    /// application is for. Null here is what says "this row cannot be turned off".
+    /// The tick that turns this shortcut off, or null for the capture one, which has no tick at all
+    /// and no setting behind it because that shortcut is the feature the application is for. Null
+    /// here is what says "this row cannot be turned off".
     /// </param>
     /// <param name="ShadowHint">
     /// Where to say that a higher-priority shortcut has taken this combination. Null for capture,

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -212,10 +212,14 @@ public partial class SettingsPage : UserControl
 
             foreach (var field in _hotkeyFields) field.Box.Text = field.Display(s);
 
-            // The ticks, then the "a shortcut above took this" lines the ticks can change.
+            // The ticks, then the "a shortcut above took this" lines the ticks can change. The
+            // availability pass is explicit because the toggle handler ignores changes made while
+            // loading, so nothing else would grey these rows out on the way in.
             foreach (var binding in HotkeyBindings.Resolve(s))
                 if (FieldFor(binding.Action)?.EnabledBox is { } box)
                     box.IsChecked = binding.Enabled;
+
+            foreach (var field in _hotkeyFields) ApplyHotkeyRowAvailability(field);
 
             RefreshHotkeyShadowHints();
             ApiKeyBox.Secret = s.ApiKey;
@@ -886,6 +890,27 @@ public partial class SettingsPage : UserControl
     private HotkeyField? FieldFor(HotkeyAction action) =>
         _hotkeyFields.FirstOrDefault(field => field.Action == action);
 
+    /// <summary>
+    /// Greys out the box and the record button of a shortcut that is switched off.
+    /// </summary>
+    /// <remarks>
+    /// The tick is the whole row's switch, so leaving the rest of the row live invites the user to
+    /// record a combination for a shortcut that will not be registered — an edit that appears to work
+    /// and changes nothing.
+    ///
+    /// Only the tick does this. A row shadowed by a higher-priority shortcut stays editable on
+    /// purpose: re-recording it onto a free combination is exactly how that is fixed, and disabling
+    /// the row would take the fix away along with the problem.
+    /// </remarks>
+    private static void ApplyHotkeyRowAvailability(HotkeyField field)
+    {
+        // No tick means the row cannot be switched off at all — the capture shortcut.
+        var on = field.EnabledBox is not { } box || box.IsChecked == true;
+
+        field.Box.IsEnabled = on;
+        field.Record.IsEnabled = on;
+    }
+
     private void HotkeyEnabled_Toggled(object sender, RoutedEventArgs e)
     {
         if (_loading) return;
@@ -893,7 +918,12 @@ public partial class SettingsPage : UserControl
         var field = _hotkeyFields.FirstOrDefault(f => ReferenceEquals(f.EnabledBox, sender));
         if (field?.SetEnabled is not { } setEnabled || field.EnabledBox is not { } box) return;
 
+        // Switching a row off while it is waiting for a key would leave it recording into a control
+        // about to be disabled, and the tick would look like it had done nothing.
+        if (ReferenceEquals(_recording, field)) StopRecording();
+
         Persist(s => setEnabled(s, box.IsChecked == true));
+        ApplyHotkeyRowAvailability(field);
 
         // The global hooks are bound from these settings, so the tick means nothing until they are
         // rebound — without this the shortcut keeps working until the application is restarted, and

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -895,6 +895,12 @@ public partial class SettingsPage : UserControl
 
         Persist(s => setEnabled(s, box.IsChecked == true));
 
+        // The global hooks are bound from these settings, so the tick means nothing until they are
+        // rebound — without this the shortcut keeps working until the application is restarted, and
+        // a switch that takes effect later is worse than no switch.
+        if (System.Windows.Application.Current.MainWindow is MainWindow main)
+            main.ReRegisterHotkey();
+
         // Turning one off releases its combination, which can bring a shadowed row back — so the
         // hints below are re-read from the resolver rather than only cleared for this row.
         RefreshHotkeyShadowHints();

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -31,6 +31,17 @@ public partial class ShellWindow : Window
     private static ShellWindow? _instance;
 
     /// <summary>
+    /// The open shell, or null when it is closed to the tray.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="ShowOrActivate"/> this never creates one. A shortcut that starts 即時翻譯
+    /// needs to hand the shell over to be hidden when it happens to be open, and must not conjure a
+    /// window to hide when it is not — the session is about to cover the screen either way.
+    /// Reliable because <see cref="OnClosed"/> clears it.
+    /// </remarks>
+    public static ShellWindow? Current => _instance;
+
+    /// <summary>
     /// The shell's dimensions from the last time it was open, for as long as the process lives.
     /// </summary>
     /// <remarks>

--- a/tests/OverTranslate.Tests/HotkeyBindingsTests.cs
+++ b/tests/OverTranslate.Tests/HotkeyBindingsTests.cs
@@ -1,0 +1,108 @@
+using OverTranslate.Models;
+using OverTranslate.Services;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class HotkeyBindingsTests
+{
+    private const uint CtrlAlt = 3;
+
+    [Fact]
+    public void ThreeDistinctCombinationsAllStayOn()
+    {
+        var active = HotkeyBindings.Active(new AppSettings()).ToList();
+
+        Assert.Equal(
+            [HotkeyAction.Capture, HotkeyAction.TranslationWindow, HotkeyAction.Realtime],
+            active.Select(binding => binding.Action));
+    }
+
+    [Fact]
+    public void TheShortcutAddedLastLosesToOneSomebodyAlreadyChose()
+    {
+        // The upgrade this whole type exists for. Realtime defaults to Ctrl+Alt+S, and an existing
+        // installation may already have put Ctrl+Alt+S on the translation window — a combination its
+        // owner picked, against one they have never seen. Left to Windows, whichever registered
+        // second would simply fail and the user would be told nothing.
+        var settings = new AppSettings
+        {
+            TranslationWindowHotkeyModifiers = CtrlAlt,
+            TranslationWindowHotkeyVirtualKey = 0x53,
+            TranslationWindowHotkeyDisplay = "Ctrl+Alt+S",
+        };
+
+        var resolved = HotkeyBindings.Resolve(settings);
+        var window = resolved.Single(b => b.Action == HotkeyAction.TranslationWindow);
+        var realtime = resolved.Single(b => b.Action == HotkeyAction.Realtime);
+
+        Assert.True(window.IsActive);
+        Assert.False(realtime.IsActive);
+        Assert.Equal(HotkeyAction.TranslationWindow, realtime.ShadowedBy);
+    }
+
+    [Fact]
+    public void CaptureOutranksEverythingBecauseItIsWhatTheApplicationIsFor()
+    {
+        var settings = new AppSettings
+        {
+            TranslationWindowHotkeyModifiers = CtrlAlt,
+            TranslationWindowHotkeyVirtualKey = 0x41, // the capture default
+            RealtimeHotkeyModifiers = CtrlAlt,
+            RealtimeHotkeyVirtualKey = 0x41,
+        };
+
+        var resolved = HotkeyBindings.Resolve(settings);
+
+        Assert.True(resolved.Single(b => b.Action == HotkeyAction.Capture).IsActive);
+        Assert.Equal(
+            HotkeyAction.Capture,
+            resolved.Single(b => b.Action == HotkeyAction.TranslationWindow).ShadowedBy);
+        Assert.Equal(
+            HotkeyAction.Capture,
+            resolved.Single(b => b.Action == HotkeyAction.Realtime).ShadowedBy);
+    }
+
+    [Fact]
+    public void SwitchingOffTheHolderHandsTheCombinationDown()
+    {
+        // A shortcut that is off does not reserve its combination. Without this, turning the window
+        // shortcut off would leave the realtime one still shadowed by something no longer running,
+        // which is the kind of state a user cannot reason their way out of.
+        var settings = new AppSettings
+        {
+            TranslationWindowHotkeyModifiers = CtrlAlt,
+            TranslationWindowHotkeyVirtualKey = 0x53,
+            TranslationWindowHotkeyEnabled = false,
+        };
+
+        var realtime = HotkeyBindings.Resolve(settings)
+            .Single(binding => binding.Action == HotkeyAction.Realtime);
+
+        Assert.True(realtime.IsActive);
+        Assert.Null(realtime.ShadowedBy);
+    }
+
+    [Fact]
+    public void ASwitchedOffShortcutIsNotRegisteredEvenWithNothingInItsWay()
+    {
+        var settings = new AppSettings { RealtimeHotkeyEnabled = false };
+
+        var realtime = HotkeyBindings.Resolve(settings)
+            .Single(binding => binding.Action == HotkeyAction.Realtime);
+
+        Assert.False(realtime.IsActive);
+        Assert.Null(realtime.ShadowedBy); // off by choice, not because something took it
+        Assert.DoesNotContain(
+            HotkeyBindings.Active(settings), binding => binding.Action == HotkeyAction.Realtime);
+    }
+
+    [Fact]
+    public void CaptureCannotBeSwitchedOff()
+    {
+        // There is no setting for it — see AppSettings.TranslationWindowHotkeyEnabled for why — so
+        // this pins that the resolver never reports it as anything but enabled.
+        Assert.True(HotkeyBindings.Resolve(new AppSettings())
+            .Single(binding => binding.Action == HotkeyAction.Capture).Enabled);
+    }
+}

--- a/tests/OverTranslate.Tests/RealtimeQuickStartTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeQuickStartTests.cs
@@ -1,0 +1,65 @@
+using OverTranslate.Models;
+using OverTranslate.Views.Realtime;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class RealtimeQuickStartTests
+{
+    private static AppSettings Ready() => new()
+    {
+        RealtimeSourceLanguage = "JA",
+        RealtimeTargetLanguage = "ZH-HANT",
+        RealtimeBlockCount = 2,
+    };
+
+    [Fact]
+    public void AFirstRunIsTurnedAwayBecauseNoSourceLanguageHasBeenChosen()
+    {
+        // The realtime picker deliberately does not offer 自動, so a fresh install has nothing here
+        // and the shortcut has nothing to translate from. Pressing it must say so rather than open a
+        // framing layer that could never produce a translation.
+        var quickStart = RealtimeQuickStart.From(new AppSettings());
+
+        Assert.False(quickStart.CanStart);
+        Assert.Equal("S.Realtime.ChooseSourceFirst", quickStart.BlockedReasonKey);
+    }
+
+    [Fact]
+    public void AHandEditedAutomaticSourceIsTurnedAwayToo()
+    {
+        // Not reachable through the picker, which never offers it — reachable by editing the file.
+        var settings = Ready();
+        settings.RealtimeSourceLanguage = LanguageData.AutomaticSourceLanguage;
+
+        var quickStart = RealtimeQuickStart.From(settings);
+
+        Assert.False(quickStart.CanStart);
+        Assert.Equal("S.Realtime.ChooseSourceFirst", quickStart.BlockedReasonKey);
+    }
+
+    [Fact]
+    public void AConfiguredInstallationStartsWithNothingToSay()
+    {
+        var quickStart = RealtimeQuickStart.From(Ready());
+
+        Assert.True(quickStart.CanStart);
+        Assert.Null(quickStart.BlockedReasonKey);
+        Assert.Equal("JA", quickStart.Request!.SourceLanguage);
+        Assert.Equal(2, quickStart.Request.MaxBlocks);
+    }
+
+    [Theory]
+    [InlineData(0, RealtimeQuickStart.MinBlocks)]
+    [InlineData(-4, RealtimeQuickStart.MinBlocks)]
+    [InlineData(99, RealtimeQuickStart.MaxBlocks)]
+    public void ABlockCountFromOutsideTheStepperIsBroughtBackIntoRange(int stored, int expected)
+    {
+        // The stepper cannot produce these; a text file can, and the framing layer would be asked
+        // for a number of blocks it has no way to draw.
+        var settings = Ready();
+        settings.RealtimeBlockCount = stored;
+
+        Assert.Equal(expected, RealtimeQuickStart.From(settings).Request!.MaxBlocks);
+    }
+}

--- a/tests/OverTranslate.Tests/RealtimeQuickStartTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeQuickStartTests.cs
@@ -14,28 +14,32 @@ public class RealtimeQuickStartTests
     };
 
     [Fact]
-    public void AFirstRunIsTurnedAwayBecauseNoSourceLanguageHasBeenChosen()
+    public void AFirstRunStartsOnTheDefaultSourceLanguage()
     {
-        // The realtime picker deliberately does not offer 自動, so a fresh install has nothing here
-        // and the shortcut has nothing to translate from. Pressing it must say so rather than open a
-        // framing layer that could never produce a translation.
+        // This used to refuse and send the user to the page to choose one. It answers instead, so
+        // that pressing the shortcut on a fresh install opens block framing rather than a
+        // notification — the trade is recorded on AppSettings.RealtimeSourceLanguage.
         var quickStart = RealtimeQuickStart.From(new AppSettings());
 
-        Assert.False(quickStart.CanStart);
-        Assert.Equal("S.Realtime.ChooseSourceFirst", quickStart.BlockedReasonKey);
+        Assert.True(quickStart.CanStart);
+        Assert.Equal(LanguageData.DefaultRealtimeSourceLanguage, quickStart.Request!.SourceLanguage);
     }
 
-    [Fact]
-    public void AHandEditedAutomaticSourceIsTurnedAwayToo()
+    [Theory]
+    [InlineData("")]                                       // written by a version with no default
+    [InlineData(LanguageData.AutomaticSourceLanguage)]     // hand-edited; the picker never offers it
+    [InlineData("XX")]                                     // a code retired since
+    public void AnUnusableStoredSourceFallsBackRatherThanReachingTheSession(string stored)
     {
-        // Not reachable through the picker, which never offers it — reachable by editing the file.
+        // 自動 is the one that matters: realtime gets one look at a frame, so a mode that guesses per
+        // frame would make a subtitle track flicker between languages.
         var settings = Ready();
-        settings.RealtimeSourceLanguage = LanguageData.AutomaticSourceLanguage;
+        settings.RealtimeSourceLanguage = stored;
 
         var quickStart = RealtimeQuickStart.From(settings);
 
-        Assert.False(quickStart.CanStart);
-        Assert.Equal("S.Realtime.ChooseSourceFirst", quickStart.BlockedReasonKey);
+        Assert.True(quickStart.CanStart);
+        Assert.Equal(LanguageData.DefaultRealtimeSourceLanguage, quickStart.Request!.SourceLanguage);
     }
 
     [Fact]

--- a/tests/OverTranslate.Tests/SettingsParsingTests.cs
+++ b/tests/OverTranslate.Tests/SettingsParsingTests.cs
@@ -34,9 +34,12 @@ public class SettingsParsingTests
         Assert.Equal(LanguageData.DefaultTargetLanguage, settings.RealtimeTargetLanguage);
         Assert.Equal(TranslationProvider.Microsoft, settings.RealtimeProvider);
 
-        // Empty rather than 自動: the realtime picker does not offer that mode, so a default here
-        // would put a value in the box that the user cannot have chosen and cannot see is wrong.
-        Assert.Equal("", settings.RealtimeSourceLanguage);
+        // English rather than 自動, which the realtime picker does not offer. This was empty on
+        // purpose once — a blank asks the question instead of answering it badly — and stopped being
+        // so when the shortcut arrived, because a shortcut has no page on which to ask. What it
+        // must never be is 自動; see LanguageData.GetValidRealtimeSourceCode.
+        Assert.Equal(LanguageData.DefaultRealtimeSourceLanguage, settings.RealtimeSourceLanguage);
+        Assert.False(LanguageData.IsAutomaticSource(settings.RealtimeSourceLanguage));
         Assert.Equal("JA", settings.TargetLanguage);
         Assert.Equal(TranslationProvider.DeepL, settings.Provider);
     }

--- a/tests/OverTranslate.Tests/SettingsParsingTests.cs
+++ b/tests/OverTranslate.Tests/SettingsParsingTests.cs
@@ -194,6 +194,11 @@ public class SettingsParsingTests
             SaveScreenshotToDisk = true,
             ScreenshotSavePath = @"D:\shots",
             RealtimeGuidanceExpanded = false,
+            TranslationWindowHotkeyEnabled = false,
+            RealtimeHotkeyModifiers = 5,
+            RealtimeHotkeyVirtualKey = 0x44,
+            RealtimeHotkeyDisplay = "Ctrl+Shift+D",
+            RealtimeHotkeyEnabled = false,
         });
 
         var settings = SettingsService.Parse(written);
@@ -215,6 +220,23 @@ public class SettingsParsingTests
         Assert.True(settings.SaveScreenshotToDisk);
         Assert.Equal(@"D:\shots", settings.ScreenshotSavePath);
         Assert.False(settings.RealtimeGuidanceExpanded);
+        Assert.False(settings.TranslationWindowHotkeyEnabled);
+        Assert.Equal(5u, settings.RealtimeHotkeyModifiers);
+        Assert.Equal(0x44u, settings.RealtimeHotkeyVirtualKey);
+        Assert.Equal("Ctrl+Shift+D", settings.RealtimeHotkeyDisplay);
+        Assert.False(settings.RealtimeHotkeyEnabled);
+    }
+
+    // Written before either shortcut could be switched off: both have to come back on, or upgrading
+    // would silently disable two shortcuts the user still has.
+    [Fact]
+    public void MissingHotkeyEnabledSettings_StartOn()
+    {
+        var settings = SettingsService.Parse("""{"Theme":"Light"}""");
+
+        Assert.True(settings.TranslationWindowHotkeyEnabled);
+        Assert.True(settings.RealtimeHotkeyEnabled);
+        Assert.Equal("Ctrl+Alt+S", settings.RealtimeHotkeyDisplay);
     }
 
     // Expanded on a file written before the setting existed: someone who has never been shown the

--- a/tests/OverTranslate.Tests/SettingsParsingTests.cs
+++ b/tests/OverTranslate.Tests/SettingsParsingTests.cs
@@ -199,6 +199,7 @@ public class SettingsParsingTests
             RealtimeHotkeyVirtualKey = 0x44,
             RealtimeHotkeyDisplay = "Ctrl+Shift+D",
             RealtimeHotkeyEnabled = false,
+            RealtimeBlockCount = 3,
         });
 
         var settings = SettingsService.Parse(written);
@@ -225,6 +226,7 @@ public class SettingsParsingTests
         Assert.Equal(0x44u, settings.RealtimeHotkeyVirtualKey);
         Assert.Equal("Ctrl+Shift+D", settings.RealtimeHotkeyDisplay);
         Assert.False(settings.RealtimeHotkeyEnabled);
+        Assert.Equal(3, settings.RealtimeBlockCount);
     }
 
     // Written before either shortcut could be switched off: both have to come back on, or upgrading


### PR DESCRIPTION
新增「即時翻譯區塊」快捷鍵（預設 Ctrl+Alt+S），按下即進入區塊選取模式；並依此重整設定頁版面、補上快捷鍵的優先序與啟用開關。

## 版面重整

| 卡片 | 變更 |
|---|---|
| **快捷鍵**（新增） | 截圖翻譯 / 開啟翻譯視窗 / **即時翻譯區塊**（新） |
| 一般設定 | 移出兩個快捷鍵與來源語言；**移入「儲存截圖」與儲存路徑** |
| 翻譯 API → **翻譯** | **移入「來源語言」，放在「翻譯服務」上方** |
| ~~截圖~~ | 已刪除 |

儲存路徑列跟著「儲存截圖」勾選框一起搬 —— 它是同一個決定的下半，且只有勾選後才顯示。

`S.Settings.TranslationApi` 更名為 `S.Settings.Translation`；`S.Settings.Screenshot` 已無人引用而刪除（`StringsParityTests` 抓到的）。

## 快捷鍵行為

**即時翻譯區塊**：按下直接進入選取模式，等同主視窗的 開始 按鈕。

生效條件：
- `RealtimeSessionController.IsActive` 為真時直接無效 —— 這一個判斷涵蓋選取模式與翻譯運行中
- 截圖翻譯進行中 → 跳系統通知擋下（共用一個 OCR 引擎與辨識槽，與頁面同一條規則）

新增 `RealtimeQuickStart`，把「能不能直接開始」的判斷抽出來，讓熱鍵與按鈕走同一套規則而非各寫一份。

**啟用開關**：翻譯視窗與即時翻譯各有一個勾選框，切換後立即重新註冊、不需重啟；停用時整列的輸入框與錄製按鈕一併變灰。截圖翻譯**不提供開關**，也沒有對應設定欄位 —— 存一個永遠必須為 true 的值只是製造出錯的機會。

## 衝突防呆

三個快捷鍵由上至下即優先序：截圖翻譯 > 開啟翻譯視窗 > 即時翻譯區塊。

新增 `Services/HotkeyBindings.cs`，純函式解析器，決定組合鍵重複時誰留著。**這不是理論問題**：新的 Ctrl+Alt+S 直接發給所有既有安裝，任何已把它設在翻譯視窗上的使用者都會撞到。交給 Windows 的話，後註冊的 `RegisterHotKey` 回傳 false 然後什麼都不說 —— 使用者只會覺得某個快捷鍵莫名壞了，而且誰失效取決於「誰剛好第二個註冊」。

`MainWindow.RegisterHotkey()` 改為依優先序註冊，被蓋掉的根本不送到 Windows，並以 Warn 記錄是誰佔走的。設定頁該列顯示「✗ 與上方的『…』重複，已停用」。

被蓋掉的那列**仍可編輯** —— 重新錄製一個沒被佔用的組合鍵正是解法。

停用的快捷鍵不佔用組合鍵，所以關掉上位的，下位的會自動拿回來。設定頁的錄製衝突檢查套用同一條規則，確保「頁面拒絕的」與「實際會註冊的」一致。

## 即時翻譯來源語言改為預設英文

原本刻意留空（「猜錯語言比問一次更糟」），改為預設英文以統一行為 —— 快捷鍵沒有頁面可以問，原本的做法是跳通知拒絕啟動，那是每次首用都要付的摩擦。

新增 `LanguageData.GetValidRealtimeSourceCode()` 作為這條規則的唯一落點，處理三種都會壞事的輸入：舊版留下的空字串、手改寫入的 `AUTO`、已淘汰的代碼 —— 全部落到英文。既有的 `GetValidOcrSourceCode()` 不能用，它的 fallback 正好是 `AUTO`（那對截圖翻譯合理，可以重讀；對即時翻譯不行）。

**代價已寫進 `AppSettings.RealtimeSourceLanguage` 註解**：非英文內容的使用者若從未開過主視窗、直接按熱鍵，會拿到英文辨識結果而沒有提示。連同「原本為什麼留空」一併記錄。

## 其他

`RealtimeBlockCount` 存進設定。原本這個數字只在 `RealtimePage` 記憶體裡，主視窗沒開時取不到 —— 但快捷鍵的用意正是不必開主視窗。不存的話，慣用 3 塊的使用者按熱鍵只會得到 1 塊。

## 測試

- `HotkeyBindingsTests` 6 個：升級撞號、截圖優先、關掉上位後下移、以及「使用者關掉」與「被蓋掉」是兩種不同狀態
- `RealtimeQuickStartTests`：預設值、不可用來源的 fallback、區塊數 clamp
- `SettingsParsingTests`：新欄位 round-trip；並釘住**舊設定檔沒有這些欄位時兩個開關都必須是開的**，否則升級會安靜關掉使用者原有的快捷鍵

482 通過 / 0 失敗 / 2 略過（既有）、0 警告。CRLF 與無 BOM 已確認保留。

## 驗證狀態

快捷鍵行為已由 @asd880921 實機測試通過。版面調整（勾選框位置、整列停用的視覺效果）建議再看一眼。
