### PR TITLE
chore: #94 補上 Windows build 診斷，並修正 WindowCaptureShield 的錯誤註解

### DIFF
--- a/src/OverTranslate/Services/DisplayDiagnostics.cs
+++ b/src/OverTranslate/Services/DisplayDiagnostics.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
+using Microsoft.Win32;
 using NLog;
 using Screen = System.Windows.Forms.Screen;
 
@@ -51,10 +52,14 @@ internal static class DisplayDiagnostics
         if (!Log.IsEnabled(level))
             return;
 
+        // Declared outside the try so a failure part-way through can still report what was gathered
+        // before it. The sections are ordered cheapest and most reliable first for the same reason.
+        var sb = new StringBuilder();
+
         try
         {
-            var sb = new StringBuilder();
             sb.AppendLine($"=== Display diagnostics [{phase}] ===");
+            AppendOsInfo(sb);
             AppendProcessInfo(sb);
             AppendVirtualScreenInfo(sb);
             AppendScreens(sb);
@@ -64,7 +69,61 @@ internal static class DisplayDiagnostics
         }
         catch (Exception ex)
         {
-            Log.Warn(ex, "Display diagnostics failed for phase {Phase}", phase);
+            // The partial snapshot goes out with the failure rather than being dropped with it. The
+            // section most likely to throw is AppendScreens — it enumerates every monitor and
+            // marshals a DEVMODE per display — and an unusual display topology is exactly what this
+            // snapshot exists to describe, so the machine that cannot finish one is the machine
+            // whose first few lines are worth the most.
+            Log.Warn(
+                ex, "Display diagnostics failed for phase {Phase}; partial snapshot:\n{Partial}",
+                phase, sb.ToString().TrimEnd());
+        }
+    }
+
+    // Which Windows this is, down to the build. Several of the capture path's behaviours are decided
+    // by the build number and by nothing else observable from here — SetWindowDisplayAffinity on a
+    // per-pixel-alpha layered window is one, and it fails silently enough that the only trace in a
+    // report is a warning with no way to tell which Windows produced it. Every other line in this
+    // snapshot describes the display topology; this one describes what is interpreting it.
+    private static void AppendOsInfo(StringBuilder sb)
+    {
+        var version = Environment.OSVersion.Version;
+
+        // Windows 11 still reports itself as 10.0, so the build is the only thing separating the
+        // two. Derived rather than read from the registry's ProductName, which says "Windows 10"
+        // on Windows 11 and would put a plain lie in the log.
+        string name = version is { Major: 10, Build: >= 22000 } ? "Windows 11"
+            : version.Major == 10 ? "Windows 10"
+            : $"Windows {version.Major}.{version.Minor}";
+
+        // The marketing release (24H2, 25H2). Worth having next to the build because that is how
+        // both Microsoft's documentation and a user describing their machine refer to it.
+        string? release = ReadCurrentVersion("DisplayVersion");
+
+        // OSVersion stops at the build; the update revision after it lives only in the registry, and
+        // it is what separates two machines that will otherwise report the same build.
+        string build = $"{version.Major}.{version.Minor}.{version.Build}";
+        if (ReadCurrentVersion("UBR") is { } ubr) build += $".{ubr}";
+
+        sb.AppendLine(
+            $"os      : {name}{(string.IsNullOrEmpty(release) ? "" : $" {release}")} build={build} " +
+            $"arch={RuntimeInformation.OSArchitecture} process={RuntimeInformation.ProcessArchitecture}");
+    }
+
+    // Null when the value is missing or unreadable. A diagnostic must not be able to break the flow
+    // it is observing, and a machine whose registry will not answer is exactly the kind this
+    // snapshot is being taken for — so it reports the rest and leaves this field out.
+    private static string? ReadCurrentVersion(string valueName)
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(
+                @"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+            return key?.GetValue(valueName)?.ToString();
+        }
+        catch (Exception)
+        {
+            return null;
         }
     }
 

--- a/src/OverTranslate/Services/WindowCaptureShield.cs
+++ b/src/OverTranslate/Services/WindowCaptureShield.cs
@@ -38,10 +38,32 @@ internal static class WindowCaptureShield
         if (SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE))
             return true;
 
-        // Not fatal, and not worth blocking the feature over: the loop's own guard is that
-        // recognising its own output produces text identical to what it already rendered, so the
-        // region settles instead of looping. Logged once — a per-window warning would repeat for
-        // every block on every session.
+        // This used to be recorded as not worth blocking the feature over, on the reasoning that the
+        // loop guards itself: recognising its own output would produce text identical to what it had
+        // already rendered, so the region would settle instead of looping. That guard is real — see
+        // TextSimilarity.IsSameContent and the Unchanged outcome in RealtimeTranslationSession — but
+        // it never engages here, and a user's log has now shown what happens instead.
+        //
+        // What comes back off the screen is not the translation. It is the translation composited
+        // over whatever the scrim failed to cover, so every reading is a fresh mixture of target and
+        // leftover source text and none of them matches the last. Every pass counts as new, and each
+        // one re-translates the previous translation. The size goes with it: a CJK reading carries no
+        // separate glyph height, so the overlay sizes its font from the detection box and draws about
+        // 1.15x the height it read (MaxHeightOverSource), which the next pass reads back as the new
+        // box. One measured line went 25px to 71px in nine seconds before the region was too blurred
+        // to recognise at all.
+        //
+        // None of that is recoverable after the fact: the scrim physically covers the source, so the
+        // pixels underneath are gone from the grab and no amount of filtering brings them back.
+        //
+        // The cause is this window, not the machine. WPF's AllowsTransparency renders through
+        // UpdateLayeredWindow, and Windows does not support display affinity on that kind of layered
+        // window — error 8 is ERROR_NOT_ENOUGH_MEMORY and has nothing to do with memory. It was
+        // fixed in Windows 11 24H2 (build 26100), so this fails on every earlier Windows and works
+        // on every later one, which is why it survived this long unnoticed. Tracked in #94, together
+        // with the fact that no caller does anything with the value returned below.
+        //
+        // Logged once — a per-window warning would repeat for every block on every session.
         if (!_unsupportedReported)
         {
             _unsupportedReported = true;


### PR DESCRIPTION
診斷 #94 時卡在一個問題：使用者提供的 log 裡沒有 Windows 版本，而那次的根因（`SetWindowDisplayAffinity` 在 per-pixel-alpha layered window 上失敗）正好以 Win11 24H2 / build 26100 為分水嶺——缺了這一欄，就無法從一份回報判定機器落在界線的哪一側。

`DisplayDiagnostics` 存在的理由就是「讓這類問題能從 log 判讀，而不必重現」，這次剛好漏掉了決定性的欄位。

本 PR 只做**記錄**：補上診斷欄位，並把一段會誤導後人的註解改成事實。**不含 #94 的實際修復。**

## 改動

### 1. 快照最上方新增 `os` 行

```
=== Display diagnostics [startup] ===
os      : Windows 11 25H2 build=10.0.26200.9168 arch=X64 process=X64
process : dpiAwareness=PER_MONITOR_AWARE_V2 systemDpi=96 (100%)
...
```

- 系統名稱由 build 推導，不讀登錄檔的 `ProductName`——該值在 Windows 11 上實測仍寫著 `Windows 10 Pro`，照抄等於在 log 裡留下一句謊話。Win11 自報 10.0，只有 build ≥ 22000 分得出來。
- `DisplayVersion`（25H2）與 UBR 從登錄檔補上。`Environment.OSVersion` 只到 build 為止，而微軟文件與使用者描述機器時用的都是 25H2 這種代號。
- 登錄檔讀不到就省略該欄位而非拋出，沿用這個檔案原本的原則：診斷不該弄壞它在觀察的流程，而登錄檔答不出來的機器正好就是這種快照要服務的對象。

### 2. 失敗時輸出部分快照

原本 `StringBuilder` 宣告在 `try` 內，任何一個區段拋出就整份作廢，log 裡只剩一行 failed。最有機會拋的是 `AppendScreens`——它列舉每個螢幕並為每個顯示器 marshal 一個 `DEVMODE`——而異常的顯示器組態正是這份快照存在的理由。也就是說最需要這份 log 的機器，最有可能什麼都拿不到。

改為在 `catch` 中一併輸出已蒐集的內容。各區段的順序本來就是由便宜可靠往昂貴脆弱排，新增的 `os` 行放在最前面也是同一個理由。

### 3. 修正 `WindowCaptureShield` 的註解

原註解宣稱排除截圖失敗無所謂，因為「迴圈會自我保護：辨識自己的輸出會得到與已繪製內容相同的文字，所以區域會收斂」。

那個保護機制**是存在的**（`TextSimilarity.IsSameContent` 與 `RealtimeTranslationSession` 的 `Unchanged` 結果），錯的是從它推出的結論——在自我擷取的情況下它永遠不會生效：讀回來的不是譯文，而是譯文疊在 scrim 沒蓋住的殘餘原文之上，每次都是新的混合體，永遠不相同，於是每一輪都算「new」並重譯上一輪的譯文；字級也跟著跑，因為 CJK 讀取不帶獨立字高，疊圖直接以偵測框高推導字級並畫出約 1.15 倍，下一輪再把它讀成新的框。

註解改為記錄實際行為、錯誤碼 8 的真正含意、24H2 這條版本界線，以及「回傳值目前無人使用」這件事，並指向 #94。純註解，無行為變更。

## 驗證

- `dotnet build` 0 警告 0 錯誤
- 既有測試 498 通過 / 0 失敗 / 2 略過
- 以拋棄式 console 專案跑同一段邏輯，確認本機 `DisplayVersion=25H2`、`UBR=9168` 實際存在，且 `ProductName` 確實回報 `Windows 10 Pro`

## 不在此 PR 範圍

#94 的實際修復（疊圖視窗改用非 layered 的透明方案）。那需要一台 24H2 之前的 Windows 作為驗證環境，本機 build 26200 落在已修復的一側，無法重現。

Refs #94
