### PR TITLE
feat: add natural and single-shot realtime translation

### DIFF
--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -10,6 +10,8 @@ public class AppSettings
     public uint HotkeyModifiers { get; set; } = 3;
     public uint HotkeyVirtualKey { get; set; } = 0x41;
     public string HotkeyDisplay { get; set; } = "Ctrl+Alt+A";
+    public ShortcutInputKind HotkeyInputKind { get; set; } = ShortcutInputKind.Keyboard;
+    public GamepadShortcutButton HotkeyGamepadButton { get; set; } = GamepadShortcutButton.None;
 
     /// <summary>
     /// The shortcut that opens the translation window. Ctrl+Alt+W by default.
@@ -25,6 +27,8 @@ public class AppSettings
     public uint TranslationWindowHotkeyVirtualKey { get; set; } = 0x57;
 
     public string TranslationWindowHotkeyDisplay { get; set; } = "Ctrl+Alt+W";
+    public ShortcutInputKind TranslationWindowHotkeyInputKind { get; set; } = ShortcutInputKind.Keyboard;
+    public GamepadShortcutButton TranslationWindowHotkeyGamepadButton { get; set; } = GamepadShortcutButton.None;
 
     /// <summary>
     /// Whether the translation-window shortcut is registered at all.
@@ -52,9 +56,25 @@ public class AppSettings
 
     /// <inheritdoc cref="RealtimeHotkeyModifiers"/>
     public string RealtimeHotkeyDisplay { get; set; } = "Ctrl+Alt+S";
+    public ShortcutInputKind RealtimeHotkeyInputKind { get; set; } = ShortcutInputKind.Keyboard;
+    public GamepadShortcutButton RealtimeHotkeyGamepadButton { get; set; } = GamepadShortcutButton.None;
 
     /// <inheritdoc cref="TranslationWindowHotkeyEnabled"/>
     public bool RealtimeHotkeyEnabled { get; set; } = true;
+
+    /// <summary>
+    /// While realtime translation is running, toggles the one-shot translation/original view.
+    /// Ctrl+Alt+D by default.
+    /// </summary>
+    public uint SingleShotHotkeyModifiers { get; set; } = 3;
+
+    public uint SingleShotHotkeyVirtualKey { get; set; } = 0x44;
+
+    public string SingleShotHotkeyDisplay { get; set; } = "Ctrl+Alt+D";
+    public ShortcutInputKind SingleShotHotkeyInputKind { get; set; } = ShortcutInputKind.Keyboard;
+    public GamepadShortcutButton SingleShotHotkeyGamepadButton { get; set; } = GamepadShortcutButton.None;
+
+    public bool SingleShotHotkeyEnabled { get; set; } = true;
 
     public string SourceLanguage { get; set; } = LanguageData.DefaultOcrSourceLanguage;
     public string TargetLanguage { get; set; } = "ZH-HANT";

--- a/src/OverTranslate/Models/ShortcutInput.cs
+++ b/src/OverTranslate/Models/ShortcutInput.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace OverTranslate.Models;
+
+/// <summary>
+/// The physical input used to trigger a shortcut. Keyboard keeps the existing Windows RegisterHotKey
+/// path; mouse and gamepad are observed without swallowing the original input, so the foreground game
+/// or application still receives them.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ShortcutInputKind
+{
+    Keyboard,
+    MouseMiddle,
+    Gamepad,
+}
+
+/// <summary>
+/// A single XInput button that can be bound as a shortcut. Values deliberately match XInput's
+/// wButtons bit mask, so no translation table is needed in the polling path.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum GamepadShortcutButton : ushort
+{
+    None = 0x0000,
+    DPadUp = 0x0001,
+    DPadDown = 0x0002,
+    DPadLeft = 0x0004,
+    DPadRight = 0x0008,
+    Start = 0x0010,
+    Back = 0x0020,
+    LeftThumb = 0x0040,
+    RightThumb = 0x0080,
+    LeftShoulder = 0x0100,
+    RightShoulder = 0x0200,
+    A = 0x1000,
+    B = 0x2000,
+    X = 0x4000,
+    Y = 0x8000,
+}

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -189,6 +189,12 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.StartTranslating">Start</sys:String>
     <sys:String x:Key="S.Realtime.Running">Translating</sys:String>
     <sys:String x:Key="S.Realtime.Paused">Paused</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotShown">One-shot · translation shown</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotOriginal">One-shot · original</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotResume">Resume continuous realtime translation</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotReused">Text unchanged — reused the previous translation</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotNoText">No readable text was found in the current block</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotOnlyWhileRunning">Start realtime translation before using the one-shot shortcut</sys:String>
     <sys:String x:Key="S.Realtime.Pause">Pause realtime translation</sys:String>
     <sys:String x:Key="S.Realtime.Resume">Resume realtime translation</sys:String>
     <sys:String x:Key="S.Realtime.CaptureScreenshot">Capture a screenshot</sys:String>
@@ -242,6 +248,8 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.HotkeyEnable">Enable this shortcut</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkey">Realtime block</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkeyHint">Press this shortcut to enter realtime [[block selection mode]]</sys:String>
+    <sys:String x:Key="S.Settings.SingleShotHotkey">One-shot / original</sys:String>
+    <sys:String x:Key="S.Settings.SingleShotHotkeyHint">While [[realtime translation]] is running: press once to [[recognise and translate once]], press again to show the original; unchanged text reuses the previous translation. Supports single keys, middle mouse and XInput gamepad buttons</sys:String>
     <sys:String x:Key="S.Settings.HotkeyShadowed">✗ Same as "{0}" above, so it is off</sys:String>
 
     <sys:String x:Key="S.Settings.General">General</sys:String>
@@ -306,6 +314,9 @@ The parameter is left out of the request when this is off. Models differ — fol
     <!-- Settings page, composed in code-behind -->
     <sys:String x:Key="S.Settings.Saved">✓ Saved</sys:String>
     <sys:String x:Key="S.Settings.HotkeyPrompt">Press a shortcut...</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyPromptAnyInput">Press a keyboard key, middle mouse, or gamepad button…</sys:String>
+    <sys:String x:Key="S.Settings.MouseMiddle">Middle Mouse</sys:String>
+    <sys:String x:Key="S.Settings.GamepadButton">Gamepad {0}</sys:String>
     <sys:String x:Key="S.Settings.FolderPickerTitle">Choose where to save screenshots</sys:String>
     <sys:String x:Key="S.Settings.LoggingEnvOverride">The log level is currently set by the OVERTRANSLATE_LOGLEVEL environment variable, so this option has no effect.</sys:String>
     <sys:String x:Key="S.Settings.StartupFailed">✗ Could not change the startup setting: {0}</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -201,6 +201,12 @@
     <sys:String x:Key="S.Realtime.StartTranslating">開始翻譯</sys:String>
     <sys:String x:Key="S.Realtime.Running">即時翻譯中</sys:String>
     <sys:String x:Key="S.Realtime.Paused">已暫停</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotShown">單次翻譯 · 已顯示</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotOriginal">單次翻譯 · 原文</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotResume">恢復連續即時翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotReused">文字未變，沿用上次翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotNoText">目前區塊沒有辨識到文字</sys:String>
+    <sys:String x:Key="S.Realtime.SingleShotOnlyWhileRunning">請先開始即時翻譯，再使用單次翻譯快捷鍵</sys:String>
     <sys:String x:Key="S.Realtime.Pause">暫停即時翻譯</sys:String>
     <sys:String x:Key="S.Realtime.Resume">繼續即時翻譯</sys:String>
     <sys:String x:Key="S.Realtime.CaptureScreenshot">擷取畫面截圖</sys:String>
@@ -257,6 +263,8 @@
     <sys:String x:Key="S.Settings.HotkeyEnable">啟用此快捷鍵</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkey">即時翻譯區塊</sys:String>
     <sys:String x:Key="S.Settings.RealtimeHotkeyHint">按下快捷鍵即可進入即時[[翻譯區塊選取模式]]</sys:String>
+    <sys:String x:Key="S.Settings.SingleShotHotkey">單次翻譯 / 原文</sys:String>
+    <sys:String x:Key="S.Settings.SingleShotHotkeyHint">[[即時翻譯]]進行中使用：第一次按會[[單次辨識並翻譯]]目前區塊，再按一次顯示原文；內容未變時會沿用上次翻譯。可設定單鍵、滑鼠中鍵或 XInput 搖桿按鍵</sys:String>
     <sys:String x:Key="S.Settings.HotkeyShadowed">✗ 與上方的「{0}」重複，已停用</sys:String>
 
     <sys:String x:Key="S.Settings.General">一般設定</sys:String>
@@ -325,6 +333,9 @@
     <!-- Settings page, composed in code-behind -->
     <sys:String x:Key="S.Settings.Saved">✓ 已儲存</sys:String>
     <sys:String x:Key="S.Settings.HotkeyPrompt">請按下快捷鍵...</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyPromptAnyInput">請按鍵盤按鍵、滑鼠中鍵或搖桿按鍵…</sys:String>
+    <sys:String x:Key="S.Settings.MouseMiddle">滑鼠中鍵</sys:String>
+    <sys:String x:Key="S.Settings.GamepadButton">搖桿 {0}</sys:String>
     <sys:String x:Key="S.Settings.FolderPickerTitle">選擇截圖儲存資料夾</sys:String>
     <sys:String x:Key="S.Settings.LoggingEnvOverride">目前記錄等級由環境變數 OVERTRANSLATE_LOGLEVEL 指定，此選項暫時無效。</sys:String>
     <sys:String x:Key="S.Settings.StartupFailed">✗ 無法設定開機啟動：{0}</sys:String>

--- a/src/OverTranslate/Services/GamepadInput.cs
+++ b/src/OverTranslate/Services/GamepadInput.cs
@@ -1,0 +1,136 @@
+using System.Runtime.InteropServices;
+using OverTranslate.Models;
+
+namespace OverTranslate.Services;
+
+/// <summary>
+/// Minimal XInput reader used by shortcut recording and the global gamepad shortcut listener.
+/// No package is required, and no vibration/input is sent back to the controller.
+/// </summary>
+internal static class GamepadInput
+{
+    private const uint ErrorSuccess = 0;
+    private static int _backend; // 0 unknown, 14 xinput1_4, 91 xinput9_1_0, -1 unavailable
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XInputGamepad
+    {
+        public ushort Buttons;
+        public byte LeftTrigger;
+        public byte RightTrigger;
+        public short ThumbLX;
+        public short ThumbLY;
+        public short ThumbRX;
+        public short ThumbRY;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct XInputState
+    {
+        public uint PacketNumber;
+        public XInputGamepad Gamepad;
+    }
+
+    [DllImport("xinput1_4.dll", EntryPoint = "XInputGetState")]
+    private static extern uint XInputGetState14(uint userIndex, out XInputState state);
+
+    [DllImport("xinput9_1_0.dll", EntryPoint = "XInputGetState")]
+    private static extern uint XInputGetState91(uint userIndex, out XInputState state);
+
+    public static bool TryGetButtons(int controllerIndex, out ushort buttons)
+    {
+        buttons = 0;
+        if (controllerIndex is < 0 or > 3 || _backend == -1) return false;
+
+        if (_backend is 0 or 14)
+        {
+            try
+            {
+                if (XInputGetState14((uint)controllerIndex, out var state) == ErrorSuccess)
+                {
+                    _backend = 14;
+                    buttons = state.Gamepad.Buttons;
+                    return true;
+                }
+                if (_backend == 14) return false;
+            }
+            catch (DllNotFoundException)
+            {
+                _backend = 91;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                _backend = 91;
+            }
+        }
+
+        if (_backend is 0 or 91)
+        {
+            try
+            {
+                var result = XInputGetState91((uint)controllerIndex, out var state);
+                _backend = 91;
+                if (result != ErrorSuccess) return false;
+                buttons = state.Gamepad.Buttons;
+                return true;
+            }
+            catch (DllNotFoundException)
+            {
+                _backend = -1;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                _backend = -1;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Returns the first supported button newly present in a button mask.</summary>
+    public static GamepadShortcutButton FirstButton(ushort pressedMask)
+    {
+        foreach (var button in SupportedButtons)
+            if ((pressedMask & (ushort)button) != 0)
+                return button;
+        return GamepadShortcutButton.None;
+    }
+
+    public static IReadOnlyList<GamepadShortcutButton> SupportedButtons { get; } =
+    new[]
+    {
+        GamepadShortcutButton.A,
+        GamepadShortcutButton.B,
+        GamepadShortcutButton.X,
+        GamepadShortcutButton.Y,
+        GamepadShortcutButton.LeftShoulder,
+        GamepadShortcutButton.RightShoulder,
+        GamepadShortcutButton.LeftThumb,
+        GamepadShortcutButton.RightThumb,
+        GamepadShortcutButton.DPadUp,
+        GamepadShortcutButton.DPadDown,
+        GamepadShortcutButton.DPadLeft,
+        GamepadShortcutButton.DPadRight,
+        GamepadShortcutButton.Start,
+        GamepadShortcutButton.Back,
+    };
+
+    public static string ButtonName(GamepadShortcutButton button) => button switch
+    {
+        GamepadShortcutButton.LeftShoulder => "LB",
+        GamepadShortcutButton.RightShoulder => "RB",
+        GamepadShortcutButton.LeftThumb => "L3",
+        GamepadShortcutButton.RightThumb => "R3",
+        GamepadShortcutButton.DPadUp => "D-Pad Up",
+        GamepadShortcutButton.DPadDown => "D-Pad Down",
+        GamepadShortcutButton.DPadLeft => "D-Pad Left",
+        GamepadShortcutButton.DPadRight => "D-Pad Right",
+        GamepadShortcutButton.Start => "Start",
+        GamepadShortcutButton.Back => "Back",
+        GamepadShortcutButton.A => "A",
+        GamepadShortcutButton.B => "B",
+        GamepadShortcutButton.X => "X",
+        GamepadShortcutButton.Y => "Y",
+        _ => button.ToString(),
+    };
+}

--- a/src/OverTranslate/Services/GlobalAuxiliaryHotkeys.cs
+++ b/src/OverTranslate/Services/GlobalAuxiliaryHotkeys.cs
@@ -1,0 +1,141 @@
+using System.Runtime.InteropServices;
+using System.Windows.Threading;
+using OverTranslate.Models;
+
+namespace OverTranslate.Services;
+
+/// <summary>
+/// Observes non-keyboard shortcut inputs. It never swallows the input: middle click and controller
+/// buttons continue to reach the foreground application/game after OverTranslate reacts to them.
+/// </summary>
+internal sealed class GlobalAuxiliaryHotkeys : IDisposable
+{
+    private const int WhMouseLl = 14;
+    private const int WmMButtonDown = 0x0207;
+
+    private readonly Dictionary<ShortcutTrigger, HotkeyAction> _bindings = new();
+    private readonly ushort[] _previousGamepadButtons = new ushort[4];
+    private readonly DispatcherTimer _gamepadTimer = new() { Interval = TimeSpan.FromMilliseconds(35) };
+
+    private LowLevelMouseProc? _mouseProc;
+    private IntPtr _mouseHook;
+
+    public event Action<HotkeyAction>? ShortcutPressed;
+
+    public GlobalAuxiliaryHotkeys()
+    {
+        _gamepadTimer.Tick += (_, _) => PollGamepads();
+    }
+
+    public void Register(IEnumerable<HotkeyBinding> bindings)
+    {
+        ClearRuntimeHooks();
+        _bindings.Clear();
+
+        foreach (var binding in bindings)
+        {
+            if (!binding.IsActive || binding.InputKind == ShortcutInputKind.Keyboard) continue;
+            _bindings[binding.Trigger] = binding.Action;
+        }
+
+        if (_bindings.Keys.Any(t => t.Kind == ShortcutInputKind.MouseMiddle))
+            InstallMouseHook();
+
+        if (_bindings.Keys.Any(t => t.Kind == ShortcutInputKind.Gamepad))
+        {
+            SnapshotGamepads();
+            _gamepadTimer.Start();
+        }
+    }
+
+    private void InstallMouseHook()
+    {
+        _mouseProc = MouseHookCallback;
+        IntPtr moduleHandle = GetModuleHandle(null);
+        _mouseHook = SetWindowsHookEx(WhMouseLl, _mouseProc, moduleHandle, 0);
+    }
+
+    private IntPtr MouseHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        if (nCode >= 0 && wParam.ToInt32() == WmMButtonDown &&
+            _bindings.TryGetValue(ShortcutTrigger.MouseMiddle(), out var action))
+        {
+            ShortcutPressed?.Invoke(action);
+        }
+
+        return CallNextHookEx(_mouseHook, nCode, wParam, lParam);
+    }
+
+    private void SnapshotGamepads()
+    {
+        for (int i = 0; i < _previousGamepadButtons.Length; i++)
+            _previousGamepadButtons[i] = GamepadInput.TryGetButtons(i, out var buttons) ? buttons : (ushort)0;
+    }
+
+    private void PollGamepads()
+    {
+        for (int i = 0; i < _previousGamepadButtons.Length; i++)
+        {
+            if (!GamepadInput.TryGetButtons(i, out var current))
+            {
+                _previousGamepadButtons[i] = 0;
+                continue;
+            }
+
+            ushort pressed = (ushort)(current & ~_previousGamepadButtons[i]);
+            _previousGamepadButtons[i] = current;
+            if (pressed == 0) continue;
+
+            // More than one physical button may be pressed in one poll. Fire each supported edge;
+            // conflict resolution ensures one button maps to at most one app action.
+            foreach (var button in GamepadInput.SupportedButtons)
+            {
+                if ((pressed & (ushort)button) == 0) continue;
+                if (_bindings.TryGetValue(ShortcutTrigger.Gamepad(button), out var action))
+                    ShortcutPressed?.Invoke(action);
+            }
+        }
+    }
+
+    private void ClearRuntimeHooks()
+    {
+        _gamepadTimer.Stop();
+        Array.Clear(_previousGamepadButtons, 0, _previousGamepadButtons.Length);
+
+        if (_mouseHook != IntPtr.Zero)
+        {
+            UnhookWindowsHookEx(_mouseHook);
+            _mouseHook = IntPtr.Zero;
+        }
+        _mouseProc = null;
+    }
+
+    public void Dispose()
+    {
+        ClearRuntimeHooks();
+        _bindings.Clear();
+    }
+
+    private delegate IntPtr LowLevelMouseProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr SetWindowsHookEx(
+        int idHook,
+        LowLevelMouseProc lpfn,
+        IntPtr hMod,
+        uint dwThreadId);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr CallNextHookEx(
+        IntPtr hhk,
+        int nCode,
+        IntPtr wParam,
+        IntPtr lParam);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern IntPtr GetModuleHandle(string? lpModuleName);
+}

--- a/src/OverTranslate/Services/GlobalHotkey.cs
+++ b/src/OverTranslate/Services/GlobalHotkey.cs
@@ -28,6 +28,9 @@ public class GlobalHotkey : IDisposable
     /// <summary>The shortcut that drops straight into 即時翻譯 block framing.</summary>
     public const int RealtimeId = 9003;
 
+    /// <summary>The shortcut that toggles one-shot translation while realtime is running.</summary>
+    public const int SingleShotId = 9004;
+
     public GlobalHotkey(int id) => _id = id;
 
     [DllImport("user32.dll", SetLastError = true)]

--- a/src/OverTranslate/Services/HotkeyBindings.cs
+++ b/src/OverTranslate/Services/HotkeyBindings.cs
@@ -2,89 +2,146 @@ using OverTranslate.Models;
 
 namespace OverTranslate.Services;
 
-/// <summary>The three global shortcuts, in priority order — see <see cref="HotkeyBindings"/>.</summary>
+/// <summary>The global shortcuts, in priority order — see <see cref="HotkeyBindings"/>.</summary>
 public enum HotkeyAction
 {
     Capture,
     TranslationWindow,
     Realtime,
+    SingleShot,
+}
+
+/// <summary>
+/// One physical shortcut trigger. Keyboard uses modifiers + virtual key; mouse middle has no code;
+/// gamepad stores exactly one XInput button value in <see cref="Code"/>.
+/// </summary>
+public readonly record struct ShortcutTrigger(ShortcutInputKind Kind, uint Modifiers, uint Code)
+{
+    public static ShortcutTrigger Keyboard(uint modifiers, uint virtualKey) =>
+        new(ShortcutInputKind.Keyboard, modifiers, virtualKey);
+
+    public static ShortcutTrigger MouseMiddle() =>
+        new(ShortcutInputKind.MouseMiddle, 0, 0);
+
+    public static ShortcutTrigger Gamepad(GamepadShortcutButton button) =>
+        new(ShortcutInputKind.Gamepad, 0, (uint)button);
+
+    public uint VirtualKey => Kind == ShortcutInputKind.Keyboard ? Code : 0;
+    public GamepadShortcutButton GamepadButton => Kind == ShortcutInputKind.Gamepad
+        ? (GamepadShortcutButton)Code
+        : GamepadShortcutButton.None;
 }
 
 /// <param name="ShadowedBy">
-/// The higher-priority action holding this combination, or null when this one gets it. Carried so the
+/// The higher-priority action holding this trigger, or null when this one gets it. Carried so the
 /// settings page can say which shortcut took it rather than only that this one is off.
 /// </param>
 public readonly record struct HotkeyBinding(
     HotkeyAction Action,
-    uint Modifiers,
-    uint VirtualKey,
+    ShortcutTrigger Trigger,
     bool Enabled,
     HotkeyAction? ShadowedBy)
 {
-    /// <summary>Whether this one should actually be registered with Windows.</summary>
+    /// <summary>Whether this one should actually be registered/observed.</summary>
     public bool IsActive => Enabled && ShadowedBy is null;
+
+    // Compatibility/readability helpers for the keyboard registration path and existing tests.
+    public ShortcutInputKind InputKind => Trigger.Kind;
+    public uint Modifiers => Trigger.Modifiers;
+    public uint VirtualKey => Trigger.VirtualKey;
+    public GamepadShortcutButton GamepadButton => Trigger.GamepadButton;
 }
 
 /// <summary>
-/// Works out which shortcuts are live when two of them want the same combination.
+/// Works out which shortcuts are live when two of them want the same physical trigger.
 /// </summary>
 /// <remarks>
-/// Windows keys a registration by window and combination, so the second claim on one is simply
-/// refused: <c>RegisterHotKey</c> returns false and nothing else happens. Which of the two loses is
-/// then whichever happened to be registered second, i.e. an ordering nobody chose.
-///
-/// The settings page already refuses to RECORD a combination another shortcut holds, so a user
-/// cannot create the clash by hand. Stored settings can still arrive in one anyway, and that is what
-/// this exists for: adding <see cref="HotkeyAction.Realtime"/> gave every existing installation a
-/// Ctrl+Alt+S it never agreed to, and anyone who had already put Ctrl+Alt+S on the translation
-/// window would have had one of the two stop working with no explanation.
-///
-/// So the order is declared rather than discovered, and it runs from the feature the application is
-/// for down to the most recently added: capture, then the translation window, then realtime. A
-/// shortcut shadowed by a higher one is reported rather than silently dropped.
+/// Keyboard combinations are registered with RegisterHotKey; mouse middle and gamepad buttons are
+/// observed by the application's global input listener. They all share the same conflict resolver so
+/// "mouse middle" cannot silently do two different things, and the same is true of one gamepad
+/// button. Priority remains capture, translation window, realtime, then single-shot.
 /// </remarks>
 public static class HotkeyBindings
 {
+    /// <summary>Returns the trigger stored for one action.</summary>
+    public static ShortcutTrigger TriggerFor(AppSettings settings, HotkeyAction action) => action switch
+    {
+        HotkeyAction.Capture => BuildTrigger(
+            settings.HotkeyInputKind,
+            settings.HotkeyModifiers,
+            settings.HotkeyVirtualKey,
+            settings.HotkeyGamepadButton),
+        HotkeyAction.TranslationWindow => BuildTrigger(
+            settings.TranslationWindowHotkeyInputKind,
+            settings.TranslationWindowHotkeyModifiers,
+            settings.TranslationWindowHotkeyVirtualKey,
+            settings.TranslationWindowHotkeyGamepadButton),
+        HotkeyAction.Realtime => BuildTrigger(
+            settings.RealtimeHotkeyInputKind,
+            settings.RealtimeHotkeyModifiers,
+            settings.RealtimeHotkeyVirtualKey,
+            settings.RealtimeHotkeyGamepadButton),
+        HotkeyAction.SingleShot => BuildTrigger(
+            settings.SingleShotHotkeyInputKind,
+            settings.SingleShotHotkeyModifiers,
+            settings.SingleShotHotkeyVirtualKey,
+            settings.SingleShotHotkeyGamepadButton),
+        _ => throw new ArgumentOutOfRangeException(nameof(action), action, null),
+    };
+
+    private static ShortcutTrigger BuildTrigger(
+        ShortcutInputKind kind,
+        uint modifiers,
+        uint virtualKey,
+        GamepadShortcutButton gamepadButton) => kind switch
+    {
+        ShortcutInputKind.MouseMiddle => ShortcutTrigger.MouseMiddle(),
+        ShortcutInputKind.Gamepad when gamepadButton != GamepadShortcutButton.None =>
+            ShortcutTrigger.Gamepad(gamepadButton),
+        // A malformed/old setting that says Gamepad but has no button is safer as the keyboard it
+        // already has stored than as a trigger that can never fire.
+        _ => ShortcutTrigger.Keyboard(modifiers, virtualKey),
+    };
+
     /// <summary>
     /// Every shortcut, in priority order, each marked with whether it is live and what took it.
     /// </summary>
     public static IReadOnlyList<HotkeyBinding> Resolve(AppSettings settings)
     {
         // Declaration order IS the priority order; nothing else encodes it.
-        var declared = new (HotkeyAction Action, uint Modifiers, uint Key, bool Enabled)[]
+        var declared = new (HotkeyAction Action, ShortcutTrigger Trigger, bool Enabled)[]
         {
-            (HotkeyAction.Capture, settings.HotkeyModifiers, settings.HotkeyVirtualKey, true),
+            (HotkeyAction.Capture, TriggerFor(settings, HotkeyAction.Capture), true),
             (HotkeyAction.TranslationWindow,
-                settings.TranslationWindowHotkeyModifiers,
-                settings.TranslationWindowHotkeyVirtualKey,
+                TriggerFor(settings, HotkeyAction.TranslationWindow),
                 settings.TranslationWindowHotkeyEnabled),
             (HotkeyAction.Realtime,
-                settings.RealtimeHotkeyModifiers,
-                settings.RealtimeHotkeyVirtualKey,
+                TriggerFor(settings, HotkeyAction.Realtime),
                 settings.RealtimeHotkeyEnabled),
+            (HotkeyAction.SingleShot,
+                TriggerFor(settings, HotkeyAction.SingleShot),
+                settings.SingleShotHotkeyEnabled),
         };
 
-        var claimed = new Dictionary<(uint, uint), HotkeyAction>();
+        var claimed = new Dictionary<ShortcutTrigger, HotkeyAction>();
         var resolved = new List<HotkeyBinding>(declared.Length);
 
-        foreach (var (action, modifiers, key, enabled) in declared)
+        foreach (var (action, trigger, enabled) in declared)
         {
-            // A disabled shortcut does not claim its combination, so turning one off hands the
-            // combination to whatever was shadowed by it rather than leaving it reserved.
             HotkeyAction? shadowedBy = null;
             if (enabled)
             {
-                if (claimed.TryGetValue((modifiers, key), out var holder)) shadowedBy = holder;
-                else claimed[(modifiers, key)] = action;
+                if (claimed.TryGetValue(trigger, out var holder)) shadowedBy = holder;
+                else claimed[trigger] = action;
             }
 
-            resolved.Add(new HotkeyBinding(action, modifiers, key, enabled, shadowedBy));
+            resolved.Add(new HotkeyBinding(action, trigger, enabled, shadowedBy));
         }
 
         return resolved;
     }
 
-    /// <summary>The shortcuts to register, in priority order.</summary>
+    /// <summary>The shortcuts to register/observe, in priority order.</summary>
     public static IEnumerable<HotkeyBinding> Active(AppSettings settings) =>
         Resolve(settings).Where(binding => binding.IsActive);
 }

--- a/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
@@ -1,0 +1,311 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using GdiColor = System.Drawing.Color;
+using MediaColor = System.Windows.Media.Color;
+using WpfRect = System.Windows.Rect;
+
+namespace OverTranslate.Services.Realtime;
+
+/// <summary>
+/// Builds a live-looking background patch for realtime translation. The source glyph rectangle is
+/// replaced with colour interpolated from the pixels immediately around it, while every pixel
+/// outside the OCR rectangle stays exactly as it was on screen. This is intentionally lightweight:
+/// it runs several times per second next to OCR and avoids adding another native/AI dependency.
+/// </summary>
+internal static class RealtimeNaturalBackground
+{
+    // OCR rectangles are often tight around the main glyph body. Japanese dakuten/handakuten,
+    // punctuation dots and antialiasing can sit well outside that rectangle, which leaves the white
+    // "crumbs" visible after replacement. Padding is therefore adaptive to the detected line height
+    // rather than a fixed two pixels. The top side is deliberately the largest because detached
+    // Japanese marks overwhelmingly live above the glyph body.
+    private const int MinErasePadX = 5;
+    private const int MinErasePadTop = 8;
+    private const int MinErasePadBottom = 4;
+
+    public static Bitmap? CreatePatch(
+        Bitmap frame,
+        Rectangle patchBounds,
+        IReadOnlyList<WpfRect> sourceLineBounds)
+    {
+        var frameBounds = new Rectangle(0, 0, frame.Width, frame.Height);
+        var clippedPatch = Rectangle.Intersect(frameBounds, patchBounds);
+        if (clippedPatch.Width <= 0 || clippedPatch.Height <= 0)
+            return null;
+
+        Bitmap patch;
+        try
+        {
+            patch = frame.Clone(clippedPatch, PixelFormat.Format32bppArgb);
+        }
+        catch
+        {
+            return null;
+        }
+
+        foreach (var source in sourceLineBounds)
+        {
+            var local = Rectangle.FromLTRB(
+                (int)Math.Floor(source.Left) - clippedPatch.Left,
+                (int)Math.Floor(source.Top) - clippedPatch.Top,
+                (int)Math.Ceiling(source.Right) - clippedPatch.Left,
+                (int)Math.Ceiling(source.Bottom) - clippedPatch.Top);
+
+            EraseSourceText(patch, local);
+        }
+
+        return patch;
+    }
+
+    /// <summary>
+    /// Samples the source text colour so the replacement keeps roughly the same visual hierarchy as
+    /// the original. Falls back to the configured realtime text colour when no convincing foreground
+    /// pixels can be separated from the local background.
+    /// </summary>
+    public static MediaColor SampleTextColor(Bitmap frame, WpfRect bounds, MediaColor fallback)
+    {
+        if (frame.Width <= 0 || frame.Height <= 0 || bounds.Width <= 0 || bounds.Height <= 0)
+            return fallback;
+
+        var bg = SampleDominantBackground(frame, bounds);
+        var area = Clamp(bounds, frame.Width, frame.Height);
+        if (area.Width <= 0 || area.Height <= 0)
+            return fallback;
+
+        int maxDiff = 0;
+        for (int y = area.Top; y < area.Bottom; y += 2)
+        {
+            for (int x = area.Left; x < area.Right; x += 2)
+            {
+                var c = frame.GetPixel(x, y);
+                int diff = Math.Abs(c.R - bg.R) + Math.Abs(c.G - bg.G) + Math.Abs(c.B - bg.B);
+                if (diff > maxDiff) maxDiff = diff;
+            }
+        }
+
+        if (maxDiff < 36)
+            return fallback;
+
+        int threshold = Math.Max(54, (int)Math.Round(maxDiff * 0.58));
+        long r = 0, g = 0, b = 0, count = 0;
+        for (int y = area.Top; y < area.Bottom; y += 2)
+        {
+            for (int x = area.Left; x < area.Right; x += 2)
+            {
+                var c = frame.GetPixel(x, y);
+                int diff = Math.Abs(c.R - bg.R) + Math.Abs(c.G - bg.G) + Math.Abs(c.B - bg.B);
+                if (diff < threshold) continue;
+                r += c.R;
+                g += c.G;
+                b += c.B;
+                count++;
+            }
+        }
+
+        if (count == 0)
+            return fallback;
+
+        var sampled = MediaColor.FromRgb((byte)(r / count), (byte)(g / count), (byte)(b / count));
+        return EnsureReadable(sampled, MediaColor.FromRgb(bg.R, bg.G, bg.B), fallback);
+    }
+
+    private static void EraseSourceText(Bitmap bitmap, Rectangle source)
+    {
+        int heightBasis = Math.Clamp(source.Height, 12, 72);
+        int padX = Math.Max(MinErasePadX, (int)Math.Ceiling(heightBasis * 0.16));
+        int padTop = Math.Max(MinErasePadTop, (int)Math.Ceiling(heightBasis * 0.34));
+        int padBottom = Math.Max(MinErasePadBottom, (int)Math.Ceiling(heightBasis * 0.16));
+
+        var expanded = Rectangle.FromLTRB(
+            source.Left - padX,
+            source.Top - padTop,
+            source.Right + padX,
+            source.Bottom + padBottom);
+        var rect = Rectangle.Intersect(new Rectangle(0, 0, bitmap.Width, bitmap.Height), expanded);
+        if (rect.Width <= 0 || rect.Height <= 0) return;
+
+        var data = bitmap.LockBits(
+            new Rectangle(0, 0, bitmap.Width, bitmap.Height),
+            ImageLockMode.ReadWrite,
+            PixelFormat.Format32bppArgb);
+
+        try
+        {
+            int stride = Math.Abs(data.Stride);
+            var pixels = new byte[stride * bitmap.Height];
+            for (int y = 0; y < bitmap.Height; y++)
+                Marshal.Copy(IntPtr.Add(data.Scan0, y * data.Stride), pixels, y * stride, stride);
+            var original = (byte[])pixels.Clone();
+
+            int RowOffset(int y) => y * stride;
+
+            bool hasTopBottom = rect.Top > 0 && rect.Bottom < bitmap.Height;
+            bool hasLeftRight = rect.Left > 0 && rect.Right < bitmap.Width;
+
+            if (hasTopBottom)
+            {
+                int topY = rect.Top - 1;
+                int bottomY = rect.Bottom;
+                for (int y = rect.Top; y < rect.Bottom; y++)
+                {
+                    double t = (y - rect.Top + 1.0) / (rect.Height + 1.0);
+                    int dstRow = RowOffset(y);
+                    int topRow = RowOffset(topY);
+                    int bottomRow = RowOffset(bottomY);
+
+                    for (int x = rect.Left; x < rect.Right; x++)
+                    {
+                        int dst = dstRow + x * 4;
+                        int a = topRow + x * 4;
+                        int b = bottomRow + x * 4;
+                        pixels[dst] = Lerp(original[a], original[b], t);
+                        pixels[dst + 1] = Lerp(original[a + 1], original[b + 1], t);
+                        pixels[dst + 2] = Lerp(original[a + 2], original[b + 2], t);
+                        pixels[dst + 3] = 255;
+                    }
+                }
+            }
+            else if (hasLeftRight)
+            {
+                int leftX = rect.Left - 1;
+                int rightX = rect.Right;
+                for (int y = rect.Top; y < rect.Bottom; y++)
+                {
+                    int row = RowOffset(y);
+                    int left = row + leftX * 4;
+                    int right = row + rightX * 4;
+                    for (int x = rect.Left; x < rect.Right; x++)
+                    {
+                        double t = (x - rect.Left + 1.0) / (rect.Width + 1.0);
+                        int dst = row + x * 4;
+                        pixels[dst] = Lerp(original[left], original[right], t);
+                        pixels[dst + 1] = Lerp(original[left + 1], original[right + 1], t);
+                        pixels[dst + 2] = Lerp(original[left + 2], original[right + 2], t);
+                        pixels[dst + 3] = 255;
+                    }
+                }
+            }
+            else
+            {
+                var fill = BorderAverage(original, stride, bitmap.Width, bitmap.Height, rect, RowOffset);
+                for (int y = rect.Top; y < rect.Bottom; y++)
+                {
+                    int row = RowOffset(y);
+                    for (int x = rect.Left; x < rect.Right; x++)
+                    {
+                        int dst = row + x * 4;
+                        pixels[dst] = fill.B;
+                        pixels[dst + 1] = fill.G;
+                        pixels[dst + 2] = fill.R;
+                        pixels[dst + 3] = 255;
+                    }
+                }
+            }
+
+            for (int y = 0; y < bitmap.Height; y++)
+                Marshal.Copy(pixels, y * stride, IntPtr.Add(data.Scan0, y * data.Stride), stride);
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+    }
+
+    private static GdiColor BorderAverage(
+        byte[] pixels,
+        int stride,
+        int width,
+        int height,
+        Rectangle rect,
+        Func<int, int> rowOffset)
+    {
+        long r = 0, g = 0, b = 0, n = 0;
+
+        void Add(int x, int y)
+        {
+            if (x < 0 || x >= width || y < 0 || y >= height) return;
+            int i = rowOffset(y) + x * 4;
+            b += pixels[i];
+            g += pixels[i + 1];
+            r += pixels[i + 2];
+            n++;
+        }
+
+        for (int x = rect.Left; x < rect.Right; x++)
+        {
+            Add(x, rect.Top - 1);
+            Add(x, rect.Bottom);
+        }
+        for (int y = rect.Top; y < rect.Bottom; y++)
+        {
+            Add(rect.Left - 1, y);
+            Add(rect.Right, y);
+        }
+
+        return n == 0
+            ? GdiColor.Black
+            : GdiColor.FromArgb(255, (int)(r / n), (int)(g / n), (int)(b / n));
+    }
+
+    private static GdiColor SampleDominantBackground(Bitmap frame, WpfRect bounds)
+    {
+        int padX = Math.Max(4, (int)Math.Round(bounds.Height * 0.35));
+        int padY = Math.Max(3, (int)Math.Round(bounds.Height * 0.28));
+        int x1 = Math.Clamp((int)Math.Floor(bounds.Left) - padX, 0, frame.Width);
+        int y1 = Math.Clamp((int)Math.Floor(bounds.Top) - padY, 0, frame.Height);
+        int x2 = Math.Clamp((int)Math.Ceiling(bounds.Right) + padX, 0, frame.Width);
+        int y2 = Math.Clamp((int)Math.Ceiling(bounds.Bottom) + padY, 0, frame.Height);
+        int innerX1 = Math.Clamp((int)Math.Floor(bounds.Left), 0, frame.Width);
+        int innerY1 = Math.Clamp((int)Math.Floor(bounds.Top), 0, frame.Height);
+        int innerX2 = Math.Clamp((int)Math.Ceiling(bounds.Right), 0, frame.Width);
+        int innerY2 = Math.Clamp((int)Math.Ceiling(bounds.Bottom), 0, frame.Height);
+
+        var buckets = new Dictionary<int, (long R, long G, long B, int Count)>();
+        for (int y = y1; y < y2; y += 2)
+        {
+            for (int x = x1; x < x2; x += 2)
+            {
+                bool inside = x >= innerX1 && x < innerX2 && y >= innerY1 && y < innerY2;
+                if (inside) continue;
+
+                var c = frame.GetPixel(x, y);
+                int key = ((c.R >> 4) << 8) | ((c.G >> 4) << 4) | (c.B >> 4);
+                var bucket = buckets.GetValueOrDefault(key);
+                buckets[key] = (bucket.R + c.R, bucket.G + c.G, bucket.B + c.B, bucket.Count + 1);
+            }
+        }
+
+        if (buckets.Count == 0)
+            return GdiColor.White;
+
+        var dominant = buckets.Values.OrderByDescending(x => x.Count).First();
+        return GdiColor.FromArgb(
+            255,
+            (int)(dominant.R / dominant.Count),
+            (int)(dominant.G / dominant.Count),
+            (int)(dominant.B / dominant.Count));
+    }
+
+    private static MediaColor EnsureReadable(MediaColor sampled, MediaColor background, MediaColor fallback)
+    {
+        double distance = Math.Abs(sampled.R - background.R) +
+                          Math.Abs(sampled.G - background.G) +
+                          Math.Abs(sampled.B - background.B);
+        if (distance >= 90)
+            return sampled;
+
+        // The source may depend on an outline that sampling cannot reproduce. In that case the user's
+        // configured colour is safer than returning a nearly invisible foreground.
+        return fallback;
+    }
+
+    private static Rectangle Clamp(WpfRect rect, int width, int height) => Rectangle.FromLTRB(
+        Math.Clamp((int)Math.Floor(rect.Left), 0, width),
+        Math.Clamp((int)Math.Floor(rect.Top), 0, height),
+        Math.Clamp((int)Math.Ceiling(rect.Right), 0, width),
+        Math.Clamp((int)Math.Ceiling(rect.Bottom), 0, height));
+
+    private static byte Lerp(byte a, byte b, double t) =>
+        (byte)Math.Clamp((int)Math.Round(a + (b - a) * t), 0, 255);
+}

--- a/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
@@ -110,6 +110,18 @@ public sealed class RealtimeTranslationSession
     private string _sourceLanguage = "";
     private string _targetLanguage = "";
 
+    // One-shot mode deliberately has its own memory rather than relying only on the translation
+    // cache. OCR of an unchanged game line is not byte-for-byte deterministic; this remembers the
+    // last joined reading and lets TextSimilarity decide that a tiny recognition wobble is still
+    // the same text, so showing the translation again does not hit the provider or visibly change
+    // wording just because one glyph was read differently.
+    private readonly Dictionary<int, SingleShotSnapshot> _singleShotSnapshots = [];
+    private CancellationTokenSource? _singleShotCts;
+
+    private sealed record SingleShotSnapshot(
+        string SourceText,
+        IReadOnlyList<TranslatedBlock> Lines);
+
     public RealtimeTranslationSession(OcrService ocr, TranslationService translation)
     {
         _ocr = ocr;
@@ -134,6 +146,9 @@ public sealed class RealtimeTranslationSession
     /// or ended by <see cref="Stop"/>.
     /// </summary>
     public bool IsPaused { get; private set; }
+
+    /// <summary>True while continuous polling is stopped and the user is toggling frozen one-shot results.</summary>
+    public bool IsSingleShotMode { get; private set; }
 
     public void Start(
         IReadOnlyList<RealtimeRegion> regions,
@@ -219,6 +234,143 @@ public sealed class RealtimeTranslationSession
     }
 
     /// <summary>
+    /// Stops continuous polling and enters the human-paced one-shot mode without releasing the OCR
+    /// model. The cache generation is advanced so a provider reply that belonged to the continuous
+    /// loop cannot arrive after the mode switch and paint stale text over the requested snapshot.
+    /// </summary>
+    /// <returns>The new generation used by one-shot results.</returns>
+    public int EnterSingleShotMode()
+    {
+        if (IsSingleShotMode) return _translationCache.Generation;
+
+        StopLoops();
+        _singleShotCts?.Cancel();
+        _singleShotCts?.Dispose();
+        _singleShotCts = null;
+
+        IsPaused = false;
+        IsSingleShotMode = true;
+        _ocr.SetKeepWarm(true);
+
+        var generation = _translationCache.Invalidate();
+        Log.Info("Realtime one-shot mode entered: continuous region loops stopped");
+        return generation;
+    }
+
+    /// <summary>Returns from one-shot mode to the ordinary continuous watcher.</summary>
+    public int ResumeContinuousFromSingleShot()
+    {
+        if (!IsSingleShotMode) return _translationCache.Generation;
+
+        _singleShotCts?.Cancel();
+        _singleShotCts?.Dispose();
+        _singleShotCts = null;
+
+        // A one-shot request may still be unwinding when the user presses Resume. Move generations
+        // before continuous polling starts so that request cannot paint after the mode changed.
+        var generation = _translationCache.Invalidate();
+        IsSingleShotMode = false;
+
+        Log.Info("Realtime one-shot mode ended: resuming continuous region loops");
+        Start(_regions, _sourceLanguage, _targetLanguage, _provider);
+        return generation;
+    }
+
+    /// <summary>
+    /// Reads every framed region exactly once. A region whose recognised wording is effectively the
+    /// same as the last one-shot uses the previous translated wording immediately; changed text is
+    /// translated normally and replaces that memory.
+    /// </summary>
+    /// <returns>Counts of reused, newly translated and empty regions.</returns>
+    public async Task<(int Reused, int Translated, int Empty)> CaptureSingleShotAsync()
+    {
+        if (!IsSingleShotMode) return (0, 0, 0);
+
+        _singleShotCts?.Cancel();
+        _singleShotCts?.Dispose();
+        _singleShotCts = new CancellationTokenSource();
+        var token = _singleShotCts.Token;
+        var generation = _translationCache.Generation;
+
+        var reusedCount = 0;
+        var translatedCount = 0;
+        var emptyCount = 0;
+
+        foreach (var region in _regions)
+        {
+            token.ThrowIfCancellationRequested();
+
+            try
+            {
+                SetBusy(true);
+                using var frame = GrabRegion(region.Bounds);
+                if (frame is null)
+                {
+                    emptyCount++;
+                    continue;
+                }
+
+                var recognized = await RecognizeSingleShotAsync(
+                    region, frame, _sourceLanguage, token);
+                if (recognized is null)
+                {
+                    // The continuous pass that was cancelled when one-shot mode was entered can
+                    // still own the last OCR slot for a brief moment. The helper retries before
+                    // reaching here; if it is still busy, leave this region alone rather than
+                    // pretending the screen was empty.
+                    continue;
+                }
+
+                var sourceText = string.Join('\n', recognized.Select(block => block.Text));
+                if (recognized.Count == 0 || string.IsNullOrWhiteSpace(sourceText))
+                {
+                    _singleShotSnapshots[region.Id] = new SingleShotSnapshot("", []);
+                    RaiseRegionUpdated(new RealtimeRegionUpdate(region.Id, [], generation));
+                    emptyCount++;
+                    ClearFailure();
+                    continue;
+                }
+
+                if (_singleShotSnapshots.TryGetValue(region.Id, out var previous) &&
+                    previous.Lines.Count == recognized.Count &&
+                    TextSimilarity.IsSameContent(sourceText, previous.SourceText))
+                {
+                    var reused = ReflowSingleShotTranslation(recognized, previous.Lines);
+                    _singleShotSnapshots[region.Id] = new SingleShotSnapshot(sourceText, reused);
+                    RaiseRegionUpdated(new RealtimeRegionUpdate(region.Id, reused, generation));
+                    reusedCount++;
+                    ClearFailure();
+                    continue;
+                }
+
+                var translated = await TranslateAsync(
+                    recognized, _sourceLanguage, _targetLanguage, generation, token);
+                if (translated is null) continue;
+
+                _singleShotSnapshots[region.Id] = new SingleShotSnapshot(sourceText, translated);
+                RaiseRegionUpdated(new RealtimeRegionUpdate(region.Id, translated, generation));
+                translatedCount++;
+                ClearFailure();
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex, "Realtime one-shot capture failed for region {Region}", region.Id);
+                ReportFailure(DescribeFailure(ex));
+            }
+            finally
+            {
+                SetBusy(false);
+            }
+        }
+
+        return (reusedCount, translatedCount, emptyCount);
+    }
+
+    /// <summary>
     /// Starts watching again after <see cref="Pause"/>, with the blocks, languages and engine the
     /// session was started with.
     /// </summary>
@@ -238,7 +390,12 @@ public sealed class RealtimeTranslationSession
     public void Stop()
     {
         StopLoops();
+        _singleShotCts?.Cancel();
+        _singleShotCts?.Dispose();
+        _singleShotCts = null;
+        _singleShotSnapshots.Clear();
         IsPaused = false;
+        IsSingleShotMode = false;
     }
 
     private void StopLoops()
@@ -392,6 +549,68 @@ public sealed class RealtimeTranslationSession
     /// Unchanged can be told apart from a genuinely new line that the tolerance swallowed.</param>
     private readonly record struct PassReading(
         PassOutcome Outcome, int OcrMs, int Lines, int SourceLength, int RenderedLength);
+
+    /// <summary>Recognition path used by the explicit one-shot request.</summary>
+    private async Task<List<OcrTextBlock>?> RecognizeSingleShotAsync(
+        RealtimeRegion region,
+        Bitmap frame,
+        string sourceLanguage,
+        CancellationToken token)
+    {
+        var (primarySize, fallbackSizes) =
+            RealtimeDetectorSize.For(frame.Width, frame.Height, region.Mode);
+
+        List<OcrTextBlock>? recognized = null;
+        // A cancelled continuous pass may still be unwinding through native OCR when the hotkey is
+        // pressed. A one-shot request is human-paced, so waiting a few short turns for that slot is
+        // preferable to making the press appear to do nothing.
+        for (var attempt = 0; attempt < 6 && recognized is null; attempt++)
+        {
+            recognized = await _ocr.TryRecognizeAsync(frame, sourceLanguage, primarySize, token);
+            if (recognized is null) await Task.Delay(70, token);
+        }
+
+        if (recognized is null) return null;
+
+        recognized = RejectCollapsedBlocks(recognized, frame.Height, region.Id);
+        recognized = RejectShortReadings(recognized, region.Id);
+
+        foreach (var retrySize in fallbackSizes)
+        {
+            if (recognized.Count > 0) break;
+
+            var retried = await _ocr.TryRecognizeAsync(frame, sourceLanguage, retrySize, token);
+            if (retried is null) continue;
+
+            retried = RejectCollapsedBlocks(retried, frame.Height, region.Id);
+            retried = RejectShortReadings(retried, region.Id);
+            if (retried.Count > 0) recognized = retried;
+        }
+
+        return recognized;
+    }
+
+    /// <summary>
+    /// Keeps the already-translated wording but attaches it to this fresh OCR pass's rectangles.
+    /// This is why hiding and showing the same line remains natural even when a game nudges its text
+    /// by a pixel between the two key presses.
+    /// </summary>
+    private static List<TranslatedBlock> ReflowSingleShotTranslation(
+        IReadOnlyList<OcrTextBlock> current,
+        IReadOnlyList<TranslatedBlock> previous)
+    {
+        var result = new List<TranslatedBlock>(current.Count);
+        for (var i = 0; i < current.Count; i++)
+        {
+            var block = current[i];
+            var old = previous[i];
+            result.Add(new TranslatedBlock(
+                block.Text, old.TranslatedText, block.Bounds,
+                block.SourceLineBounds, block.SourceGlyphHeight,
+                old.BackgroundColor, old.TextColor));
+        }
+        return result;
+    }
 
     /// <summary>
     /// Reads one frame and decides what the region now shows. Everything here is bounded work the

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -24,6 +24,8 @@ public partial class MainWindow : Window
     private GlobalHotkey? _hotkey;
     private GlobalHotkey? _windowHotkey;
     private GlobalHotkey? _realtimeHotkey;
+    private GlobalHotkey? _singleShotHotkey;
+    private GlobalAuxiliaryHotkeys? _auxiliaryHotkeys;
     private OverlayWindow? _overlayWindow;
     private ScreenCaptureWindow? _captureWindow;
     private ToolbarWindow? _toolbarWindow;
@@ -112,23 +114,24 @@ public partial class MainWindow : Window
         _realtimeHotkey = new GlobalHotkey(GlobalHotkey.RealtimeId);
         _realtimeHotkey.HotkeyPressed += OnRealtimeHotkeyPressed;
 
+        _singleShotHotkey = new GlobalHotkey(GlobalHotkey.SingleShotId);
+        _singleShotHotkey.HotkeyPressed += OnSingleShotHotkeyPressed;
+
         var hooks = new Dictionary<HotkeyAction, GlobalHotkey>
         {
             [HotkeyAction.Capture] = _hotkey,
             [HotkeyAction.TranslationWindow] = _windowHotkey,
             [HotkeyAction.Realtime] = _realtimeHotkey,
+            [HotkeyAction.SingleShot] = _singleShotHotkey,
         };
 
-        foreach (var binding in HotkeyBindings.Resolve(settings))
+        var resolved = HotkeyBindings.Resolve(settings);
+        foreach (var binding in resolved)
         {
-            if (!hooks.TryGetValue(binding.Action, out var hook)) continue;
-
             if (binding.ShadowedBy is { } holder)
             {
-                // Warn rather than Debug: the user pressed a key and nothing happened, and this line
-                // is the only place that says why.
                 Log.Warn(
-                    "Hotkey {Action} not registered: {Holder} already claims that combination",
+                    "Hotkey {Action} not registered: {Holder} already claims that trigger",
                     binding.Action, holder);
                 continue;
             }
@@ -139,7 +142,34 @@ public partial class MainWindow : Window
                 continue;
             }
 
-            hook.Register(hwnd, binding.Modifiers, binding.VirtualKey);
+            if (binding.InputKind == OverTranslate.Models.ShortcutInputKind.Keyboard &&
+                hooks.TryGetValue(binding.Action, out var hook))
+            {
+                hook.Register(hwnd, binding.Modifiers, binding.VirtualKey);
+            }
+        }
+
+        _auxiliaryHotkeys = new GlobalAuxiliaryHotkeys();
+        _auxiliaryHotkeys.ShortcutPressed += OnAuxiliaryHotkeyPressed;
+        _auxiliaryHotkeys.Register(resolved);
+    }
+
+    private void OnAuxiliaryHotkeyPressed(HotkeyAction action)
+    {
+        switch (action)
+        {
+            case HotkeyAction.Capture:
+                OnHotkeyPressed(this, EventArgs.Empty);
+                break;
+            case HotkeyAction.TranslationWindow:
+                OnTranslationWindowHotkeyPressed(this, EventArgs.Empty);
+                break;
+            case HotkeyAction.Realtime:
+                OnRealtimeHotkeyPressed(this, EventArgs.Empty);
+                break;
+            case HotkeyAction.SingleShot:
+                OnSingleShotHotkeyPressed(this, EventArgs.Empty);
+                break;
         }
     }
 
@@ -188,6 +218,9 @@ public partial class MainWindow : Window
         _hotkey?.Unregister();
         _windowHotkey?.Unregister();
         _realtimeHotkey?.Unregister();
+        _singleShotHotkey?.Unregister();
+        _auxiliaryHotkeys?.Dispose();
+        _auxiliaryHotkeys = null;
         RegisterHotkey();
     }
 
@@ -231,6 +264,27 @@ public partial class MainWindow : Window
         // means there is nothing to put away.
         RealtimeSessionController.Instance.Start(request, ShellWindow.Current);
     }
+
+    /// <summary>
+    /// Toggles one-shot translation while a realtime session is running. The first press stops the
+    /// continuous watcher and translates the already-framed regions once; the next press removes
+    /// the overlay so the original can be read. Later presses OCR once again and reuse the last
+    /// translation when the recognised wording is effectively unchanged.
+    /// </summary>
+    private void OnSingleShotHotkeyPressed(object? sender, EventArgs e) =>
+        Dispatcher.Invoke(async () =>
+        {
+            var realtime = RealtimeSessionController.Instance;
+            if (!realtime.IsTranslating)
+            {
+                ShowTrayNotification(
+                    LocalizationService.Get("S.Realtime.Title"),
+                    LocalizationService.Get("S.Realtime.SingleShotOnlyWhileRunning"));
+                return;
+            }
+
+            await realtime.ToggleSingleShotAsync();
+        });
 
     /// <summary>
     /// Starts a capture, or — during a realtime session — pauses and resumes that session instead.
@@ -980,6 +1034,9 @@ public partial class MainWindow : Window
         _hotkey?.Dispose();
         _windowHotkey?.Dispose();
         _realtimeHotkey?.Dispose();
+        _singleShotHotkey?.Dispose();
+        _auxiliaryHotkeys?.Dispose();
+        _auxiliaryHotkeys = null;
         if (_notifyIcon != null)
         {
             _notifyIcon.Visible = false;

--- a/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml
@@ -10,14 +10,12 @@
         Focusable="False"
         IsHitTestVisible="False">
 
-    <!-- One window per watched block rather than a single desktop-spanning layer: a translucent
-         window is composed in software, so redrawing a subtitle-sized surface a few times a minute
-         costs nothing, while redrawing the whole desktop for the same change would not. -->
+    <!-- One window per watched block rather than a single desktop-spanning layer. Natural mode
+         refreshes only these small surfaces, so the repaired background can follow video/game
+         motion without redrawing a whole-screen overlay. -->
     <Grid x:Name="LayerHost">
-        <!-- Every scrim is drawn before any text, so a line whose scrim overlaps the line above can
-             never cover that line's words. Two overlapping scrims darkening each other is fine —
-             they are only there to hide what is underneath — but text disappearing behind one is
-             the feature failing at the only thing it does. -->
+        <!-- Every repaired background is drawn before any translated text, so overlapping source
+             areas can never paint over a translation that has already been laid out. -->
         <Canvas x:Name="ScrimCanvas"/>
         <Canvas x:Name="TextCanvas"/>
     </Grid>

--- a/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Windows.Threading;
 using OverTranslate.Layout;
 using OverTranslate.Services;
 using OverTranslate.Services.Realtime;
@@ -16,15 +17,15 @@ using Size = System.Windows.Size;
 namespace OverTranslate.Views.Realtime;
 
 /// <summary>
-/// The live subtitle layer for one watched block: a click-through window pinned over the region,
-/// drawing each translated line as plain text on a black scrim exactly where its source sits.
+/// The live subtitle layer for one watched block: a click-through window pinned over the region.
+/// In natural mode it captures the application underneath, removes the source glyph rectangle with
+/// a lightweight local background repair, then draws the translation back into the same place.
 /// </summary>
 /// <remarks>
-/// No bubbles and no sampled colours here, unlike the screenshot overlay. That overlay produces a
-/// still the user studies, so it is worth matching the page's own background; this one sits over
-/// content that is still moving, where a sampled colour would be wrong a frame later. A fixed black
-/// scrim is only as wide as the text it has to hide, which is what lets the user draw a block
-/// deliberately larger than the text without the surrounding picture being covered up.
+/// The background patch is refreshed while a line is visible. That matters over video/game content:
+/// a one-time screenshot would turn the translated line into a frozen rectangular tile while the
+/// picture behind it kept moving. The overlay itself is excluded from capture, so every refresh sees
+/// the original application rather than recursively photographing its own translation.
 /// </remarks>
 public partial class RealtimeBlockWindow : Window
 {
@@ -34,7 +35,14 @@ public partial class RealtimeBlockWindow : Window
     // of what the user is watching, while the same slack to its left and right lands on picture they
     // are not reading anyway.
     private const double ScrimPaddingX = 5;
-    private const double ScrimPaddingY = 1;
+    private const double ScrimPaddingY = 3;
+
+    // The OCR box can omit detached punctuation/diacritics (especially Japanese dakuten). The
+    // repaired background therefore extends beyond the visible translation band. Pixels in this
+    // guard are copied from the original frame unchanged unless the adaptive eraser identifies them
+    // as part of the source line, so the larger patch does not look like a larger subtitle panel.
+    private const double MinNaturalGuardX = 10;
+    private const double MinNaturalGuardY = 12;
 
     private const double MinFontSize = 8.5;
     private const double LineHeightRatio = 1.22;
@@ -53,6 +61,11 @@ public partial class RealtimeBlockWindow : Window
     private static readonly FontFamily TextFont =
         new("Microsoft JhengHei, Segoe UI Variable Text, Segoe UI, Sans-Serif");
 
+    // Natural mode uses a real patch of the application under the source text. Refreshing at the
+    // same cadence as the screen watcher keeps that patch moving with video without adding another
+    // high-frequency rendering loop. No OCR or translation happens here.
+    private static readonly TimeSpan NaturalRefreshInterval = TimeSpan.FromMilliseconds(250);
+
     private readonly System.Drawing.Rectangle _physBounds;
     private readonly bool _latinSourceToCjkTarget;
 
@@ -67,6 +80,8 @@ public partial class RealtimeBlockWindow : Window
     private double _dpiY = 1.0;
     private bool _isLoaded;
 
+    private readonly DispatcherTimer _naturalRefresh = new() { Interval = NaturalRefreshInterval };
+    private readonly List<NaturalPatchVisual> _naturalPatches = [];
     private IReadOnlyList<TranslatedBlock> _lines = [];
 
     public RealtimeBlockWindow(
@@ -87,6 +102,9 @@ public partial class RealtimeBlockWindow : Window
         _scrimBrush = Freeze(new SolidColorBrush(
             RealtimeSubtitleColors.Scrim(scrimColor, scrimOpacity)));
 
+        _naturalRefresh.Tick += (_, _) => RefreshNaturalBackgrounds();
+        Closed += (_, _) => _naturalRefresh.Stop();
+
         Loaded += (_, _) =>
         {
             if (PresentationSource.FromVisual(this)?.CompositionTarget is { } target)
@@ -96,6 +114,7 @@ public partial class RealtimeBlockWindow : Window
             }
             _isLoaded = true;
             Rebuild();
+            UpdateNaturalRefreshTimer();
         };
     }
 
@@ -157,7 +176,11 @@ public partial class RealtimeBlockWindow : Window
         if (_isLoaded && LooksIdentical(_lines, lines)) return;
 
         _lines = lines;
-        if (_isLoaded) Rebuild();
+        if (_isLoaded)
+        {
+            Rebuild();
+            UpdateNaturalRefreshTimer();
+        }
     }
 
     // A pixel of movement is below what anyone can see and well inside recognition's own precision.
@@ -188,24 +211,32 @@ public partial class RealtimeBlockWindow : Window
     {
         ScrimCanvas.Children.Clear();
         TextCanvas.Children.Clear();
+        _naturalPatches.Clear();
 
         double canvasWidth = _physBounds.Width / _dpiX;
         double canvasHeight = _physBounds.Height / _dpiY;
 
+        using var frame = CaptureUnderlyingRegion();
         foreach (var line in _lines)
         {
             if (string.IsNullOrWhiteSpace(line.TranslatedText)) continue;
-            if (BuildLine(line, canvasWidth, canvasHeight) is not { } visual) continue;
+            if (BuildLine(line, canvasWidth, canvasHeight, frame) is not { } visual) continue;
 
-            ScrimCanvas.Children.Add(visual.Scrim);
+            ScrimCanvas.Children.Add(visual.Background);
             TextCanvas.Children.Add(visual.Text);
+            _naturalPatches.Add(new NaturalPatchVisual(visual.Background, line, visual.PatchBounds));
         }
     }
 
-    /// <summary>One line's two halves, drawn into separate layers so text always wins over scrims.</summary>
-    private readonly record struct LineVisual(UIElement Scrim, UIElement Text);
+    /// <summary>One line's background patch and translated text, kept in separate layers.</summary>
+    private readonly record struct LineVisual(
+        Border Background, Border Text, System.Drawing.Rectangle PatchBounds);
 
-    private LineVisual? BuildLine(TranslatedBlock line, double canvasWidth, double canvasHeight)
+    private readonly record struct NaturalPatchVisual(
+        Border Surface, TranslatedBlock Line, System.Drawing.Rectangle PatchBounds);
+
+    private LineVisual? BuildLine(
+        TranslatedBlock line, double canvasWidth, double canvasHeight, System.Drawing.Bitmap? frame)
     {
         double left = line.Bounds.X / _dpiX;
         double top = line.Bounds.Y / _dpiY;
@@ -311,7 +342,7 @@ public partial class RealtimeBlockWindow : Window
             }
         }
 
-        double scrimWidth = textWidth + ScrimPaddingX * 2;
+        double scrimWidth = Math.Min(canvasWidth, Math.Max(textWidth, sourceWidth) + ScrimPaddingX * 2);
 
         // A grouped block's bounds are the union of its lines, which is the area that has to be
         // covered and is not an inflated single box, so it keeps using them.
@@ -324,16 +355,47 @@ public partial class RealtimeBlockWindow : Window
         double scrimTop = Math.Clamp(
             top + sourceHeight / 2 - scrimHeight / 2, 0, Math.Max(0, canvasHeight - scrimHeight));
 
-        var scrim = new Border
+        double naturalGuardX = Math.Clamp(sourceHeight * 0.20, MinNaturalGuardX, 20);
+        double naturalGuardY = Math.Clamp(sourceHeight * 0.40, MinNaturalGuardY, 26);
+        double patchLeft = Math.Max(0, scrimLeft - naturalGuardX);
+        double patchTop = Math.Max(0, scrimTop - naturalGuardY);
+        double patchRight = Math.Min(canvasWidth, scrimLeft + scrimWidth + naturalGuardX);
+        double patchBottom = Math.Min(canvasHeight, scrimTop + scrimHeight + naturalGuardY);
+        double patchWidth = Math.Max(0, patchRight - patchLeft);
+        double patchHeight = Math.Max(0, patchBottom - patchTop);
+
+        var patchBounds = ToPhysicalPatchBounds(patchLeft, patchTop, patchWidth, patchHeight);
+        var naturalBrush = BuildNaturalBrush(frame, line, patchBounds);
+        if (naturalBrush is null)
         {
-            Width = scrimWidth,
-            Height = scrimHeight,
-            Background = _scrimBrush,
-            CornerRadius = new CornerRadius(3),
+            // Capture can fail on protected/UAC surfaces. Keep the old compact fallback band in
+            // that case rather than painting the much larger natural-mode guard with a flat colour.
+            patchLeft = scrimLeft;
+            patchTop = scrimTop;
+            patchWidth = scrimWidth;
+            patchHeight = scrimHeight;
+            patchBounds = ToPhysicalPatchBounds(patchLeft, patchTop, patchWidth, patchHeight);
+        }
+
+        var background = new Border
+        {
+            Width = patchWidth,
+            Height = patchHeight,
+            Background = (System.Windows.Media.Brush?)naturalBrush ?? _scrimBrush,
+            // A natural patch should meet the surrounding picture edge-for-edge. Rounded corners
+            // would reveal four pieces of the source text underneath.
+            CornerRadius = new CornerRadius(0),
         };
 
+        var foreground = _textBrush;
+        if (frame is not null)
+        {
+            var sampled = RealtimeNaturalBackground.SampleTextColor(frame, line.Bounds, _textBrush.Color);
+            foreground = Freeze(new SolidColorBrush(sampled));
+        }
+
         // Same geometry, no background: the two are stacked in separate layers, so the text has to
-        // carry its own box to land in exactly the place the scrim covers.
+        // carry its own box to land in exactly the place the repaired background covers.
         var text = new Border
         {
             Width = scrimWidth,
@@ -346,7 +408,7 @@ public partial class RealtimeBlockWindow : Window
                 FontFamily = TextFont,
                 FontSize = fontSize,
                 FontWeight = FontWeights.SemiBold,
-                Foreground = _textBrush,
+                Foreground = foreground,
                 TextWrapping = wrapped ? TextWrapping.Wrap : TextWrapping.NoWrap,
                 // Never trimmed. A line that cannot fit on one line has already been switched to
                 // wrapping above, so getting here without it means the text fits; leaving
@@ -356,13 +418,92 @@ public partial class RealtimeBlockWindow : Window
             }
         };
 
-        foreach (var element in (UIElement[])[scrim, text])
-        {
-            Canvas.SetLeft(element, scrimLeft);
-            Canvas.SetTop(element, scrimTop);
-        }
+        Canvas.SetLeft(background, patchLeft);
+        Canvas.SetTop(background, patchTop);
+        Canvas.SetLeft(text, scrimLeft);
+        Canvas.SetTop(text, scrimTop);
 
-        return new LineVisual(scrim, text);
+        return new LineVisual(background, text, patchBounds);
+    }
+
+    private void UpdateNaturalRefreshTimer()
+    {
+        if (!_isLoaded || _naturalPatches.Count == 0)
+            _naturalRefresh.Stop();
+        else if (!_naturalRefresh.IsEnabled)
+            _naturalRefresh.Start();
+    }
+
+    private void RefreshNaturalBackgrounds()
+    {
+        if (!_isLoaded || _naturalPatches.Count == 0) return;
+
+        using var frame = CaptureUnderlyingRegion();
+        if (frame is null) return;
+
+        foreach (var patch in _naturalPatches)
+        {
+            if (BuildNaturalBrush(frame, patch.Line, patch.PatchBounds) is { } brush)
+                patch.Surface.Background = brush;
+        }
+    }
+
+    private System.Drawing.Bitmap? CaptureUnderlyingRegion()
+    {
+        if (_physBounds.Width <= 0 || _physBounds.Height <= 0) return null;
+
+        System.Drawing.Bitmap? bitmap = null;
+        try
+        {
+            bitmap = new System.Drawing.Bitmap(
+                _physBounds.Width, _physBounds.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            using var graphics = System.Drawing.Graphics.FromImage(bitmap);
+            graphics.CopyFromScreen(
+                _physBounds.Left, _physBounds.Top, 0, 0, _physBounds.Size,
+                System.Drawing.CopyPixelOperation.SourceCopy);
+            return bitmap;
+        }
+        catch
+        {
+            bitmap?.Dispose();
+            return null;
+        }
+    }
+
+    private System.Drawing.Rectangle ToPhysicalPatchBounds(
+        double left, double top, double width, double height)
+    {
+        int x1 = Math.Clamp((int)Math.Floor(left * _dpiX), 0, _physBounds.Width);
+        int y1 = Math.Clamp((int)Math.Floor(top * _dpiY), 0, _physBounds.Height);
+        int x2 = Math.Clamp((int)Math.Ceiling((left + width) * _dpiX), 0, _physBounds.Width);
+        int y2 = Math.Clamp((int)Math.Ceiling((top + height) * _dpiY), 0, _physBounds.Height);
+        return System.Drawing.Rectangle.FromLTRB(x1, y1, x2, y2);
+    }
+
+    private static ImageBrush? BuildNaturalBrush(
+        System.Drawing.Bitmap? frame,
+        TranslatedBlock line,
+        System.Drawing.Rectangle patchBounds)
+    {
+        if (frame is null || patchBounds.Width <= 0 || patchBounds.Height <= 0) return null;
+
+        var sourceLines = line.SourceLineBounds is { Count: > 0 } lines
+            ? lines
+            : (IReadOnlyList<System.Windows.Rect>)[line.Bounds];
+
+        using var patch = RealtimeNaturalBackground.CreatePatch(frame, patchBounds, sourceLines);
+        if (patch is null) return null;
+
+        var image = BitmapInterop.ToBitmapSource(patch);
+        var brush = new ImageBrush(image)
+        {
+            Stretch = Stretch.Fill,
+            AlignmentX = AlignmentX.Left,
+            AlignmentY = AlignmentY.Top,
+            TileMode = TileMode.None,
+        };
+        brush.Freeze();
+        return brush;
     }
 
     // Largest size at which the wrapped translation still fits the height it is allowed. For a

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
@@ -54,8 +54,12 @@ public partial class RealtimeControlWindow : Window
     // like a session with nothing to translate — no words, no scrims, a still screen — so the one
     // thing that separates them has to stay on screen for as long as the state lasts.
     private static string PausedStatus => LocalizationService.Get("S.Realtime.Paused");
+    private static string SingleShotShownStatus => LocalizationService.Get("S.Realtime.SingleShotShown");
+    private static string SingleShotOriginalStatus => LocalizationService.Get("S.Realtime.SingleShotOriginal");
     private bool _hasLanguages;
     private bool _isPaused;
+    private bool _isSingleShot;
+    private bool _singleShotVisible;
 
     // The scale WPF renders this window at, which is the DPI of whatever monitor it currently sits
     // on — not necessarily the one the session runs on. Everything that converts between the window's
@@ -235,6 +239,23 @@ public partial class RealtimeControlWindow : Window
         SetBusy(false);
     }
 
+    /// <summary>
+    /// Shows the running capsule as one-shot mode. In this mode the realtime loops are stopped: the
+    /// hotkey alternates between one frozen translation and the untouched original, while the pause
+    /// button becomes the explicit way back to continuous realtime translation.
+    /// </summary>
+    public void SetSingleShotMode(bool enabled, bool translationVisible)
+    {
+        _isSingleShot = enabled;
+        _singleShotVisible = enabled && translationVisible;
+        if (enabled) _isPaused = false;
+
+        ApplyPauseButton();
+        _messageTimer.Stop();
+        RestoreText();
+        SetBusy(false);
+    }
+
     public void SetMode(RealtimeControlMode mode)
     {
         _mode = mode;
@@ -244,6 +265,8 @@ public partial class RealtimeControlWindow : Window
         // Both modes are entered by the session doing something — framing or starting — and neither
         // is a paused one. Going back to edit mode from a paused session is the case this covers.
         _isPaused = false;
+        _isSingleShot = false;
+        _singleShotVisible = false;
         ApplyPauseButton();
 
         _messageTimer.Stop();
@@ -347,11 +370,16 @@ public partial class RealtimeControlWindow : Window
     private void RestoreText()
     {
         EditHintText.Text = EditHint;
-        RunStatusText.Text = _isPaused ? PausedStatus : RunStatus;
 
-        // The pair steps aside while paused: it describes work that is not happening, and it is the
-        // one thing on this line long enough to hide the word that says so.
-        var showPair = _hasLanguages && !_isPaused;
+        if (_isSingleShot)
+            RunStatusText.Text = _singleShotVisible ? SingleShotShownStatus : SingleShotOriginalStatus;
+        else
+            RunStatusText.Text = _isPaused ? PausedStatus : RunStatus;
+
+        // The language pair describes the continuously-running engine. In one-shot mode the state
+        // itself is more important, because the user needs to know whether they are looking at the
+        // frozen translation or at the untouched original.
+        var showPair = _hasLanguages && !_isPaused && !_isSingleShot;
         LangPairPanel.Visibility = showPair ? Visibility.Visible : Visibility.Collapsed;
         RunStatusText.Visibility = showPair ? Visibility.Collapsed : Visibility.Visible;
 
@@ -367,10 +395,25 @@ public partial class RealtimeControlWindow : Window
     private void SetDotState(bool failed) =>
         StatusDot.SetResourceReference(
             System.Windows.Shapes.Shape.FillProperty,
-            failed ? "AppError" : _isPaused ? "AppTextSecondary" : "AppAccent");
+            failed
+                ? "AppError"
+                : (_isPaused || (_isSingleShot && !_singleShotVisible))
+                    ? "AppTextSecondary"
+                    : "AppAccent");
 
     private void ApplyPauseButton()
     {
+        // In one-shot mode the continuous watcher is stopped, so this button is the explicit route
+        // back to it and therefore uses the same play glyph as Resume.
+        if (_isSingleShot)
+        {
+            PauseBtn.Content = "\uE768";
+            var resume = LocalizationService.Get("S.Realtime.SingleShotResume");
+            PauseBtn.ToolTip = resume;
+            System.Windows.Automation.AutomationProperties.SetName(PauseBtn, resume);
+            return;
+        }
+
         // Segoe Fluent Icons: play to resume, pause to stop. The glyph is what the press does.
         PauseBtn.Content = _isPaused ? "\uE768" : "\uE769";
         PauseBtn.ToolTip = RealtimePauseHint.ForControlTooltip(RealtimePauseHint.CurrentHotkey, _isPaused);

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -64,6 +64,8 @@ internal sealed class RealtimeSessionController
     // UI updates are dispatched asynchronously. Carrying the session's generation here prevents an
     // update queued before a pause from restoring text after the screen was cleared.
     private int _visibleGeneration;
+    private bool _singleShotVisible;
+    private bool _singleShotBusy;
 
     /// <summary>
     /// The layout the last sitting ended with, offered back to the next one.
@@ -146,6 +148,8 @@ internal sealed class RealtimeSessionController
         // second inference runtime could be built by accident.
         _session = new RealtimeTranslationSession(AppServices.Ocr, AppServices.Translation);
         Volatile.Write(ref _visibleGeneration, 0);
+        _singleShotVisible = false;
+        _singleShotBusy = false;
         _session.RegionUpdated += OnRegionUpdated;
         _session.Failed += OnSessionFailed;
         _session.BusyChanged += OnBusyChanged;
@@ -208,6 +212,25 @@ internal sealed class RealtimeSessionController
     {
         if (!IsTranslating || _session is null || _control is not { } control) return false;
 
+        // In one-shot mode the continuous watcher is already stopped. The existing pause/resume
+        // button and capture hotkey become the natural way back to normal realtime translation.
+        if (_session.IsSingleShotMode)
+        {
+            if (_singleShotBusy) return true;
+
+            var resumeGeneration = _session.ResumeContinuousFromSingleShot();
+            Volatile.Write(ref _visibleGeneration, resumeGeneration);
+            _singleShotVisible = false;
+            _singleShotBusy = false;
+
+            foreach (var window in _blockWindows.Values)
+                window.SetLines([]);
+
+            control.SetSingleShotMode(false, false);
+            control.SetPaused(false);
+            return true;
+        }
+
         if (_session.IsPaused)
         {
             // Before the loops start, so the first result cannot arrive to a bar still saying 已暫停.
@@ -216,8 +239,8 @@ internal sealed class RealtimeSessionController
             return true;
         }
 
-        var generation = _session.Pause();
-        Volatile.Write(ref _visibleGeneration, generation);
+        var pauseGeneration = _session.Pause();
+        Volatile.Write(ref _visibleGeneration, pauseGeneration);
 
         // The whole point of the feature: 暫停 takes the words and their scrims off the screen
         // rather than freezing them there, because a frozen translation over a scene that has moved
@@ -230,12 +253,73 @@ internal sealed class RealtimeSessionController
         return true;
     }
 
+    /// <summary>
+    /// Alternates one-shot translation and the untouched original over the already-framed realtime
+    /// regions. The first press also stops continuous polling. Every later "show" press OCRs once;
+    /// the session reuses its previous translation when that reading is effectively unchanged.
+    /// </summary>
+    public async Task<bool> ToggleSingleShotAsync()
+    {
+        if (!IsTranslating || _session is null || _control is not { } control) return false;
+        if (_singleShotBusy) return true;
+
+        if (!_session.IsSingleShotMode)
+        {
+            var generation = _session.EnterSingleShotMode();
+            Volatile.Write(ref _visibleGeneration, generation);
+            _singleShotVisible = false;
+
+            // A continuous result already on screen belongs to the mode we just left. Remove it
+            // before taking the requested snapshot so the first one-shot frame starts from original.
+            foreach (var window in _blockWindows.Values)
+                window.SetLines([]);
+
+            control.SetSingleShotMode(true, false);
+        }
+
+        if (_singleShotVisible)
+        {
+            foreach (var window in _blockWindows.Values)
+                window.SetLines([]);
+
+            _singleShotVisible = false;
+            control.SetSingleShotMode(true, false);
+            return true;
+        }
+
+        _singleShotBusy = true;
+        try
+        {
+            var result = await _session.CaptureSingleShotAsync();
+            var hasResult = result.Translated > 0 || result.Reused > 0;
+            _singleShotVisible = hasResult;
+            control.SetSingleShotMode(true, hasResult);
+
+            if (result.Translated == 0 && result.Reused > 0)
+                control.ShowMessage(LocalizationService.Get("S.Realtime.SingleShotReused"));
+            else if (!hasResult && result.Empty > 0)
+                control.ShowMessage(LocalizationService.Get("S.Realtime.SingleShotNoText"));
+
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return true;
+        }
+        finally
+        {
+            _singleShotBusy = false;
+        }
+    }
+
     public void Stop()
     {
         if (!IsActive) return;
 
         Log.Info("Realtime session ending");
 
+        _singleShotVisible = false;
+        _singleShotBusy = false;
         _stayOnTop.Stop();
         DisposeEscapeHook();
 
@@ -290,6 +374,8 @@ internal sealed class RealtimeSessionController
         if (_request is not { } request || _control is not { } control) return;
 
         _session?.Stop();
+        _singleShotVisible = false;
+        _singleShotBusy = false;
         CloseBlockWindows();
         CloseEditWindow();
 
@@ -372,6 +458,8 @@ internal sealed class RealtimeSessionController
         control.BringToFront();
         _stayOnTop.Start();
 
+        _singleShotVisible = false;
+        _singleShotBusy = false;
         _session.Start(regions, request.SourceLanguage, request.TargetLanguage, request.Provider);
     }
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="OverTranslate.Views.Settings.SettingsPage"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:OverTranslate.Views.Controls">
+             xmlns:controls="clr-namespace:OverTranslate.Views.Controls"
+             PreviewMouseDown="SettingsPage_PreviewMouseDown">
 
     <Grid Margin="28,22,28,20">
         <Grid.RowDefinitions>
@@ -68,6 +69,7 @@
                 <Border Style="{StaticResource CardBorder}">
                     <Grid>
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -190,6 +192,48 @@
                                        Style="{StaticResource FieldHint}"/>
                             <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
                                        x:Name="RealtimeHotkeyShadowHint"
+                                       Style="{StaticResource FieldHint}"
+                                       Visibility="Collapsed"/>
+                        </Grid>
+
+                        <!-- One-shot translation. Active only while realtime translation is running. -->
+                        <Grid Grid.Row="4" Margin="0,10,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="70"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="HotkeyToggle"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Column="0" Grid.Row="0" Text="{DynamicResource S.Settings.SingleShotHotkey}"
+                                       Style="{StaticResource FieldLabel}"/>
+                            <TextBox   Grid.Column="1" Grid.Row="0" x:Name="SingleShotHotkeyBox"
+                                       Style="{StaticResource ModernTextBox}"
+                                       IsReadOnly="True"
+                                       Margin="0,0,8,0"
+                                       PreviewKeyDown="HotkeyBox_PreviewKeyDown"
+                                       GotFocus="HotkeyBox_GotFocus"
+                                       LostFocus="HotkeyBox_LostFocus"/>
+                            <Button    Grid.Column="2" Grid.Row="0" x:Name="SingleShotRecordBtn" Content="{DynamicResource S.Common.Record}"
+                                       Style="{StaticResource FlatButton}"
+                                       Height="34"
+                                       Click="RecordBtn_Click"/>
+                            <CheckBox  Grid.Column="3" Grid.Row="0" x:Name="SingleShotHotkeyEnabledCheckBox"
+                                       Style="{StaticResource ModernCheckBox}"
+                                       VerticalAlignment="Center"
+                                       Margin="10,0,0,0"
+                                       ToolTip="{DynamicResource S.Settings.HotkeyEnable}"
+                                       Checked="HotkeyEnabled_Toggled"
+                                       Unchecked="HotkeyEnabled_Toggled"/>
+                            <TextBlock Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3"
+                                       controls:HighlightedText.Source="{DynamicResource S.Settings.SingleShotHotkeyHint}"
+                                       Style="{StaticResource FieldHint}"/>
+                            <TextBlock Grid.Column="1" Grid.Row="2" Grid.ColumnSpan="3"
+                                       x:Name="SingleShotHotkeyShadowHint"
                                        Style="{StaticResource FieldHint}"
                                        Visibility="Collapsed"/>
                         </Grid>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -34,6 +34,8 @@ public partial class SettingsPage : UserControl
     private readonly DispatcherTimer _openAiSettingsDebounce;
     private readonly DispatcherTimer _promptDebounce;
     private readonly DispatcherTimer _statusHold;
+    private readonly DispatcherTimer _hotkeyGamepadRecordTimer;
+    private readonly ushort[] _recordGamepadButtons = new ushort[4];
 
     private const int PromptAutoSegment = 0;
     private const int PromptExplicitSegment = 1;
@@ -61,7 +63,7 @@ public partial class SettingsPage : UserControl
     /// <param name="AdvertisedInShell">
     /// Whether the shell's nav rail prints this combination beside a button, and so has to be told
     /// when it changes. True for the capture shortcut, which the interface names in three places;
-    /// false for the other two, which it names nowhere.
+    /// false for the other shortcuts, which it names nowhere.
     /// </param>
     /// <param name="EnabledBox">
     /// The tick that turns this shortcut off, or null for the capture one, which has no tick at all
@@ -78,8 +80,8 @@ public partial class SettingsPage : UserControl
         TextBox Box,
         Button Record,
         Func<AppSettings, string> Display,
-        Func<AppSettings, (uint Modifiers, uint Key)> Combination,
-        Action<AppSettings, uint, uint, string> Apply,
+        Func<AppSettings, ShortcutTrigger> Trigger,
+        Action<AppSettings, ShortcutTrigger, string> Apply,
         bool AdvertisedInShell,
         // Fully qualified: WinForms is also referenced here and has its own CheckBox.
         System.Windows.Controls.CheckBox? EnabledBox = null,
@@ -105,26 +107,16 @@ public partial class SettingsPage : UserControl
                 "S.Settings.CaptureHotkey",
                 HotkeyBox, RecordBtn,
                 s => s.HotkeyDisplay,
-                s => (s.HotkeyModifiers, s.HotkeyVirtualKey),
-                (s, mods, vk, display) =>
-                {
-                    s.HotkeyModifiers = mods;
-                    s.HotkeyVirtualKey = vk;
-                    s.HotkeyDisplay = display;
-                },
+                s => HotkeyBindings.TriggerFor(s, HotkeyAction.Capture),
+                ApplyCaptureTrigger,
                 AdvertisedInShell: true),
             new HotkeyField(
                 HotkeyAction.TranslationWindow,
                 "S.Settings.WindowHotkey",
                 WindowHotkeyBox, WindowRecordBtn,
                 s => s.TranslationWindowHotkeyDisplay,
-                s => (s.TranslationWindowHotkeyModifiers, s.TranslationWindowHotkeyVirtualKey),
-                (s, mods, vk, display) =>
-                {
-                    s.TranslationWindowHotkeyModifiers = mods;
-                    s.TranslationWindowHotkeyVirtualKey = vk;
-                    s.TranslationWindowHotkeyDisplay = display;
-                },
+                s => HotkeyBindings.TriggerFor(s, HotkeyAction.TranslationWindow),
+                ApplyWindowTrigger,
                 AdvertisedInShell: false,
                 WindowHotkeyEnabledCheckBox,
                 (s, on) => s.TranslationWindowHotkeyEnabled = on,
@@ -134,17 +126,23 @@ public partial class SettingsPage : UserControl
                 "S.Settings.RealtimeHotkey",
                 RealtimeHotkeyBox, RealtimeRecordBtn,
                 s => s.RealtimeHotkeyDisplay,
-                s => (s.RealtimeHotkeyModifiers, s.RealtimeHotkeyVirtualKey),
-                (s, mods, vk, display) =>
-                {
-                    s.RealtimeHotkeyModifiers = mods;
-                    s.RealtimeHotkeyVirtualKey = vk;
-                    s.RealtimeHotkeyDisplay = display;
-                },
+                s => HotkeyBindings.TriggerFor(s, HotkeyAction.Realtime),
+                ApplyRealtimeTrigger,
                 AdvertisedInShell: false,
                 RealtimeHotkeyEnabledCheckBox,
                 (s, on) => s.RealtimeHotkeyEnabled = on,
                 RealtimeHotkeyShadowHint),
+            new HotkeyField(
+                HotkeyAction.SingleShot,
+                "S.Settings.SingleShotHotkey",
+                SingleShotHotkeyBox, SingleShotRecordBtn,
+                s => s.SingleShotHotkeyDisplay,
+                s => HotkeyBindings.TriggerFor(s, HotkeyAction.SingleShot),
+                ApplySingleShotTrigger,
+                AdvertisedInShell: false,
+                SingleShotHotkeyEnabledCheckBox,
+                (s, on) => s.SingleShotHotkeyEnabled = on,
+                SingleShotHotkeyShadowHint),
         ];
 
         _apiKeyDebounce = new DispatcherTimer { Interval = ApiKeyDebounce };
@@ -174,6 +172,9 @@ public partial class SettingsPage : UserControl
             PersistPrompt();
         };
 
+        _hotkeyGamepadRecordTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(45) };
+        _hotkeyGamepadRecordTimer.Tick += (_, _) => PollRecordingGamepad();
+
         _statusHold = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(1600) };
         _statusHold.Tick += (_, _) => { _statusHold.Stop(); FadeStatusOut(); };
 
@@ -183,7 +184,11 @@ public partial class SettingsPage : UserControl
         // user navigated away. A static event holding an instance handler also has to be let go
         // of at some point, which rules out subscribing only once.
         Loaded   += (_, _) => LocalizationService.LanguageChanged += OnLanguageChanged;
-        Unloaded += (_, _) => LocalizationService.LanguageChanged -= OnLanguageChanged;
+        Unloaded += (_, _) =>
+        {
+            LocalizationService.LanguageChanged -= OnLanguageChanged;
+            StopRecording();
+        };
 
         LoadSettings();
     }
@@ -982,26 +987,87 @@ public partial class SettingsPage : UserControl
         }
     }
 
+    private static void ApplyCaptureTrigger(AppSettings s, ShortcutTrigger trigger, string display)
+    {
+        s.HotkeyInputKind = trigger.Kind;
+        s.HotkeyDisplay = display;
+        if (trigger.Kind == ShortcutInputKind.Keyboard)
+        {
+            s.HotkeyModifiers = trigger.Modifiers;
+            s.HotkeyVirtualKey = trigger.VirtualKey;
+            s.HotkeyGamepadButton = GamepadShortcutButton.None;
+        }
+        else if (trigger.Kind == ShortcutInputKind.Gamepad)
+        {
+            s.HotkeyGamepadButton = trigger.GamepadButton;
+        }
+    }
+
+    private static void ApplyWindowTrigger(AppSettings s, ShortcutTrigger trigger, string display)
+    {
+        s.TranslationWindowHotkeyInputKind = trigger.Kind;
+        s.TranslationWindowHotkeyDisplay = display;
+        if (trigger.Kind == ShortcutInputKind.Keyboard)
+        {
+            s.TranslationWindowHotkeyModifiers = trigger.Modifiers;
+            s.TranslationWindowHotkeyVirtualKey = trigger.VirtualKey;
+            s.TranslationWindowHotkeyGamepadButton = GamepadShortcutButton.None;
+        }
+        else if (trigger.Kind == ShortcutInputKind.Gamepad)
+        {
+            s.TranslationWindowHotkeyGamepadButton = trigger.GamepadButton;
+        }
+    }
+
+    private static void ApplyRealtimeTrigger(AppSettings s, ShortcutTrigger trigger, string display)
+    {
+        s.RealtimeHotkeyInputKind = trigger.Kind;
+        s.RealtimeHotkeyDisplay = display;
+        if (trigger.Kind == ShortcutInputKind.Keyboard)
+        {
+            s.RealtimeHotkeyModifiers = trigger.Modifiers;
+            s.RealtimeHotkeyVirtualKey = trigger.VirtualKey;
+            s.RealtimeHotkeyGamepadButton = GamepadShortcutButton.None;
+        }
+        else if (trigger.Kind == ShortcutInputKind.Gamepad)
+        {
+            s.RealtimeHotkeyGamepadButton = trigger.GamepadButton;
+        }
+    }
+
+    private static void ApplySingleShotTrigger(AppSettings s, ShortcutTrigger trigger, string display)
+    {
+        s.SingleShotHotkeyInputKind = trigger.Kind;
+        s.SingleShotHotkeyDisplay = display;
+        if (trigger.Kind == ShortcutInputKind.Keyboard)
+        {
+            s.SingleShotHotkeyModifiers = trigger.Modifiers;
+            s.SingleShotHotkeyVirtualKey = trigger.VirtualKey;
+            s.SingleShotHotkeyGamepadButton = GamepadShortcutButton.None;
+        }
+        else if (trigger.Kind == ShortcutInputKind.Gamepad)
+        {
+            s.SingleShotHotkeyGamepadButton = trigger.GamepadButton;
+        }
+    }
+
     private void StartRecording(HotkeyField field)
     {
-        // Only one at a time: two boxes both saying 請按下快捷鍵 would leave the next key press
-        // ambiguous to the user long before it was ambiguous to the code.
         StopRecording();
 
         _recording = field;
-        field.Box.Text = LocalizationService.Get("S.Settings.HotkeyPrompt");
+        field.Box.Text = LocalizationService.Get("S.Settings.HotkeyPromptAnyInput");
         field.Record.Content = LocalizationService.Get("S.Common.Cancel");
         field.Box.Focus();
+
+        for (int i = 0; i < _recordGamepadButtons.Length; i++)
+            _recordGamepadButtons[i] = GamepadInput.TryGetButtons(i, out var buttons) ? buttons : (ushort)0;
+        _hotkeyGamepadRecordTimer.Start();
     }
 
-    /// <summary>Ends recording and puts the stored combination back in the box.</summary>
-    /// <remarks>
-    /// Reads the setting rather than remembering what was there, so this also serves as the way
-    /// back after a successful capture: the new value has been persisted by then, and restoring
-    /// from the settings shows it.
-    /// </remarks>
     private void StopRecording()
     {
+        _hotkeyGamepadRecordTimer.Stop();
         if (_recording is not { } field) return;
 
         field.Box.Text = field.Display(SettingsService.Instance.Current);
@@ -1027,10 +1093,19 @@ public partial class SettingsPage : UserControl
     {
         if (FieldOf(sender) is not { } field || !ReferenceEquals(_recording, field)) return;
 
-        // 焦點移到該欄位的錄製鈕時由 Click 事件處理，這裡不介入
-        if (Keyboard.FocusedElement == field.Record) return;
+        // Keep recording while focus moves inside this settings page. This is what lets the user
+        // press middle mouse anywhere on the page after clicking Record instead of having to aim at
+        // the read-only box itself.
+        if (Keyboard.FocusedElement is DependencyObject focused && IsDescendantOfThisPage(focused)) return;
 
         StopRecording();
+    }
+
+    private bool IsDescendantOfThisPage(DependencyObject child)
+    {
+        for (DependencyObject? current = child; current is not null; current = LogicalTreeHelper.GetParent(current))
+            if (ReferenceEquals(current, this)) return true;
+        return false;
     }
 
     private void HotkeyBox_PreviewKeyDown(object sender, KeyEventArgs e)
@@ -1040,6 +1115,12 @@ public partial class SettingsPage : UserControl
 
         bool isSystemKey = e.Key == Key.System;
         var key = isSystemKey ? e.SystemKey : e.Key;
+
+        if (key == Key.Escape)
+        {
+            StopRecording();
+            return;
+        }
 
         if (key == Key.LeftCtrl || key == Key.RightCtrl ||
             key == Key.LeftAlt  || key == Key.RightAlt  ||
@@ -1052,17 +1133,55 @@ public partial class SettingsPage : UserControl
         if (isSystemKey || Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt)) mods |= GlobalHotkey.MOD_ALT;
         if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)) mods |= GlobalHotkey.MOD_SHIFT;
 
-        if (mods == 0) return;
-
         uint vk = (uint)KeyInterop.VirtualKeyFromKey(key);
-        var display = $"{GlobalHotkey.ModifiersToString(mods)}+{key}";
+        if (vk == 0) return;
 
-        // Windows keys a registration by window and combination, so the second shortcut to claim
-        // one is simply refused — RegisterHotKey returns false and nothing else happens. Left to
-        // itself that reads as a shortcut that stopped working for no reason, so the clash is
-        // refused here, where there is something to say about it.
-        // A shortcut that is switched off does not hold its combination — same rule as
-        // HotkeyBindings, so what the page refuses and what actually gets registered agree.
+        var prefix = GlobalHotkey.ModifiersToString(mods);
+        var display = string.IsNullOrEmpty(prefix) ? key.ToString() : $"{prefix}+{key}";
+        CommitShortcut(recording, ShortcutTrigger.Keyboard(mods, vk), display);
+    }
+
+    private void SettingsPage_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (_recording is not { } recording || e.ChangedButton != MouseButton.Middle) return;
+        e.Handled = true;
+        CommitShortcut(
+            recording,
+            ShortcutTrigger.MouseMiddle(),
+            LocalizationService.Get("S.Settings.MouseMiddle"));
+    }
+
+    private void PollRecordingGamepad()
+    {
+        if (_recording is not { } recording)
+        {
+            _hotkeyGamepadRecordTimer.Stop();
+            return;
+        }
+
+        for (int i = 0; i < _recordGamepadButtons.Length; i++)
+        {
+            if (!GamepadInput.TryGetButtons(i, out var current))
+            {
+                _recordGamepadButtons[i] = 0;
+                continue;
+            }
+
+            ushort pressed = (ushort)(current & ~_recordGamepadButtons[i]);
+            _recordGamepadButtons[i] = current;
+            var button = GamepadInput.FirstButton(pressed);
+            if (button == GamepadShortcutButton.None) continue;
+
+            var display = LocalizationService.Format(
+                "S.Settings.GamepadButton",
+                GamepadInput.ButtonName(button));
+            CommitShortcut(recording, ShortcutTrigger.Gamepad(button), display);
+            return;
+        }
+    }
+
+    private void CommitShortcut(HotkeyField recording, ShortcutTrigger trigger, string display)
+    {
         var settings = SettingsService.Instance.Current;
         var enabled = HotkeyBindings.Resolve(settings)
             .Where(binding => binding.Enabled)
@@ -1072,7 +1191,7 @@ public partial class SettingsPage : UserControl
         var taken = _hotkeyFields.FirstOrDefault(
             field => !ReferenceEquals(field, recording) &&
                      enabled.Contains(field.Action) &&
-                     field.Combination(settings) == (mods, vk));
+                     field.Trigger(settings) == trigger);
 
         if (taken is not null)
         {
@@ -1082,23 +1201,15 @@ public partial class SettingsPage : UserControl
             return;
         }
 
-        Persist(s => recording.Apply(s, mods, vk, display));
-
-        // After the write, so the box picks the new combination up out of the settings.
+        Persist(s => recording.Apply(s, trigger, display));
         StopRecording();
-
-        // Recording cannot create a clash — it is refused above — but it can clear one a stored
-        // setting arrived in, so the shadow lines are re-read rather than left as they were.
         RefreshHotkeyShadowHints();
 
-        // The global hook holds the old combination until it is rebound
         if (System.Windows.Application.Current.MainWindow is MainWindow main)
             main.ReRegisterHotkey();
 
-        // The nav rail advertises the capture shortcut beside 截圖翻譯 and is on screen right now,
-        // so it has to be told; nothing else re-reads it until the shell is next shown or
-        // activated. The window shortcut is advertised nowhere, so there is nothing to refresh.
         if (recording.AdvertisedInShell && Window.GetWindow(this) is Shell.ShellWindow shell)
             shell.RefreshHotkeyHint();
     }
+
 }

--- a/tests/OverTranslate.Tests/HotkeyBindingsTests.cs
+++ b/tests/OverTranslate.Tests/HotkeyBindingsTests.cs
@@ -9,12 +9,12 @@ public class HotkeyBindingsTests
     private const uint CtrlAlt = 3;
 
     [Fact]
-    public void ThreeDistinctCombinationsAllStayOn()
+    public void FourDistinctCombinationsAllStayOn()
     {
         var active = HotkeyBindings.Active(new AppSettings()).ToList();
 
         Assert.Equal(
-            [HotkeyAction.Capture, HotkeyAction.TranslationWindow, HotkeyAction.Realtime],
+            [HotkeyAction.Capture, HotkeyAction.TranslationWindow, HotkeyAction.Realtime, HotkeyAction.SingleShot],
             active.Select(binding => binding.Action));
     }
 
@@ -64,6 +64,23 @@ public class HotkeyBindingsTests
     }
 
     [Fact]
+    public void SingleShotLosesToRealtimeWhenAStoredSettingCollides()
+    {
+        var settings = new AppSettings
+        {
+            SingleShotHotkeyModifiers = CtrlAlt,
+            SingleShotHotkeyVirtualKey = 0x53,
+            SingleShotHotkeyDisplay = "Ctrl+Alt+S",
+        };
+
+        var single = HotkeyBindings.Resolve(settings)
+            .Single(binding => binding.Action == HotkeyAction.SingleShot);
+
+        Assert.False(single.IsActive);
+        Assert.Equal(HotkeyAction.Realtime, single.ShadowedBy);
+    }
+
+    [Fact]
     public void SwitchingOffTheHolderHandsTheCombinationDown()
     {
         // A shortcut that is off does not reserve its combination. Without this, turning the window
@@ -105,4 +122,51 @@ public class HotkeyBindingsTests
         Assert.True(HotkeyBindings.Resolve(new AppSettings())
             .Single(binding => binding.Action == HotkeyAction.Capture).Enabled);
     }
+    [Fact]
+    public void MiddleMouseUsesTheSamePriorityRulesAsKeyboard()
+    {
+        var settings = new AppSettings
+        {
+            RealtimeHotkeyInputKind = ShortcutInputKind.MouseMiddle,
+            SingleShotHotkeyInputKind = ShortcutInputKind.MouseMiddle,
+        };
+
+        var resolved = HotkeyBindings.Resolve(settings);
+        Assert.True(resolved.Single(b => b.Action == HotkeyAction.Realtime).IsActive);
+        Assert.Equal(HotkeyAction.Realtime,
+            resolved.Single(b => b.Action == HotkeyAction.SingleShot).ShadowedBy);
+    }
+
+    [Fact]
+    public void GamepadButtonCanBeAUniqueShortcut()
+    {
+        var settings = new AppSettings
+        {
+            SingleShotHotkeyInputKind = ShortcutInputKind.Gamepad,
+            SingleShotHotkeyGamepadButton = GamepadShortcutButton.X,
+        };
+
+        var single = HotkeyBindings.Resolve(settings)
+            .Single(b => b.Action == HotkeyAction.SingleShot);
+
+        Assert.True(single.IsActive);
+        Assert.Equal(ShortcutInputKind.Gamepad, single.InputKind);
+        Assert.Equal(GamepadShortcutButton.X, single.GamepadButton);
+    }
+
+    [Fact]
+    public void KeyboardAndGamepadWithSameNumericCodeDoNotCollide()
+    {
+        var settings = new AppSettings
+        {
+            RealtimeHotkeyModifiers = 0,
+            RealtimeHotkeyVirtualKey = 0x58,
+            SingleShotHotkeyInputKind = ShortcutInputKind.Gamepad,
+            SingleShotHotkeyGamepadButton = GamepadShortcutButton.X,
+        };
+
+        Assert.True(HotkeyBindings.Resolve(settings)
+            .Single(b => b.Action == HotkeyAction.SingleShot).IsActive);
+    }
+
 }

--- a/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
@@ -1,0 +1,81 @@
+using System.Drawing;
+using OverTranslate.Services.Realtime;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class RealtimeNaturalBackgroundTests
+{
+    [Fact]
+    public void CreatePatch_ReplacesSourceRectButKeepsSurroundingPixels()
+    {
+        using var frame = new Bitmap(48, 24);
+        for (int y = 0; y < frame.Height; y++)
+        for (int x = 0; x < frame.Width; x++)
+            frame.SetPixel(x, y, Color.FromArgb(255, 20 + y * 3, 30 + y * 2, 45 + y));
+
+        var source = new System.Windows.Rect(14, 8, 20, 7);
+        using (var g = Graphics.FromImage(frame))
+            g.FillRectangle(Brushes.White, 14, 8, 20, 7);
+
+        var patchBounds = new Rectangle(6, 3, 36, 17);
+        using var patch = RealtimeNaturalBackground.CreatePatch(frame, patchBounds, [source]);
+
+        Assert.NotNull(patch);
+        Assert.Equal(frame.GetPixel(7, 4), patch!.GetPixel(1, 1));
+
+        // The centre was solid white in the source. Natural repair must replace it with local
+        // background rather than simply copying the source screenshot into the overlay.
+        var repaired = patch.GetPixel(18, 9);
+        Assert.True(repaired.R < 180);
+        Assert.True(repaired.G < 180);
+        Assert.True(repaired.B < 180);
+    }
+
+    [Fact]
+    public void CreatePatch_CleansDetachedMarksAboveTightOcrBox()
+    {
+        using var frame = new Bitmap(100, 50);
+        using (var g = Graphics.FromImage(frame))
+        {
+            g.Clear(Color.FromArgb(255, 18, 78, 62));
+            // Main glyph body is inside the OCR rectangle. The two small marks imitate Japanese
+            // dakuten that OCR often leaves outside a tight line box.
+            g.FillRectangle(Brushes.White, 25, 20, 50, 14);
+            g.FillRectangle(Brushes.White, 34, 13, 3, 5);
+            g.FillRectangle(Brushes.White, 40, 13, 3, 5);
+        }
+
+        var source = new System.Windows.Rect(25, 20, 50, 14);
+        using var patch = RealtimeNaturalBackground.CreatePatch(
+            frame, new Rectangle(10, 5, 80, 40), [source]);
+
+        Assert.NotNull(patch);
+        // Global (35,14) becomes local (25,9). It was white before repair and should now be close
+        // to the green background rather than surviving as a bright fragment.
+        var repairedMark = patch!.GetPixel(25, 9);
+        Assert.True(repairedMark.R < 100);
+        Assert.True(repairedMark.G < 140);
+        Assert.True(repairedMark.B < 120);
+    }
+
+    [Fact]
+    public void SampleTextColor_PrefersContrastingSourceGlyphColour()
+    {
+        using var frame = new Bitmap(80, 40);
+        using (var g = Graphics.FromImage(frame))
+        {
+            g.Clear(Color.FromArgb(255, 24, 28, 34));
+            g.FillRectangle(Brushes.White, 20, 12, 40, 12);
+        }
+
+        var sampled = RealtimeNaturalBackground.SampleTextColor(
+            frame,
+            new System.Windows.Rect(20, 12, 40, 12),
+            System.Windows.Media.Colors.Lime);
+
+        Assert.True(sampled.R > 220);
+        Assert.True(sampled.G > 220);
+        Assert.True(sampled.B > 220);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds several improvements to realtime translation:

- Natural translation display mode
  - Removes the original detected text
  - Restores the surrounding background
  - Draws translated text back in the original location
  - Expands the cleanup area to reduce leftover punctuation and Japanese dakuten/handakuten artifacts

- Single-shot translation mode
  - Press once to capture and translate the configured realtime regions
  - Press again to temporarily restore the original game text
  - If the detected text has not changed, the previous translation is reused
  - If the text changes, a new translation is requested
  - Helps avoid visual instability in highly dynamic game scenes

- Expanded hotkey input
  - Keyboard combinations
  - Single keyboard keys
  - Middle mouse button
  - XInput gamepad buttons

- Added/updated tests for hotkey bindings and natural background restoration

The project version remains unchanged at 2.0.1.