### PR TITLE
feat: AI 提示詞開放語言名稱與代碼四個佔位符，設定頁改以表格說明

### DIFF
--- a/src/OverTranslate/Models/LanguageData.cs
+++ b/src/OverTranslate/Models/LanguageData.cs
@@ -251,6 +251,49 @@ public static class LanguageData
         return IsAutomaticSource(resolved) ? DefaultRealtimeSourceLanguage : resolved;
     }
 
+    /// <summary>
+    /// Codes whose model-facing spelling is not just this application's own code in lower case.
+    /// </summary>
+    /// <remarks>
+    /// The pickers carry codes chosen for the translation APIs — DeepL's <c>EN-US</c>, <c>PT-BR</c>,
+    /// <c>ZH-HANT</c> — and a local translation model expects BCP 47 instead. Only the entries that
+    /// actually differ are listed; everything else is a plain two-letter code that lower-casing
+    /// already gets right, and listing those too would be a table to keep in step for no gain.
+    ///
+    /// <c>ZH</c> maps to Simplified rather than bare <c>zh</c> because that is what it means in this
+    /// application's own OCR picker (簡體中文), and a model given <c>zh</c> has to guess between the
+    /// two scripts.
+    /// </remarks>
+    private static readonly Dictionary<string, string> ModelLanguageTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["EN-US"] = "en",
+        ["ZH"] = "zh-Hans",
+        ["ZH-HANS"] = "zh-Hans",
+        ["ZH-HANT"] = "zh-Hant",
+        ["PT-BR"] = "pt-BR",
+    };
+
+    /// <summary>
+    /// The language tag to name a language by when instructing a translation model, e.g. <c>ja</c>.
+    /// </summary>
+    /// <remarks>
+    /// Translation-only models are trained with the language named as "Japanese (ja)" — the tag is
+    /// not decoration beside the name, it is the part the model was trained to key on. See
+    /// <see cref="Services.Providers.OpenAiCompatibleProvider.DefaultPromptTemplate"/>.
+    ///
+    /// Returns empty for 自動, which has no language to name: the prompt says "any language" there
+    /// and a tag would be inventing one.
+    /// </remarks>
+    public static string GetModelLanguageTag(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code) || IsAutomaticSource(code))
+            return "";
+
+        return ModelLanguageTags.TryGetValue(code, out var mapped)
+            ? mapped
+            : code.ToLowerInvariant();
+    }
+
     public static string GetValidTargetCode(string? targetCode)
     {
         if (string.IsNullOrWhiteSpace(targetCode))

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -264,8 +264,17 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.PromptAuto">Automatic</sys:String>
     <sys:String x:Key="S.Settings.PromptExplicit">Chosen language</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">Reset to default</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}: target language (e.g. Japanese) | {target_code}: target language code (e.g. ja)</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}: source language (e.g. English) | {source_code}: source language code (e.g. en)&#10;{target_name}: target language (e.g. Japanese) | {target_code}: target language code (e.g. ja)</sys:String>
+    <sys:String x:Key="S.Settings.PromptParams">Available parameters</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamsTip">Write these into the prompt; each is replaced with the language in use before it is sent</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamCol1">Parameter</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamCol2">Description</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamCol3">Example</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamSourceName">Source language name</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamSourceCode">Source language code</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamTargetName">Target language name</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamTargetCode">Target language code</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamSourceNameEg">English</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamTargetNameEg">Japanese</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">Advanced</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">Enable</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -264,8 +264,8 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.PromptAuto">Automatic</sys:String>
     <sys:String x:Key="S.Settings.PromptExplicit">Chosen language</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">Reset to default</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintAuto">{target}: target language</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source}: source language  {target}: target language</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target}: target language  {target_code}: target language code</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source}: source language  {source_code}: source language code  {target}: target language  {target_code}: target language code</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">Advanced</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">Enable</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -264,8 +264,8 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.PromptAuto">Automatic</sys:String>
     <sys:String x:Key="S.Settings.PromptExplicit">Chosen language</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">Reset to default</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target}: target language  {target_code}: target language code</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source}: source language  {source_code}: source language code  {target}: target language  {target_code}: target language code</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}: target language  {target_code}: target language code</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}: source language  {source_code}: source language code  {target_name}: target language  {target_code}: target language code</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">Advanced</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">Enable</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -264,8 +264,8 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.PromptAuto">Automatic</sys:String>
     <sys:String x:Key="S.Settings.PromptExplicit">Chosen language</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">Reset to default</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}: target language  {target_code}: target language code</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}: source language  {source_code}: source language code  {target_name}: target language  {target_code}: target language code</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}: target language (e.g. Japanese) | {target_code}: target language code (e.g. ja)</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}: source language (e.g. English) | {source_code}: source language code (e.g. en)&#10;{target_name}: target language (e.g. Japanese) | {target_code}: target language code (e.g. ja)</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">Advanced</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">Enable</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -265,7 +265,7 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.PromptExplicit">Chosen language</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">Reset to default</sys:String>
     <sys:String x:Key="S.Settings.PromptParams">Available parameters</sys:String>
-    <sys:String x:Key="S.Settings.PromptParamsTip">Write these into the prompt; each is replaced with the language in use before it is sent</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamsTip">Write these into the prompt; each is replaced with the language actually in use before the request is sent, so one prompt serves every language pair.</sys:String>
     <sys:String x:Key="S.Settings.PromptParamCol1">Parameter</sys:String>
     <sys:String x:Key="S.Settings.PromptParamCol2">Description</sys:String>
     <sys:String x:Key="S.Settings.PromptParamCol3">Example</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -282,8 +282,18 @@
     <sys:String x:Key="S.Settings.PromptExplicit">指定語言</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">還原預設</sys:String>
     <!-- 例子用的是語言選單裡真正會被代入的名稱（英語 / 日語），不是泛稱 -->
-    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}：目標語言(例：日語) | {target_code}：目標語言代號(例：ja)</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}：來源語言(例：英語) | {source_code}：來源語言代號(例：en)&#10;{target_name}：目標語言(例：日語) | {target_code}：目標語言代號(例：ja)</sys:String>
+    <!-- 可用參數表。範例用的是語言選單裡真正會被代入的名稱與代碼，不是泛稱 -->
+    <sys:String x:Key="S.Settings.PromptParams">可用參數</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamsTip">在提示詞中寫入這些參數，送出前會替換成當次的語言</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamCol1">參數</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamCol2">說明</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamCol3">範例</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamSourceName">來源語言名稱</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamSourceCode">來源語言代碼</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamTargetName">目標語言名稱</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamTargetCode">目標語言代碼</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamSourceNameEg">英語</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamTargetNameEg">日語</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">進階</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">啟用</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -284,7 +284,7 @@
     <!-- 例子用的是語言選單裡真正會被代入的名稱（英語 / 日語），不是泛稱 -->
     <!-- 可用參數表。範例用的是語言選單裡真正會被代入的名稱與代碼，不是泛稱 -->
     <sys:String x:Key="S.Settings.PromptParams">可用參數</sys:String>
-    <sys:String x:Key="S.Settings.PromptParamsTip">在提示詞中寫入這些參數，送出前會替換成當次的語言</sys:String>
+    <sys:String x:Key="S.Settings.PromptParamsTip">在提示詞中寫入這些參數，送出前會替換成當次實際使用的語言，因此一份提示詞就能套用到所有語言組合。</sys:String>
     <sys:String x:Key="S.Settings.PromptParamCol1">參數</sys:String>
     <sys:String x:Key="S.Settings.PromptParamCol2">說明</sys:String>
     <sys:String x:Key="S.Settings.PromptParamCol3">範例</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -281,8 +281,9 @@
     <sys:String x:Key="S.Settings.PromptAuto">自動</sys:String>
     <sys:String x:Key="S.Settings.PromptExplicit">指定語言</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">還原預設</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}：目標語言  {target_code}：目標語言代碼</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}：來源語言  {source_code}：來源語言代碼  {target_name}：目標語言  {target_code}：目標語言代碼</sys:String>
+    <!-- 例子用的是語言選單裡真正會被代入的名稱（英語 / 日語），不是泛稱 -->
+    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}：目標語言(例：日語) | {target_code}：目標語言代號(例：ja)</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}：來源語言(例：英語) | {source_code}：來源語言代號(例：en)&#10;{target_name}：目標語言(例：日語) | {target_code}：目標語言代號(例：ja)</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">進階</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">啟用</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -281,8 +281,8 @@
     <sys:String x:Key="S.Settings.PromptAuto">自動</sys:String>
     <sys:String x:Key="S.Settings.PromptExplicit">指定語言</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">還原預設</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintAuto">{target}：目標語言</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source}：來源語言  {target}：目標語言</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target}：目標語言  {target_code}：目標語言代碼</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source}：來源語言  {source_code}：來源語言代碼  {target}：目標語言  {target_code}：目標語言代碼</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">進階</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">啟用</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -281,8 +281,8 @@
     <sys:String x:Key="S.Settings.PromptAuto">自動</sys:String>
     <sys:String x:Key="S.Settings.PromptExplicit">指定語言</sys:String>
     <sys:String x:Key="S.Settings.ResetDefault">還原預設</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target}：目標語言  {target_code}：目標語言代碼</sys:String>
-    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source}：來源語言  {source_code}：來源語言代碼  {target}：目標語言  {target_code}：目標語言代碼</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintAuto" xml:space="preserve">{target_name}：目標語言  {target_code}：目標語言代碼</sys:String>
+    <sys:String x:Key="S.Settings.PromptHintExplicit" xml:space="preserve">{source_name}：來源語言  {source_code}：來源語言代碼  {target_name}：目標語言  {target_code}：目標語言代碼</sys:String>
     <sys:String x:Key="S.Settings.OpenAiAdvanced">進階</sys:String>
     <sys:String x:Key="S.Settings.Temperature">Temperature</sys:String>
     <sys:String x:Key="S.Settings.TemperatureEnable">啟用</sys:String>

--- a/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
+++ b/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
@@ -324,29 +324,27 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     /// measurably stopped half-way through a Japanese line when handed the restructured wording.
     ///
     /// That is also why TranslateGemma's own documented wording — "You are a professional Japanese
-    /// (ja) to French (fr) translator." — was not adopted whole. What was taken from it is the part
-    /// that carries the information: the language tag beside the name. The tag is what a
-    /// translation-only model keys on, and this template named languages in prose alone until now.
-    /// See <see cref="LanguageData.GetModelLanguageTag"/>.
+    /// (ja) to French (fr) translator." — was not adopted, and why the language tags are not here
+    /// either. Both were tried: on the model this ships against, naming the languages alone reads
+    /// better than naming them with their tags, so the shipped default names them alone.
     ///
-    /// The brackets around each tag are written here rather than produced by the substitution, so
-    /// that a template is free to place the tag differently — or leave it out — for a model that
-    /// wants something else. That is the whole reason the tag has its own placeholder instead of
-    /// being fused into the name.
+    /// The tags keep their own placeholders all the same — see
+    /// <see cref="SourceCodePlaceholder"/> and <see cref="LanguageData.GetModelLanguageTag"/>.
+    /// This default is tuned for one model, and someone pointing this provider at a different one
+    /// has to be able to write what that model expects; a placeholder nothing ships with is still
+    /// the difference between editing a prompt and not being able to.
     /// </remarks>
     internal static string DefaultPromptTemplate(bool automatic) =>
         UsesChinesePrompt()
             ? (automatic
-                ? $"從各種語言翻譯成 {TargetPlaceholder} ({TargetCodePlaceholder})。" +
+                ? $"從(各種語言)翻譯成({TargetPlaceholder})。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。"
-                : $"從 {SourcePlaceholder} ({SourceCodePlaceholder}) " +
-                  $"翻譯成 {TargetPlaceholder} ({TargetCodePlaceholder})。" +
+                : $"從({SourcePlaceholder})翻譯成({TargetPlaceholder})。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。")
             : (automatic
-                ? $"Translate the input text from any language to {TargetPlaceholder} ({TargetCodePlaceholder}). " +
+                ? $"Translate the input text from (any language) to ({TargetPlaceholder}). " +
                   "Do not think or add extra text. Return only a natural, human-sounding translation."
-                : $"Translate the input text from {SourcePlaceholder} ({SourceCodePlaceholder}) " +
-                  $"to {TargetPlaceholder} ({TargetCodePlaceholder}). " +
+                : $"Translate the input text from ({SourcePlaceholder}) to ({TargetPlaceholder}). " +
                   "Do not think or add extra text. Return only a natural, human-sounding translation.");
 
     private static bool UsesChinesePrompt() =>

--- a/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
+++ b/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
@@ -242,10 +242,24 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     }
 
     /// <summary>The placeholder a template uses for the language being translated out of.</summary>
-    internal const string SourcePlaceholder = "{source}";
+    internal const string SourcePlaceholder = "{source_name}";
 
     /// <summary>The placeholder a template uses for the language being translated into.</summary>
-    internal const string TargetPlaceholder = "{target}";
+    internal const string TargetPlaceholder = "{target_name}";
+
+    /// <summary>
+    /// What the name placeholders were called before the tags gained their own.
+    /// </summary>
+    /// <remarks>
+    /// Still substituted, and deliberately not advertised in the settings hint: a template someone
+    /// wrote before this change is sitting in their settings file, and dropping these would send the
+    /// model a literal "{source}" instead of a language. Nothing writes them any more, so the pair
+    /// only ever shrinks.
+    /// </remarks>
+    internal const string LegacySourcePlaceholder = "{source}";
+
+    /// <inheritdoc cref="LegacySourcePlaceholder"/>
+    internal const string LegacyTargetPlaceholder = "{target}";
 
     /// <summary>
     /// The placeholders for the language tags — <c>ja</c> rather than <c>Japanese</c>.
@@ -323,9 +337,10 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     internal static string DefaultPromptTemplate(bool automatic) =>
         UsesChinesePrompt()
             ? (automatic
-                ? $"從各種語言翻譯成{TargetPlaceholder} ({TargetCodePlaceholder})。" +
+                ? $"從各種語言翻譯成 {TargetPlaceholder} ({TargetCodePlaceholder})。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。"
-                : $"從{SourcePlaceholder} ({SourceCodePlaceholder})翻譯成{TargetPlaceholder} ({TargetCodePlaceholder})。" +
+                : $"從 {SourcePlaceholder} ({SourceCodePlaceholder}) " +
+                  $"翻譯成 {TargetPlaceholder} ({TargetCodePlaceholder})。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。")
             : (automatic
                 ? $"Translate the input text from any language to {TargetPlaceholder} ({TargetCodePlaceholder}). " +
@@ -363,14 +378,17 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
             ? (UsesChinesePrompt() ? "各種語言" : "any language")
             : LanguageData.GetSourceDisplayName(sourceLang);
 
+        var target = LanguageData.GetTargetDisplayName(targetLang);
+
         return template
             .Replace(SourceCodePlaceholder, automatic ? "" : LanguageData.GetModelLanguageTag(sourceLang),
                 StringComparison.OrdinalIgnoreCase)
             .Replace(TargetCodePlaceholder, LanguageData.GetModelLanguageTag(targetLang),
                 StringComparison.OrdinalIgnoreCase)
             .Replace(SourcePlaceholder, source, StringComparison.OrdinalIgnoreCase)
-            .Replace(TargetPlaceholder, LanguageData.GetTargetDisplayName(targetLang),
-                StringComparison.OrdinalIgnoreCase);
+            .Replace(TargetPlaceholder, target, StringComparison.OrdinalIgnoreCase)
+            .Replace(LegacySourcePlaceholder, source, StringComparison.OrdinalIgnoreCase)
+            .Replace(LegacyTargetPlaceholder, target, StringComparison.OrdinalIgnoreCase);
     }
 
     internal static string StripThinking(string value) => ThinkingBlock.Replace(value, "").Trim();

--- a/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
+++ b/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
@@ -290,18 +290,27 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     /// Both automatic forms deliberately keep the "from … to …" skeleton of the explicit one rather
     /// than restructuring the sentence. Translation-only models are trained on that shape, and one
     /// measurably stopped half-way through a Japanese line when handed the restructured wording.
+    ///
+    /// That is also why TranslateGemma's own documented wording — "You are a professional Japanese
+    /// (ja) to French (fr) translator." — was not adopted whole. What was taken from it is the part
+    /// that carries the information: the language tag beside the name. The tag is what a
+    /// translation-only model keys on, and this template named languages in prose alone until now.
+    /// See <see cref="Name"/> and <see cref="LanguageData.GetModelLanguageTag"/>.
+    ///
+    /// The placeholders no longer sit inside literal brackets, because the tag brings its own: with
+    /// both, a filled template read "從(日語 (ja))翻譯成…".
     /// </remarks>
     internal static string DefaultPromptTemplate(bool automatic) =>
         UsesChinesePrompt()
             ? (automatic
-                ? $"從(各種語言)翻譯成({TargetPlaceholder})。" +
+                ? $"從各種語言翻譯成{TargetPlaceholder}。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。"
-                : $"從({SourcePlaceholder})翻譯成({TargetPlaceholder})。" +
+                : $"從{SourcePlaceholder}翻譯成{TargetPlaceholder}。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。")
             : (automatic
-                ? $"Translate the input text from (any language) to ({TargetPlaceholder}). " +
+                ? $"Translate the input text from any language to {TargetPlaceholder}. " +
                   "Do not think or add extra text. Return only a natural, human-sounding translation."
-                : $"Translate the input text from ({SourcePlaceholder}) to ({TargetPlaceholder}). " +
+                : $"Translate the input text from {SourcePlaceholder} to {TargetPlaceholder}. " +
                   "Do not think or add extra text. Return only a natural, human-sounding translation.");
 
     private static bool UsesChinesePrompt() =>
@@ -317,17 +326,34 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     /// </remarks>
     private static string Fill(string template, string sourceLang, string targetLang, bool automatic)
     {
-        var target = LanguageData.GetTargetDisplayName(targetLang);
+        var target = Name(targetLang, LanguageData.GetTargetDisplayName(targetLang));
 
         // Nothing to name when the source is 自動, so a template that asks for one anyway is given
         // the same words the built-in automatic template uses in that position.
         var source = automatic
             ? (UsesChinesePrompt() ? "各種語言" : "any language")
-            : LanguageData.GetSourceDisplayName(sourceLang);
+            : Name(sourceLang, LanguageData.GetSourceDisplayName(sourceLang));
 
         return template
             .Replace(SourcePlaceholder, source, StringComparison.OrdinalIgnoreCase)
             .Replace(TargetPlaceholder, target, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A language as a translation model expects to be told it: the name, then its tag.
+    /// </summary>
+    /// <remarks>
+    /// The tag is what TranslateGemma's documented usage puts there — "Japanese (ja) to French (fr)"
+    /// — and it is the half a translation-only model was trained to key on; the name alone leaves it
+    /// matching prose. Custom templates get the same treatment, since the placeholder means the same
+    /// thing wherever it appears.
+    ///
+    /// Falls back to the name alone for anything with no tag, which is only 自動 today.
+    /// </remarks>
+    private static string Name(string code, string display)
+    {
+        var tag = LanguageData.GetModelLanguageTag(code);
+        return tag.Length == 0 ? display : $"{display} ({tag})";
     }
 
     internal static string StripThinking(string value) => ThinkingBlock.Replace(value, "").Trim();

--- a/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
+++ b/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
@@ -248,6 +248,24 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     internal const string TargetPlaceholder = "{target}";
 
     /// <summary>
+    /// The placeholders for the language tags — <c>ja</c> rather than <c>Japanese</c>.
+    /// </summary>
+    /// <remarks>
+    /// Separate from the name rather than fused into it, so a template can put the two wherever its
+    /// model expects them: TranslateGemma wants "Japanese (ja)", another model may want the tag
+    /// alone, and this application cannot know which. The built-in templates compose the pair
+    /// themselves — see <see cref="DefaultPromptTemplate"/> — so the shipped wording is unaffected by
+    /// the split.
+    ///
+    /// The names keep meaning only the name, which is also what they meant before the tags existed:
+    /// a template someone wrote back then still reads the way they wrote it.
+    /// </remarks>
+    internal const string SourceCodePlaceholder = "{source_code}";
+
+    /// <inheritdoc cref="SourceCodePlaceholder"/>
+    internal const string TargetCodePlaceholder = "{target_code}";
+
+    /// <summary>
     /// The instruction for one batch: the user's own template when they have written one, otherwise
     /// the built-in template for this case, with the language placeholders filled in.
     /// </summary>
@@ -295,22 +313,25 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     /// (ja) to French (fr) translator." — was not adopted whole. What was taken from it is the part
     /// that carries the information: the language tag beside the name. The tag is what a
     /// translation-only model keys on, and this template named languages in prose alone until now.
-    /// See <see cref="Name"/> and <see cref="LanguageData.GetModelLanguageTag"/>.
+    /// See <see cref="LanguageData.GetModelLanguageTag"/>.
     ///
-    /// The placeholders no longer sit inside literal brackets, because the tag brings its own: with
-    /// both, a filled template read "從(日語 (ja))翻譯成…".
+    /// The brackets around each tag are written here rather than produced by the substitution, so
+    /// that a template is free to place the tag differently — or leave it out — for a model that
+    /// wants something else. That is the whole reason the tag has its own placeholder instead of
+    /// being fused into the name.
     /// </remarks>
     internal static string DefaultPromptTemplate(bool automatic) =>
         UsesChinesePrompt()
             ? (automatic
-                ? $"從各種語言翻譯成{TargetPlaceholder}。" +
+                ? $"從各種語言翻譯成{TargetPlaceholder} ({TargetCodePlaceholder})。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。"
-                : $"從{SourcePlaceholder}翻譯成{TargetPlaceholder}。" +
+                : $"從{SourcePlaceholder} ({SourceCodePlaceholder})翻譯成{TargetPlaceholder} ({TargetCodePlaceholder})。" +
                   "不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。")
             : (automatic
-                ? $"Translate the input text from any language to {TargetPlaceholder}. " +
+                ? $"Translate the input text from any language to {TargetPlaceholder} ({TargetCodePlaceholder}). " +
                   "Do not think or add extra text. Return only a natural, human-sounding translation."
-                : $"Translate the input text from {SourcePlaceholder} to {TargetPlaceholder}. " +
+                : $"Translate the input text from {SourcePlaceholder} ({SourceCodePlaceholder}) " +
+                  $"to {TargetPlaceholder} ({TargetCodePlaceholder}). " +
                   "Do not think or add extra text. Return only a natural, human-sounding translation.");
 
     private static bool UsesChinesePrompt() =>
@@ -324,36 +345,32 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
     /// A custom template gets those same names: there is no way to tell what language the user's
     /// own prose is in, and the interface's is the best guess available.
     /// </remarks>
+    /// <remarks>
+    /// The code placeholders are replaced before the name ones purely for readability; the two sets
+    /// cannot collide, because <c>{source}</c> is not a prefix of <c>{source_code}</c> once the
+    /// closing brace is counted.
+    ///
+    /// 自動 has no tag to give, so <see cref="SourceCodePlaceholder"/> empties out there. A template
+    /// that wrote its own brackets around it is left with an empty pair, which is the cost of letting
+    /// templates place the tag themselves — the built-in automatic template names no source at all
+    /// and so never shows it.
+    /// </remarks>
     private static string Fill(string template, string sourceLang, string targetLang, bool automatic)
     {
-        var target = Name(targetLang, LanguageData.GetTargetDisplayName(targetLang));
-
         // Nothing to name when the source is 自動, so a template that asks for one anyway is given
         // the same words the built-in automatic template uses in that position.
         var source = automatic
             ? (UsesChinesePrompt() ? "各種語言" : "any language")
-            : Name(sourceLang, LanguageData.GetSourceDisplayName(sourceLang));
+            : LanguageData.GetSourceDisplayName(sourceLang);
 
         return template
+            .Replace(SourceCodePlaceholder, automatic ? "" : LanguageData.GetModelLanguageTag(sourceLang),
+                StringComparison.OrdinalIgnoreCase)
+            .Replace(TargetCodePlaceholder, LanguageData.GetModelLanguageTag(targetLang),
+                StringComparison.OrdinalIgnoreCase)
             .Replace(SourcePlaceholder, source, StringComparison.OrdinalIgnoreCase)
-            .Replace(TargetPlaceholder, target, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// A language as a translation model expects to be told it: the name, then its tag.
-    /// </summary>
-    /// <remarks>
-    /// The tag is what TranslateGemma's documented usage puts there — "Japanese (ja) to French (fr)"
-    /// — and it is the half a translation-only model was trained to key on; the name alone leaves it
-    /// matching prose. Custom templates get the same treatment, since the placeholder means the same
-    /// thing wherever it appears.
-    ///
-    /// Falls back to the name alone for anything with no tag, which is only 自動 today.
-    /// </remarks>
-    private static string Name(string code, string display)
-    {
-        var tag = LanguageData.GetModelLanguageTag(code);
-        return tag.Length == 0 ? display : $"{display} ({tag})";
+            .Replace(TargetPlaceholder, LanguageData.GetTargetDisplayName(targetLang),
+                StringComparison.OrdinalIgnoreCase);
     }
 
     internal static string StripThinking(string value) => ThinkingBlock.Replace(value, "").Trim();

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -451,9 +451,155 @@
                                                TextWrapping="Wrap"/>
                                 </Grid>
 
-                                <TextBlock x:Name="PromptHint"
-                                           Margin="2,9,0,0"
-                                           Style="{StaticResource FieldHint}"/>
+                                <!-- 可用參數. A table rather than a run-on sentence: four
+                                     placeholders each with a meaning and an example is a grid of
+                                     facts, and prose made the reader parse it back into one. Rows
+                                     are separate Grids sharing their column widths, so the two
+                                     source rows can be hidden whole when 自動 has no source. -->
+                                <StackPanel Orientation="Horizontal" Margin="2,14,0,6">
+                                    <TextBlock Text="{DynamicResource S.Settings.PromptParams}"
+                                               Style="{StaticResource SectionHeader}"
+                                               Margin="0"
+                                               VerticalAlignment="Center"/>
+                                    <TextBlock Text="&#xE946;"
+                                               FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                               FontSize="11"
+                                               Foreground="{DynamicResource AppTextSecondary}"
+                                               Margin="5,0,0,0"
+                                               VerticalAlignment="Center"
+                                               ToolTip="{DynamicResource S.Settings.PromptParamsTip}"/>
+                                </StackPanel>
+
+                                <Border BorderBrush="{DynamicResource AppBorder}"
+                                        BorderThickness="1"
+                                        CornerRadius="6"
+                                        Margin="2,0,0,0">
+                                    <StackPanel Grid.IsSharedSizeScope="True">
+                                        <StackPanel.Resources>
+                                            <Style x:Key="ParamRow" TargetType="Grid">
+                                                <Setter Property="Margin" Value="0"/>
+                                            </Style>
+                                            <Style x:Key="ParamCell" TargetType="Border">
+                                                <Setter Property="BorderBrush" Value="{DynamicResource AppBorder}"/>
+                                                <Setter Property="BorderThickness" Value="0,0,1,0"/>
+                                                <Setter Property="Padding" Value="10,6"/>
+                                            </Style>
+                                            <Style x:Key="ParamLastCell" TargetType="Border" BasedOn="{StaticResource ParamCell}">
+                                                <Setter Property="BorderThickness" Value="0"/>
+                                            </Style>
+                                            <Style x:Key="ParamText" TargetType="TextBlock">
+                                                <Setter Property="FontFamily" Value="{StaticResource AppFont}"/>
+                                                <Setter Property="FontSize" Value="11"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource AppTextSecondary}"/>
+                                                <Setter Property="VerticalAlignment" Value="Center"/>
+                                            </Style>
+                                            <Style x:Key="ParamName" TargetType="TextBlock" BasedOn="{StaticResource ParamText}">
+                                                <Setter Property="Foreground" Value="{DynamicResource AppAccent}"/>
+                                            </Style>
+                                        </StackPanel.Resources>
+
+                                        <!-- Header -->
+                                        <Border BorderBrush="{DynamicResource AppBorder}" BorderThickness="0,0,0,1">
+                                            <Grid Style="{StaticResource ParamRow}">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
+                                                </Grid.ColumnDefinitions>
+                                                <Border Grid.Column="0" Style="{StaticResource ParamCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol1}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                                <Border Grid.Column="1" Style="{StaticResource ParamCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol2}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                                <Border Grid.Column="2" Style="{StaticResource ParamLastCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol3}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                            </Grid>
+                                        </Border>
+
+                                        <!-- {source_name} -->
+                                        <Border x:Name="ParamRowSourceName"
+                                                BorderBrush="{DynamicResource AppBorder}" BorderThickness="0,0,0,1">
+                                            <Grid Style="{StaticResource ParamRow}">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
+                                                </Grid.ColumnDefinitions>
+                                                <Border Grid.Column="0" Style="{StaticResource ParamCell}">
+                                                    <!-- {} escapes the brace: XAML reads a leading { as a markup extension. -->
+                                                    <TextBlock Text="{}{source_name}" Style="{StaticResource ParamName}"/>
+                                                </Border>
+                                                <Border Grid.Column="1" Style="{StaticResource ParamCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamSourceName}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                                <Border Grid.Column="2" Style="{StaticResource ParamLastCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamSourceNameEg}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                            </Grid>
+                                        </Border>
+
+                                        <!-- {source_code} -->
+                                        <Border x:Name="ParamRowSourceCode"
+                                                BorderBrush="{DynamicResource AppBorder}" BorderThickness="0,0,0,1">
+                                            <Grid Style="{StaticResource ParamRow}">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
+                                                </Grid.ColumnDefinitions>
+                                                <Border Grid.Column="0" Style="{StaticResource ParamCell}">
+                                                    <TextBlock Text="{}{source_code}" Style="{StaticResource ParamName}"/>
+                                                </Border>
+                                                <Border Grid.Column="1" Style="{StaticResource ParamCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamSourceCode}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                                <Border Grid.Column="2" Style="{StaticResource ParamLastCell}">
+                                                    <TextBlock Text="en" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                            </Grid>
+                                        </Border>
+
+                                        <!-- {target_name} -->
+                                        <Border BorderBrush="{DynamicResource AppBorder}" BorderThickness="0,0,0,1">
+                                            <Grid Style="{StaticResource ParamRow}">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
+                                                </Grid.ColumnDefinitions>
+                                                <Border Grid.Column="0" Style="{StaticResource ParamCell}">
+                                                    <TextBlock Text="{}{target_name}" Style="{StaticResource ParamName}"/>
+                                                </Border>
+                                                <Border Grid.Column="1" Style="{StaticResource ParamCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamTargetName}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                                <Border Grid.Column="2" Style="{StaticResource ParamLastCell}">
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamTargetNameEg}" Style="{StaticResource ParamText}"/>
+                                                </Border>
+                                            </Grid>
+                                        </Border>
+
+                                        <!-- {target_code} -->
+                                        <Grid Style="{StaticResource ParamRow}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
+                                            </Grid.ColumnDefinitions>
+                                            <Border Grid.Column="0" Style="{StaticResource ParamCell}">
+                                                <TextBlock Text="{}{target_code}" Style="{StaticResource ParamName}"/>
+                                            </Border>
+                                            <Border Grid.Column="1" Style="{StaticResource ParamCell}">
+                                                <TextBlock Text="{DynamicResource S.Settings.PromptParamTargetCode}" Style="{StaticResource ParamText}"/>
+                                            </Border>
+                                            <Border Grid.Column="2" Style="{StaticResource ParamLastCell}">
+                                                <TextBlock Text="ja" Style="{StaticResource ParamText}"/>
+                                            </Border>
+                                        </Grid>
+                                    </StackPanel>
+                                </Border>
                             </StackPanel>
 
                             <!-- Collapsed by default and one level down from the fields above it:

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -470,9 +470,13 @@
                                                ToolTip="{DynamicResource S.Settings.PromptParamsTip}"/>
                                 </StackPanel>
 
+                                <!-- Left, not stretched: every column sizes to its content, so a
+                                     table pulled out to the panel's width would be four short
+                                     columns and a stretch of empty rule. -->
                                 <Border BorderBrush="{DynamicResource AppBorder}"
                                         BorderThickness="1"
                                         CornerRadius="6"
+                                        HorizontalAlignment="Left"
                                         Margin="2,0,0,0">
                                     <StackPanel Grid.IsSharedSizeScope="True">
                                         <StackPanel.Resources>
@@ -496,6 +500,13 @@
                                             <Style x:Key="ParamName" TargetType="TextBlock" BasedOn="{StaticResource ParamText}">
                                                 <Setter Property="Foreground" Value="{DynamicResource AppAccent}"/>
                                             </Style>
+                                            <!-- The header is the one row that is not data: a size up
+                                                 and dimmer, so it reads as the label of the column
+                                                 rather than the first entry in it. -->
+                                            <Style x:Key="ParamHeaderText" TargetType="TextBlock" BasedOn="{StaticResource ParamText}">
+                                                <Setter Property="FontSize" Value="12"/>
+                                                <Setter Property="Opacity" Value="0.6"/>
+                                            </Style>
                                         </StackPanel.Resources>
 
                                         <!-- Header -->
@@ -503,17 +514,17 @@
                                             <Grid Style="{StaticResource ParamRow}">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
-                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol2"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
                                                 </Grid.ColumnDefinitions>
                                                 <Border Grid.Column="0" Style="{StaticResource ParamCell}">
-                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol1}" Style="{StaticResource ParamText}"/>
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol1}" Style="{StaticResource ParamHeaderText}"/>
                                                 </Border>
                                                 <Border Grid.Column="1" Style="{StaticResource ParamCell}">
-                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol2}" Style="{StaticResource ParamText}"/>
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol2}" Style="{StaticResource ParamHeaderText}"/>
                                                 </Border>
                                                 <Border Grid.Column="2" Style="{StaticResource ParamLastCell}">
-                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol3}" Style="{StaticResource ParamText}"/>
+                                                    <TextBlock Text="{DynamicResource S.Settings.PromptParamCol3}" Style="{StaticResource ParamHeaderText}"/>
                                                 </Border>
                                             </Grid>
                                         </Border>
@@ -524,7 +535,7 @@
                                             <Grid Style="{StaticResource ParamRow}">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
-                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol2"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
                                                 </Grid.ColumnDefinitions>
                                                 <Border Grid.Column="0" Style="{StaticResource ParamCell}">
@@ -546,7 +557,7 @@
                                             <Grid Style="{StaticResource ParamRow}">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
-                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol2"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
                                                 </Grid.ColumnDefinitions>
                                                 <Border Grid.Column="0" Style="{StaticResource ParamCell}">
@@ -566,7 +577,7 @@
                                             <Grid Style="{StaticResource ParamRow}">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
-                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol2"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
                                                 </Grid.ColumnDefinitions>
                                                 <Border Grid.Column="0" Style="{StaticResource ParamCell}">
@@ -585,7 +596,7 @@
                                         <Grid Style="{StaticResource ParamRow}">
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>
-                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol2"/>
                                                 <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol3"/>
                                             </Grid.ColumnDefinitions>
                                             <Border Grid.Column="0" Style="{StaticResource ParamCell}">

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -500,17 +500,23 @@
                                             <Style x:Key="ParamName" TargetType="TextBlock" BasedOn="{StaticResource ParamText}">
                                                 <Setter Property="Foreground" Value="{DynamicResource AppAccent}"/>
                                             </Style>
-                                            <!-- The header is the one row that is not data: a size up
-                                                 and dimmer, so it reads as the label of the column
-                                                 rather than the first entry in it. -->
+                                            <!-- The header is the one row that is not data, so it is a
+                                                 size up and sits on its own ground. The text itself is
+                                                 left alone — what separates the row is the fill behind
+                                                 it, not a dimmer word. -->
                                             <Style x:Key="ParamHeaderText" TargetType="TextBlock" BasedOn="{StaticResource ParamText}">
                                                 <Setter Property="FontSize" Value="12"/>
-                                                <Setter Property="Opacity" Value="0.6"/>
                                             </Style>
                                         </StackPanel.Resources>
 
-                                        <!-- Header -->
-                                        <Border BorderBrush="{DynamicResource AppBorder}" BorderThickness="0,0,0,1">
+                                        <!-- Header. AppHeaderBg rather than AppSurfaceBg: the light
+                                             theme paints surface and card the same white, so that one
+                                             would separate nothing there. The corners are one less
+                                             than the outer border's, so the fill sits inside it
+                                             instead of squaring off its top. -->
+                                        <Border Background="{DynamicResource AppHeaderBg}"
+                                                CornerRadius="5,5,0,0"
+                                                BorderBrush="{DynamicResource AppBorder}" BorderThickness="0,0,0,1">
                                             <Grid Style="{StaticResource ParamRow}">
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="ParamCol1"/>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -461,12 +461,23 @@
                                                Style="{StaticResource SectionHeader}"
                                                Margin="0"
                                                VerticalAlignment="Center"/>
+                                    <!-- Background="Transparent", not left null: a TextBlock with no
+                                         background is only hit-testable where the glyph's own strokes
+                                         are, so the tooltip would appear over parts of an 11px "i"
+                                         and nowhere else. Transparent fills the box for hit testing
+                                         without painting anything. Padding widens that box to
+                                         something a mouse can find. -->
                                     <TextBlock Text="&#xE946;"
                                                FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                                FontSize="11"
                                                Foreground="{DynamicResource AppTextSecondary}"
-                                               Margin="5,0,0,0"
+                                               Background="Transparent"
+                                               Padding="3,2"
+                                               Margin="3,0,0,0"
                                                VerticalAlignment="Center"
+                                               Cursor="Help"
+                                               ToolTipService.InitialShowDelay="200"
+                                               ToolTipService.ShowDuration="30000"
                                                ToolTip="{DynamicResource S.Settings.PromptParamsTip}"/>
                                 </StackPanel>
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -684,8 +684,7 @@ public partial class SettingsPage : UserControl
     }
 
     /// <summary>
-    /// Writes prose that mentions <c>{source}</c> or <c>{target}</c>, with those two picked out in
-    /// the accent colour.
+    /// Writes prose that mentions the prompt placeholders, with each picked out in the accent colour.
     /// </summary>
     /// <remarks>
     /// They are the only part of the sentence that is machinery rather than words — what the user
@@ -709,10 +708,15 @@ public partial class SettingsPage : UserControl
     /// </summary>
     private static IEnumerable<(string Text, bool IsPlaceholder)> SplitOnPlaceholders(string text)
     {
+        // All four, or the tag placeholders would be the only machinery in the sentence left looking
+        // like prose. None is a prefix of another once the closing brace is counted, so the
+        // earliest-match loop below cannot pick the wrong one.
         string[] tokens =
         [
             OpenAiCompatibleProvider.SourcePlaceholder,
             OpenAiCompatibleProvider.TargetPlaceholder,
+            OpenAiCompatibleProvider.SourceCodePlaceholder,
+            OpenAiCompatibleProvider.TargetCodePlaceholder,
         ];
 
         var index = 0;

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -697,9 +697,23 @@ public partial class SettingsPage : UserControl
         target.Inlines.Clear();
         foreach (var (segment, isPlaceholder) in SplitOnPlaceholders(text))
         {
-            var run = new Run(segment);
-            if (isPlaceholder) run.SetResourceReference(TextElement.ForegroundProperty, "AppAccent");
-            target.Inlines.Add(run);
+            if (isPlaceholder)
+            {
+                var placeholder = new Run(segment);
+                placeholder.SetResourceReference(TextElement.ForegroundProperty, "AppAccent");
+                target.Inlines.Add(placeholder);
+                continue;
+            }
+
+            // The prose between placeholders may carry a line break — the explicit hint lists the
+            // source pair and the target pair one per line. Added as a LineBreak rather than left in
+            // a Run, so it does not depend on the block's wrapping to show up.
+            var lines = segment.Split('\n');
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (i > 0) target.Inlines.Add(new LineBreak());
+                if (lines[i].Length > 0) target.Inlines.Add(new Run(lines[i]));
+            }
         }
     }
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -673,14 +673,12 @@ public partial class SettingsPage : UserControl
             PromptPlaceholder,
             OpenAiCompatibleProvider.DefaultPromptTemplate(_promptSegment == PromptAutoSegment));
 
-        WritePlaceholderAware(PromptHint, LocalizationService.Get(_promptSegment == PromptAutoSegment
-            ? "S.Settings.PromptHintAuto"
-            : "S.Settings.PromptHintExplicit"));
-
-        // FieldHint hides itself when its Text is empty, and writing runs leaves that property
-        // empty however much is on screen — the hint is built out of inlines, not out of Text. A
-        // local value outranks the style's trigger, which is what keeps this one visible.
-        PromptHint.Visibility = Visibility.Visible;
+        // 自動 has no source language, so the two rows describing one would be listing parameters
+        // that resolve to nothing. Hidden whole rather than left showing an empty example.
+        var showsSource = _promptSegment != PromptAutoSegment;
+        var sourceRows = showsSource ? Visibility.Visible : Visibility.Collapsed;
+        ParamRowSourceName.Visibility = sourceRows;
+        ParamRowSourceCode.Visibility = sourceRows;
     }
 
     /// <summary>

--- a/tests/OverTranslate.Tests/LanguageDataTests.cs
+++ b/tests/OverTranslate.Tests/LanguageDataTests.cs
@@ -7,6 +7,30 @@ namespace OverTranslate.Tests;
 
 public class LanguageDataTests
 {
+    // The pickers carry codes chosen for the translation APIs; a local translation model wants BCP 47
+    // instead, and the tag is the half it was trained to key on rather than decoration beside a name.
+    [Theory]
+    [InlineData("JA", "ja")]
+    [InlineData("KO", "ko")]
+    [InlineData("EN", "en")]
+    [InlineData("EN-US", "en")]          // DeepL's regional code; the model wants the plain one
+    [InlineData("ZH", "zh-Hans")]        // 簡體中文 in this application's own OCR picker
+    [InlineData("ZH-HANS", "zh-Hans")]
+    [InlineData("ZH-HANT", "zh-Hant")]
+    [InlineData("PT-BR", "pt-BR")]       // keeps its region, unlike EN-US
+    [InlineData("BG", "bg")]             // no entry in the table; lower-casing is already right
+    public void ModelLanguageTag_IsTheFormATranslationModelExpects(string code, string expected) =>
+        Assert.Equal(expected, LanguageData.GetModelLanguageTag(code));
+
+    [Theory]
+    [InlineData("AUTO")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ModelLanguageTag_IsEmptyWhenThereIsNoLanguageToName(string? code) =>
+        // 自動 is not a language, so naming one would be inventing it — the prompt says "any
+        // language" in that position and must not gain a tag.
+        Assert.Equal("", LanguageData.GetModelLanguageTag(code));
+
     [Fact]
     public void OpenAiCompatibleProvider_IsAvailableWithoutRequiringAKey()
     {

--- a/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
+++ b/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
@@ -63,16 +63,17 @@ public class OpenAiCompatibleProviderTests
     }
 
     [Theory]
-    [InlineData("ZH-HANT", "繁體中文", "zh-Hant")]
-    [InlineData("ZH-HANS", "簡體中文", "zh-Hans")]
-    public void BuildPrompt_IsWrittenInTheInterfaceLanguage(
-        string targetCode, string targetName, string targetTag)
+    [InlineData("ZH-HANT", "繁體中文")]
+    [InlineData("ZH-HANS", "簡體中文")]
+    public void BuildPrompt_IsWrittenInTheInterfaceLanguage(string targetCode, string targetName)
     {
         WithInterfaceLanguage(LocalizationService.TraditionalChinese, () =>
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("AUTO", targetCode);
 
-            Assert.Contains($"從各種語言翻譯成 {targetName} ({targetTag})", prompt);
+            // Names alone, no tags: the shipped default is tuned for the model this provider ships
+            // against, and the tags are there for a template someone writes themselves.
+            Assert.Contains($"從(各種語言)翻譯成({targetName})", prompt);
             Assert.Contains("只回傳自然、人性化的翻譯結果", prompt);
             Assert.DoesNotContain("JSON", prompt);
             Assert.True(prompt.Length <= 80);
@@ -89,7 +90,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("JA", "ZH-HANT");
 
-            Assert.Contains("from Japanese (ja) to Traditional Chinese (zh-Hant)", prompt);
+            Assert.Contains("from (Japanese) to (Traditional Chinese)", prompt);
             Assert.DoesNotContain("繁體中文", prompt);
         });
 
@@ -97,7 +98,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("JA", "EN-US");
 
-            Assert.Contains("從 日語 (ja) 翻譯成 英語 (en)", prompt);
+            Assert.Contains("從(日語)翻譯成(英語)", prompt);
             Assert.DoesNotContain("Translate", prompt);
         });
     }
@@ -127,11 +128,9 @@ public class OpenAiCompatibleProviderTests
         });
     }
 
-    // The tag beside each name is the half a translation-only model keys on — see
-    // OpenAiCompatibleProvider.Name and LanguageData.GetModelLanguageTag.
     [Theory]
-    [InlineData("EN", "JA", "English (en)", "Japanese (ja)")]
-    [InlineData("JA", "KO", "Japanese (ja)", "Korean (ko)")]
+    [InlineData("EN", "JA", "English", "Japanese")]
+    [InlineData("JA", "KO", "Japanese", "Korean")]
     public void BuildPrompt_NamesBothLanguagesInAnEnglishInterface(
         string sourceCode,
         string targetCode,
@@ -142,7 +141,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt(sourceCode, targetCode);
 
-            Assert.Contains($"from {sourceName} to {targetName}", prompt);
+            Assert.Contains($"from ({sourceName}) to ({targetName})", prompt);
             Assert.Contains("Return only a natural, human-sounding translation", prompt);
             Assert.DoesNotContain("只回傳", prompt);
         });
@@ -155,8 +154,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("AUTO", "EN-US");
 
-            // No tag on the source: 自動 is not a language, so there is none to give.
-            Assert.Contains("from any language to English (en)", prompt);
+            Assert.Contains("from (any language) to (English)", prompt);
             Assert.Contains("Return only a natural, human-sounding translation", prompt);
         });
     }

--- a/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
+++ b/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
@@ -63,15 +63,16 @@ public class OpenAiCompatibleProviderTests
     }
 
     [Theory]
-    [InlineData("ZH-HANT", "繁體中文")]
-    [InlineData("ZH-HANS", "簡體中文")]
-    public void BuildPrompt_IsWrittenInTheInterfaceLanguage(string targetCode, string targetName)
+    [InlineData("ZH-HANT", "繁體中文", "zh-Hant")]
+    [InlineData("ZH-HANS", "簡體中文", "zh-Hans")]
+    public void BuildPrompt_IsWrittenInTheInterfaceLanguage(
+        string targetCode, string targetName, string targetTag)
     {
         WithInterfaceLanguage(LocalizationService.TraditionalChinese, () =>
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("AUTO", targetCode);
 
-            Assert.Contains($"從(各種語言)翻譯成({targetName})", prompt);
+            Assert.Contains($"從各種語言翻譯成{targetName} ({targetTag})", prompt);
             Assert.Contains("只回傳自然、人性化的翻譯結果", prompt);
             Assert.DoesNotContain("JSON", prompt);
             Assert.True(prompt.Length <= 80);
@@ -88,7 +89,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("JA", "ZH-HANT");
 
-            Assert.Contains("from (Japanese) to (Traditional Chinese)", prompt);
+            Assert.Contains("from Japanese (ja) to Traditional Chinese (zh-Hant)", prompt);
             Assert.DoesNotContain("繁體中文", prompt);
         });
 
@@ -96,7 +97,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("JA", "EN-US");
 
-            Assert.Contains("從(日語)翻譯成(英語)", prompt);
+            Assert.Contains("從日語 (ja)翻譯成英語 (en)", prompt);
             Assert.DoesNotContain("Translate", prompt);
         });
     }
@@ -109,16 +110,28 @@ public class OpenAiCompatibleProviderTests
     [InlineData("EN-US")]
     public void BuildPrompt_NamesTheSourceEvenWhenItIsAutomatic(string targetCode)
     {
-        var automatic = OpenAiCompatibleProvider.BuildPrompt("AUTO", targetCode);
-        var chosen = OpenAiCompatibleProvider.BuildPrompt("JA", targetCode);
+        WithInterfaceLanguage(LocalizationService.TraditionalChinese, () =>
+        {
+            var automatic = OpenAiCompatibleProvider.BuildPrompt("AUTO", targetCode);
+            var chosen = OpenAiCompatibleProvider.BuildPrompt("JA", targetCode);
 
-        var skeleton = chosen.Split('(')[0];
-        Assert.StartsWith(skeleton, automatic);
+            // Compared as "same opening, same closing instruction" rather than by splitting on the
+            // first bracket, which stopped isolating the skeleton once the language tag brought a
+            // bracket of its own.
+            const string tail = "。不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。";
+
+            Assert.StartsWith("從", automatic);
+            Assert.StartsWith("從", chosen);
+            Assert.EndsWith(tail, automatic);
+            Assert.EndsWith(tail, chosen);
+        });
     }
 
+    // The tag beside each name is the half a translation-only model keys on — see
+    // OpenAiCompatibleProvider.Name and LanguageData.GetModelLanguageTag.
     [Theory]
-    [InlineData("EN", "JA", "English", "Japanese")]
-    [InlineData("JA", "KO", "Japanese", "Korean")]
+    [InlineData("EN", "JA", "English (en)", "Japanese (ja)")]
+    [InlineData("JA", "KO", "Japanese (ja)", "Korean (ko)")]
     public void BuildPrompt_NamesBothLanguagesInAnEnglishInterface(
         string sourceCode,
         string targetCode,
@@ -129,7 +142,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt(sourceCode, targetCode);
 
-            Assert.Contains($"from ({sourceName}) to ({targetName})", prompt);
+            Assert.Contains($"from {sourceName} to {targetName}", prompt);
             Assert.Contains("Return only a natural, human-sounding translation", prompt);
             Assert.DoesNotContain("只回傳", prompt);
         });
@@ -142,7 +155,8 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("AUTO", "EN-US");
 
-            Assert.Contains("from (any language) to (English)", prompt);
+            // No tag on the source: 自動 is not a language, so there is none to give.
+            Assert.Contains("from any language to English (en)", prompt);
             Assert.Contains("Return only a natural, human-sounding translation", prompt);
         });
     }
@@ -159,8 +173,10 @@ public class OpenAiCompatibleProviderTests
             var chosen = OpenAiCompatibleProvider.BuildPrompt(
                 "JA", "ZH-HANT", customAuto: "自動用：翻成{target}", customExplicit: "指定用：{source}→{target}");
 
-            Assert.Equal("自動用：翻成繁體中文", automatic);
-            Assert.Equal("指定用：日語→繁體中文", chosen);
+            // A custom template gets the tagged names too: the placeholder means the same thing
+            // wherever it appears, and the model reading it is the same model.
+            Assert.Equal("自動用：翻成繁體中文 (zh-Hant)", automatic);
+            Assert.Equal("指定用：日語 (ja)→繁體中文 (zh-Hant)", chosen);
         });
     }
 
@@ -184,7 +200,9 @@ public class OpenAiCompatibleProviderTests
             var prompt = OpenAiCompatibleProvider.BuildPrompt(
                 "AUTO", "ZH-HANT", customAuto: "從({source})翻譯成({target})");
 
-            Assert.Equal("從(各種語言)翻譯成(繁體中文)", prompt);
+            // The brackets here are the user's own; the tag brings its own pair, which is why the
+            // built-in templates dropped theirs.
+            Assert.Equal("從(各種語言)翻譯成(繁體中文 (zh-Hant))", prompt);
             Assert.DoesNotContain("{source}", prompt);
         });
     }

--- a/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
+++ b/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
@@ -173,11 +173,53 @@ public class OpenAiCompatibleProviderTests
             var chosen = OpenAiCompatibleProvider.BuildPrompt(
                 "JA", "ZH-HANT", customAuto: "自動用：翻成{target}", customExplicit: "指定用：{source}→{target}");
 
-            // A custom template gets the tagged names too: the placeholder means the same thing
-            // wherever it appears, and the model reading it is the same model.
-            Assert.Equal("自動用：翻成繁體中文 (zh-Hant)", automatic);
-            Assert.Equal("指定用：日語 (ja)→繁體中文 (zh-Hant)", chosen);
+            // The name placeholders still mean the name alone, which is what they meant before the
+            // tags existed — a template written back then reads the way it was written. A template
+            // that wants the tag asks for it with {source_code} / {target_code}.
+            Assert.Equal("自動用：翻成繁體中文", automatic);
+            Assert.Equal("指定用：日語→繁體中文", chosen);
         });
+    }
+
+    // The point of splitting the tag out of the name: a template can place it wherever its own model
+    // expects it, including TranslateGemma's documented wording, which this application does not ship
+    // as its default because restructuring the sentence once cost a model half a Japanese line.
+    [Fact]
+    public void BuildPrompt_LetsATemplatePlaceTheLanguageTagItself()
+    {
+        // The English interface, because the NAME follows the interface language while the tag does
+        // not — see BuildPrompt_FollowsTheInterfaceRatherThanTheTarget.
+        WithInterfaceLanguage(LocalizationService.English, () =>
+        {
+            var prompt = OpenAiCompatibleProvider.BuildPrompt(
+                "JA", "EN-US",
+                customExplicit: "You are a professional {source} ({source_code}) to {target} ({target_code}) translator.");
+
+            Assert.Equal(
+                "You are a professional Japanese (ja) to English (en) translator.",
+                prompt);
+        });
+    }
+
+    [Fact]
+    public void BuildPrompt_LetsATemplateUseTheTagWithoutTheName()
+    {
+        var prompt = OpenAiCompatibleProvider.BuildPrompt(
+            "JA", "ZH-HANT", customExplicit: "{source_code}->{target_code}");
+
+        Assert.Equal("ja->zh-Hant", prompt);
+    }
+
+    // 自動 has no language to name, so it has no tag either. A template that asks for one anyway is
+    // left with whatever brackets it wrote around it rather than a leaked placeholder.
+    [Fact]
+    public void BuildPrompt_EmptiesTheSourceTagWhenTheSourceIsAutomatic()
+    {
+        var prompt = OpenAiCompatibleProvider.BuildPrompt(
+            "AUTO", "ZH-HANT", customAuto: "[{source_code}]{target_code}");
+
+        Assert.Equal("[]zh-Hant", prompt);
+        Assert.DoesNotContain("{source_code}", prompt);
     }
 
     [Theory]
@@ -200,9 +242,7 @@ public class OpenAiCompatibleProviderTests
             var prompt = OpenAiCompatibleProvider.BuildPrompt(
                 "AUTO", "ZH-HANT", customAuto: "從({source})翻譯成({target})");
 
-            // The brackets here are the user's own; the tag brings its own pair, which is why the
-            // built-in templates dropped theirs.
-            Assert.Equal("從(各種語言)翻譯成(繁體中文 (zh-Hant))", prompt);
+            Assert.Equal("從(各種語言)翻譯成(繁體中文)", prompt);
             Assert.DoesNotContain("{source}", prompt);
         });
     }

--- a/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
+++ b/tests/OverTranslate.Tests/OpenAiCompatibleProviderTests.cs
@@ -72,7 +72,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("AUTO", targetCode);
 
-            Assert.Contains($"從各種語言翻譯成{targetName} ({targetTag})", prompt);
+            Assert.Contains($"從各種語言翻譯成 {targetName} ({targetTag})", prompt);
             Assert.Contains("只回傳自然、人性化的翻譯結果", prompt);
             Assert.DoesNotContain("JSON", prompt);
             Assert.True(prompt.Length <= 80);
@@ -97,7 +97,7 @@ public class OpenAiCompatibleProviderTests
         {
             var prompt = OpenAiCompatibleProvider.BuildPrompt("JA", "EN-US");
 
-            Assert.Contains("從日語 (ja)翻譯成英語 (en)", prompt);
+            Assert.Contains("從 日語 (ja) 翻譯成 英語 (en)", prompt);
             Assert.DoesNotContain("Translate", prompt);
         });
     }
@@ -198,6 +198,21 @@ public class OpenAiCompatibleProviderTests
             Assert.Equal(
                 "You are a professional Japanese (ja) to English (en) translator.",
                 prompt);
+        });
+    }
+
+    // {source} / {target} were the names before the tags gained placeholders of their own. A template
+    // written back then is sitting in someone's settings file, and dropping the pair would send the
+    // model a literal "{source}" instead of a language.
+    [Fact]
+    public void BuildPrompt_StillFillsThePlaceholderNamesItUsedToAdvertise()
+    {
+        WithInterfaceLanguage(LocalizationService.English, () =>
+        {
+            var prompt = OpenAiCompatibleProvider.BuildPrompt(
+                "JA", "EN-US", customExplicit: "from {source} to {target}");
+
+            Assert.Equal("from Japanese to English", prompt);
         });
     }
 


### PR DESCRIPTION
把 AI 翻譯的提示詞從兩個佔位符擴充為四個，讓語言**名稱**與**代碼**可以分開編排；設定頁的參數說明改以表格呈現。

起點是 [TranslateGemma 的建議用法](https://ollama.com/library/translategemma)（`You are a professional Japanese (ja) to French (fr) translator.`），但最終**出貨的預設值沒有採用它** —— 見下方。

## 預設提示詞

```
從({source_name})翻譯成({target_name})。不要思考或加入額外文字，只回傳自然、人性化的翻譯結果。
```

實測在出貨的 `translategemma:4b` 上，**只列語言名稱比連同代碼一起給更好**，所以預設值維持名稱、句型也不動。

`DefaultPromptTemplate` 的註解本來就記著一個量測結論：把句子改寫成別的結構後，某個翻譯模型在日文句子讀到一半就停住。這次一併把「代碼也試過、名稱單獨較好」補進去，避免之後有人看到官方文件又改一次。

## 四個佔位符

| 佔位符 | 填入 | 範例 |
|---|---|---|
| `{source_name}` | 來源語言名稱 | 英語 |
| `{source_code}` | 來源語言代碼 | en |
| `{target_name}` | 目標語言名稱 | 日語 |
| `{target_code}` | 目標語言代碼 | ja |

代碼**不在預設值裡，但完整開放**：預設值是為出貨的那顆模型調的，換模型的使用者必須能寫出那顆模型要的格式。官方那種結構現在寫得出來：

```
You are a professional {source_name} ({source_code}) to {target_name} ({target_code}) translator.
→ You are a professional Japanese (ja) to English (en) translator.
```

只用代碼也行：`{source_code}->{target_code}` → `ja->zh-Hant`

**舊的 `{source}` / `{target}` 仍然可用但不再宣傳。** 已經寫了自訂提示詞的使用者，設定檔裡就是舊名稱；直接改名會讓他們送出字面上的 `{source}` 而不是語言。有測試釘住。

## 語言代碼對照

新增 `LanguageData.GetModelLanguageTag()`。我們的代碼是為翻譯 API 選的（`EN-US`、`PT-BR`、`ZH-HANT`），模型要的是 BCP 47，多數只要小寫，只有這幾個需要對照：

| 我們的 | 模型的 | 說明 |
|---|---|---|
| `EN-US` | `en` | DeepL 的區域碼，模型要純代碼 |
| `ZH` | `zh-Hans` | 在我們的 OCR 選單裡就是簡體中文 |
| `ZH-HANS` | `zh-Hans` | |
| `ZH-HANT` | `zh-Hant` | |
| `PT-BR` | `pt-BR` | 保留區域，與 `EN-US` 不同 |

`ZH` 對到簡體而非裸 `zh`，是因為給模型 `zh` 它得在兩種字體之間猜。

**自動偵測不給代碼** —— 那不是一種語言，硬給等於憑空發明。該位置維持「各種語言 / any language」。

## 設定頁

原本的一行小字換成「可用參數」標題 + 表格（參數 / 說明 / 範例），四個參數名套主題色。**自動模式只顯示目標語言那兩列**，因為那時沒有來源語言可代入。

其餘（分段控制、重設鈕、輸入框、預設值預覽、進階）維持原樣。

表格靠左自然展開，欄寬用 `SharedSizeGroup` 跨列對齊；標頭用 `AppHeaderBg` 區分底色 —— 不用 `AppSurfaceBg` 是因為它在淺色主題下與 `AppCardBg` 同為 `#FFFFFF`，那樣就完全沒有區別了。

ⓘ 圖示可停留顯示用途說明。它需要 `Background="Transparent"` 才有實際命中區：`TextBlock` 不設背景時只有字元筆畫本身可被滑鼠命中，那是一個 11px 的圖示。

## 測試

- `LanguageDataTests`：代碼對照的每個例外、以及自動偵測回傳空字串
- `OpenAiCompatibleProviderTests`：官方結構、只用代碼、自動時代碼為空、舊佔位符相容，以及既有的提示詞測試

498 通過 / 0 失敗 / 2 略過（既有）、0 警告。CRLF 與無 BOM 已確認保留。

## 需要實測

- 提示詞效果：`translategemma:4b` 已由 @asd880921 實測，預設值即依實測結果定案
- 版面：參數表格在**淺色主題**下的標頭對比（`#F5F5F5` vs `#FFFFFF`）差異細微，若看不出來可改用 `AppWindowBg`（`#F3F3F3`）
