### PR TITLE
refactor: #102 整個螢幕擷取改用 WGC Monitor + exclusion list

### DIFF
--- a/src/OverTranslate/OverTranslate.csproj
+++ b/src/OverTranslate/OverTranslate.csproj
@@ -19,8 +19,10 @@
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- One place only: reading a captured frame back off the GPU hands over a raw pointer and a
-         length, and copying it row by row is what that memory is for. See WgcInterop.ReadBack. -->
+    <!-- Two places, both at the capture ABI. Reading a captured frame back off the GPU hands over a
+         raw pointer and a length, and copying it row by row is what that memory is for (see
+         WgcInterop.ReadBack); the window exclusion list is called through the interface's vtable,
+         because the projection this builds against does not have it (see WgcWindowExclusion). -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/OverTranslate/Properties/AssemblyInfo.cs
+++ b/src/OverTranslate/Properties/AssemblyInfo.cs
@@ -5,6 +5,10 @@ using System.Windows;
 // The offline OCR harness, so a measurement can ask the real RealtimeDetectorSize what the app
 // would pick rather than keeping a second copy of that rule that could drift out of step with it.
 [assembly: InternalsVisibleTo("OcrHarness")]
+// The capture probe, for the same reason: the questions it answers — what this machine's
+// Windows.Graphics.Capture will do, whether an exclusion list actually took — are only worth asking
+// against the interop the application itself runs on.
+[assembly: InternalsVisibleTo("WgcProbe")]
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
                                                 //(used if a resource is not found in the page,

--- a/src/OverTranslate/Services/Realtime/Capture/DesktopGrabCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/DesktopGrabCaptureBackend.cs
@@ -6,7 +6,10 @@ namespace OverTranslate.Services.Realtime.Capture;
 
 /// <summary>
 /// Copies each region straight off the composited desktop with <see cref="Graphics.CopyFromScreen"/>
-/// — the original capture path, kept for systems where nothing better is available.
+/// — the original capture path, and now the second choice for the whole screen, behind
+/// <see cref="WgcMonitorCaptureBackend"/>. It is what serves every machine new enough for
+/// <c>WDA_EXCLUDEFROMCAPTURE</c> to work (Windows 11 24H2) and not new enough to have the window
+/// exclusion list, which today is most of them.
 /// </summary>
 /// <remarks>
 /// The source is what the user is looking at, which includes this application's own subtitle layers.

--- a/src/OverTranslate/Services/Realtime/Capture/IRealtimeCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/IRealtimeCaptureBackend.cs
@@ -16,9 +16,10 @@ namespace OverTranslate.Services.Realtime.Capture;
 ///
 /// So a backend is answerable for its own isolation. <see cref="IsIsolated"/> is the promise, made
 /// before a single region is read; a backend that cannot make it is not used. What that costs varies
-/// by source — the desktop grab needs the overlays excluded from capture, a backend that captures
-/// the watched window directly never had them in frame to begin with — and none of that reaches the
-/// session, which asks for a rectangle and gets pixels.
+/// by source — a backend that captures the watched window directly never had the overlays in frame
+/// to begin with, a monitor capture has the session compose the screen without them, and the desktop
+/// grab has to ask the overlays to hide themselves — and none of that reaches the session, which
+/// asks for a rectangle and gets pixels.
 /// </remarks>
 public interface IRealtimeCaptureBackend : IDisposable
 {

--- a/src/OverTranslate/Services/Realtime/Capture/WgcCapability.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcCapability.cs
@@ -42,8 +42,10 @@ public static class WgcCapability
 
     /// <summary>
     /// Whether a capture session can be told to leave specific windows out of its frames — the 2026
-    /// API that would let a monitor capture exclude OverTranslate's own overlays and so keep the
-    /// "frame any part of the screen" interface with none of the WDA problem.
+    /// API that lets a monitor capture exclude OverTranslate's own overlays, and so keeps the "frame
+    /// any part of the screen" interface with none of the WDA problem. What
+    /// <see cref="WgcMonitorCaptureBackend"/> is built on, and the reason it is offered only on some
+    /// machines.
     /// </summary>
     /// <remarks>
     /// Asked of both places it could live. The documentation puts it on the display-capture session,

--- a/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
@@ -1,0 +1,604 @@
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Graphics;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX;
+using Windows.Graphics.DirectX.Direct3D11;
+using NLog;
+
+namespace OverTranslate.Services.Realtime.Capture;
+
+/// <summary>
+/// Captures one whole monitor through Windows.Graphics.Capture, with OverTranslate's own overlays
+/// left out of the frames by the capture session itself, and cuts each region out of that.
+/// </summary>
+/// <remarks>
+/// This is the full-screen source done the way the window source already works: the isolation is a
+/// property of what is being captured, not a favour asked of the windows drawing on top of it. The
+/// session is told which windows to leave out, the system composes the monitor without them, and the
+/// excluded rectangles come back showing what is <i>underneath</i> — measured, because everything
+/// here depended on that and nothing said it: with a stand-in subtitle layer over a source window,
+/// the layer went from 98.5% of the region to 0.0%, and 98.1% of it came back as the source window
+/// rather than as black (<c>WgcProbe exclusion</c>).
+///
+/// What it replaces on that path is <c>WDA_EXCLUDEFROMCAPTURE</c>, which asks each overlay to hide
+/// itself from anything reading the screen and fails silently on every Windows before 11 24H2 —
+/// #94, where the loop spent nine seconds translating its own output. The difference is not that
+/// this API is newer. It is that the request and the promise are separate here: the set call returns
+/// the configuration iteration from which the exclusion holds, every frame says which iteration it
+/// was composed under, and this backend simply does not read a frame from before that number. There
+/// is no state in which it believes an exclusion that did not happen.
+///
+/// The cost is who can use it. The exclusion list needs a Windows much newer than 24H2, so a system
+/// without it is not served by this backend at all and must be offered another one — see
+/// <c>RealtimeSessionController.CreateScreenCapture</c>, which keeps the desktop grab as the second
+/// choice for machines where WDA does work.
+/// </remarks>
+[SupportedOSPlatform("windows10.0.18362.0")]
+public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    // The same throttles as the window backend, set for the same reasons: a readback is the one
+    // expensive step and frames arrive far faster than a session polls. See
+    // WgcWindowCaptureBackend, where each number is argued.
+    private static readonly TimeSpan MaxFrameAge = TimeSpan.FromMilliseconds(120);
+    private static readonly TimeSpan IdleAfter = TimeSpan.FromSeconds(1);
+    private const int FrameBuffers = 2;
+
+    // How long the first usable frame is waited for. A monitor is always being composed, so unlike
+    // a window this is about the capture chain coming up rather than about the source having
+    // content — but the wait also has to cover the exclusion taking effect, which needs a frame
+    // composed after the set call.
+    private static readonly TimeSpan FirstFrameTimeout = TimeSpan.FromSeconds(3);
+
+    private readonly Func<IntPtr> _resolveMonitor;
+    private readonly Func<IReadOnlyList<IntPtr>> _resolveOverlays;
+    private readonly IDirect3DDevice _device;
+    private readonly IntPtr _rawDevice;
+
+    private readonly object _sync = new();
+    private GraphicsCaptureItem? _item;
+    private Direct3D11CaptureFramePool? _pool;
+    private GraphicsCaptureSession? _session;
+    private IntPtr _monitor;
+    private SizeInt32 _poolSize;
+    private bool _disposed;
+
+    // Which windows the session was last told to leave out, and the iteration that answer holds
+    // from. Both are read by the frame handler on the capture stack's own thread.
+    private IntPtr[] _excluded = [];
+    private long _isolatedFrom;
+
+    private readonly object _latestLock = new();
+    private Bitmap? _latest;
+    private long _latestAt;
+    private long _lastGrabAt;
+
+    private int _framesReceived;
+    private int _framesRead;
+    private int _framesBeforeExclusion;
+    private int _rebuilds;
+    private int _exclusionUpdates;
+    private long _readbackTicks;
+    private int _outsideReported;
+
+    private WgcMonitorCaptureBackend(
+        Func<IntPtr> resolveMonitor,
+        Func<IReadOnlyList<IntPtr>> resolveOverlays,
+        IDirect3DDevice device,
+        IntPtr rawDevice)
+    {
+        _resolveMonitor = resolveMonitor;
+        _resolveOverlays = resolveOverlays;
+        _device = device;
+        _rawDevice = rawDevice;
+    }
+
+    /// <summary>
+    /// Raised when the monitor is gone — unplugged, or replaced by a mode change — and could not be
+    /// found again. Same contract as the window backend: the session ends rather than falling back
+    /// to a source that would contain this application's own overlays.
+    /// </summary>
+    public event EventHandler<string>? SourceLost;
+
+    public string Name => "WgcMonitor";
+
+    /// <summary>
+    /// True because this backend does not exist otherwise: construction fails unless the exclusion
+    /// list was accepted, and no frame composed before it was accepted is ever read.
+    /// </summary>
+    public bool IsIsolated => true;
+
+    /// <summary>
+    /// Builds a backend over the monitor <paramref name="resolveMonitor"/> names, or returns null
+    /// when this system cannot capture, when it has no window exclusion list, when the monitor
+    /// refuses capture, or when the exclusion was not accepted.
+    /// </summary>
+    /// <param name="resolveOverlays">
+    /// Every window of this application's that must stay out of the frames, asked again whenever a
+    /// poll finds the answer may have changed — overlays are created and destroyed while a session
+    /// runs, and an exclusion list set once at the start would be a list of the windows that
+    /// happened to exist then. Must be safe to call from the polling thread, so the caller hands
+    /// over a snapshot rather than reaching into windows.
+    /// </param>
+    public static WgcMonitorCaptureBackend? TryCreate(
+        Func<IntPtr> resolveMonitor, Func<IReadOnlyList<IntPtr>> resolveOverlays)
+    {
+        if (!WgcInterop.IsCaptureSupported()) return null;
+
+        if (!WgcCapability.SupportsWindowExclusion)
+        {
+            // Not a failure worth a warning: it is the ordinary state of every Windows older than
+            // the one that shipped the API, and the caller has another backend to offer.
+            Log.Info(
+                "Realtime monitor capture unavailable: this system (Windows {Version}) has no window " +
+                "exclusion list, so a monitor capture could not keep this application's overlays out " +
+                "of its frames", Environment.OSVersion.Version);
+            return null;
+        }
+
+        var monitor = resolveMonitor();
+        if (monitor == IntPtr.Zero) return null;
+
+        IDirect3DDevice? device = null;
+        var rawDevice = IntPtr.Zero;
+        WgcMonitorCaptureBackend? backend = null;
+        try
+        {
+            device = WgcInterop.CreateDirect3DDevice(out rawDevice);
+            backend = new WgcMonitorCaptureBackend(resolveMonitor, resolveOverlays, device, rawDevice);
+            if (!backend.Attach(monitor)) throw new InvalidOperationException("the monitor refused capture");
+            if (!backend.WaitForIsolatedFrame(FirstFrameTimeout))
+                throw new InvalidOperationException("no frame arrived with the exclusion list in effect");
+
+            return backend;
+        }
+        catch (Exception ex)
+        {
+            // Every reason this fails is a reason to offer another backend rather than to end the
+            // session — and refusing here is the whole point, because the alternative is a screen
+            // capture that quietly contains the subtitles it is about to read.
+            Log.Warn(ex, "Could not start monitor capture for hmonitor={Monitor:X}", monitor);
+            backend?.Dispose();
+            if (backend is null)
+            {
+                (device as IDisposable)?.Dispose();
+                if (rawDevice != IntPtr.Zero) Marshal.Release(rawDevice);
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The monitor a screen rectangle belongs to, or <see cref="IntPtr.Zero"/> if there is none.
+    /// </summary>
+    /// <remarks>
+    /// Asked of Windows rather than worked out from <c>Screen.AllScreens</c>, which would have to
+    /// match rectangles that a display arrangement can make ambiguous. Nearest rather than exact so
+    /// a session whose screen was remembered from a layout that has since changed still lands
+    /// somewhere real instead of refusing to start.
+    /// </remarks>
+    public static IntPtr MonitorFor(Rectangle screenBounds)
+    {
+        var rect = new RECT
+        {
+            Left = screenBounds.Left,
+            Top = screenBounds.Top,
+            Right = screenBounds.Right,
+            Bottom = screenBounds.Bottom
+        };
+        return MonitorFromRect(ref rect, MONITOR_DEFAULTTONEAREST);
+    }
+
+    public Bitmap? GrabRegion(Rectangle screenBounds)
+    {
+        if (screenBounds.Width <= 0 || screenBounds.Height <= 0) return null;
+        if (Volatile.Read(ref _disposed)) return null;
+
+        Volatile.Write(ref _lastGrabAt, Stopwatch.GetTimestamp());
+
+        // Before any pixels are handed out, because this is where an overlay that appeared since the
+        // last poll gets excluded. Until the frames catch up with the new list there is nothing safe
+        // to return, and the loop simply skips a poll.
+        SyncExclusions();
+
+        if (!TryGetFrameOrigin(out var origin)) return null;
+
+        lock (_latestLock)
+        {
+            if (_latest is not { } latest) return null;
+
+            var crop = screenBounds with { X = screenBounds.X - origin.X, Y = screenBounds.Y - origin.Y };
+            var visible = Rectangle.Intersect(crop, new Rectangle(0, 0, latest.Width, latest.Height));
+            if (visible.Width <= 0 || visible.Height <= 0)
+            {
+                // The region is not on this monitor any more — the screen changed resolution under
+                // it, or the layout moved. Nothing to read, and nothing to say four times a second.
+                if (Interlocked.Exchange(ref _outsideReported, 1) == 0)
+                    Log.Warn(
+                        "Realtime region {Bounds} lies outside the captured monitor at {Origin}; " +
+                        "further occurrences logged at Debug", screenBounds, origin);
+                else
+                    Log.Debug("Realtime region {Bounds} lies outside the captured monitor", screenBounds);
+                return null;
+            }
+
+            // Always the size that was asked for, so a partly-visible region does not move every
+            // recognised line relative to the block that displays it.
+            var frame = new Bitmap(
+                screenBounds.Width, screenBounds.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            try
+            {
+                using var graphics = Graphics.FromImage(frame);
+                graphics.DrawImage(
+                    latest,
+                    new Rectangle(visible.X - crop.X, visible.Y - crop.Y, visible.Width, visible.Height),
+                    visible,
+                    GraphicsUnit.Pixel);
+                return frame;
+            }
+            catch
+            {
+                frame.Dispose();
+                throw;
+            }
+        }
+    }
+
+    public string DescribeActivity()
+    {
+        var reads = Volatile.Read(ref _framesRead);
+        var averageMs = reads == 0
+            ? 0
+            : Stopwatch.GetElapsedTime(0, Volatile.Read(ref _readbackTicks)).TotalMilliseconds / reads;
+
+        return $"hmonitor={_monitor:X} received={Volatile.Read(ref _framesReceived)} read={reads} " +
+               $"avgReadback={averageMs:F1}ms discardedBeforeExclusion={Volatile.Read(ref _framesBeforeExclusion)} " +
+               $"exclusionUpdates={Volatile.Read(ref _exclusionUpdates)} excluded={_excluded.Length} " +
+               $"rebuilds={Volatile.Read(ref _rebuilds)}";
+    }
+
+    // ── Exclusion ────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Makes the session's exclusion list match the overlays that exist now, and says whether the
+    /// list is currently in force.
+    /// </summary>
+    /// <remarks>
+    /// Called on every poll rather than pushed by whatever creates an overlay, because the property
+    /// this backend promises is about frames, not about bookkeeping: asking here means an overlay
+    /// that appeared by any route — a block added, the control bar rebuilt, something a future
+    /// change introduces — is excluded before the next region is read, and nobody has to remember to
+    /// announce it. The work when nothing changed is comparing a handful of handles.
+    /// </remarks>
+    private void SyncExclusions()
+    {
+        IReadOnlyList<IntPtr> wanted;
+        try
+        {
+            wanted = _resolveOverlays();
+        }
+        catch (Exception ex)
+        {
+            // The caller's snapshot is unavailable — a session being torn down is the usual cause.
+            // Keeping the list as it is means keeping the exclusion that is already in force.
+            Log.Debug(ex, "Realtime monitor capture could not read its overlay list");
+            return;
+        }
+
+        if (Matches(_excluded, wanted)) return;
+
+        lock (_sync)
+        {
+            if (_disposed || _session is null) return;
+            if (!ApplyExclusionsLocked(wanted))
+            {
+                // The list was accepted once, at construction, and has now been refused. Frames from
+                // here on may contain the overlays, so none is read: the session stops producing
+                // rather than starting to feed on itself.
+                Volatile.Write(ref _isolatedFrom, long.MaxValue);
+                Log.Error(
+                    "Realtime monitor capture could not update its window exclusion list; " +
+                    "no further frames will be read");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets the exclusion list and records the iteration it holds from. Callers hold <see cref="_sync"/>.
+    /// </summary>
+    private bool ApplyExclusionsLocked(IReadOnlyList<IntPtr> windows)
+    {
+        if (_session is not { } session) return false;
+
+        var iteration = WgcWindowExclusion.TrySet(session, windows, out var detail);
+        if (iteration is not { } applied) return false;
+
+        _excluded = [.. windows];
+        Volatile.Write(ref _isolatedFrom, (long)applied);
+        Interlocked.Increment(ref _exclusionUpdates);
+        Log.Debug("Realtime monitor capture exclusion list: {Detail}", detail);
+        return true;
+    }
+
+    private static bool Matches(IReadOnlyList<IntPtr> current, IReadOnlyList<IntPtr> wanted)
+    {
+        if (current.Count != wanted.Count) return false;
+        for (var i = 0; i < current.Count; i++)
+            if (current[i] != wanted[i])
+                return false;
+        return true;
+    }
+
+    // ── Capture chain ────────────────────────────────────────────────────────────────────────────
+
+    private bool Attach(IntPtr monitor)
+    {
+        lock (_sync)
+        {
+            if (_disposed) return false;
+
+            DetachLocked();
+
+            var item = WgcInterop.CreateItemForMonitor(monitor);
+            if (item is null) return false;
+
+            _item = item;
+            _monitor = monitor;
+            item.Closed += OnItemClosed;
+
+            _poolSize = item.Size;
+            _pool = Direct3D11CaptureFramePool.CreateFreeThreaded(
+                _device, DirectXPixelFormat.B8G8R8A8UIntNormalized, FrameBuffers, _poolSize);
+            _pool.FrameArrived += OnFrameArrived;
+
+            _session = _pool.CreateCaptureSession(item);
+
+            // Nothing is read until this succeeds — set before StartCapture so the very first frame
+            // the system composes for this session is already composed without the overlays.
+            if (!ApplyExclusionsLocked(_resolveOverlays()))
+            {
+                Log.Warn("Realtime monitor capture refused: the window exclusion list was not accepted");
+                DetachLocked();
+                return false;
+            }
+
+            // The pointer is not part of the screen's content, and it lands in the middle of the
+            // text being read as often as anywhere else.
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 19041))
+                _session.IsCursorCaptureEnabled = false;
+
+            _session.StartCapture();
+
+            Log.Info(
+                "Realtime capture backend WgcMonitor attached: hmonitor={Monitor:X} " +
+                "itemSize={Width}x{Height} excluded={Excluded}",
+                monitor, item.Size.Width, item.Size.Height, _excluded.Length);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Free-threaded, called at the monitor's refresh rate. Takes every frame to keep the pool
+    /// turning over, reads back only what a poll has asked for — and only what was composed with the
+    /// exclusion list in force.
+    /// </summary>
+    private void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
+    {
+        try
+        {
+            using var frame = sender.TryGetNextFrame();
+            if (frame is null) return;
+
+            Interlocked.Increment(ref _framesReceived);
+
+            var content = frame.ContentSize;
+            if (content.Width != _poolSize.Width || content.Height != _poolSize.Height)
+                Recreate(content);
+
+            // The one check this whole backend rests on. A frame numbered below the iteration the
+            // exclusion was accepted at was composed before it took effect and may still hold the
+            // overlays; reading it would put this application's own subtitles in front of
+            // recognition, which is #94 with a newer API. A frame that cannot say which iteration it
+            // belongs to is treated the same way — the promise is the frame's, not the API's.
+            var iteration = WgcWindowExclusion.TryGetIteration(frame);
+            if (iteration is null || (long)iteration.Value < Volatile.Read(ref _isolatedFrom))
+            {
+                Interlocked.Increment(ref _framesBeforeExclusion);
+                return;
+            }
+
+            if (HasFrame())
+            {
+                if (Stopwatch.GetElapsedTime(Volatile.Read(ref _latestAt)) < MaxFrameAge) return;
+                if (Stopwatch.GetElapsedTime(Volatile.Read(ref _lastGrabAt)) > IdleAfter) return;
+            }
+
+            var started = Stopwatch.GetTimestamp();
+            var bitmap = WgcInterop.ReadBack(frame.Surface, content.Width, content.Height);
+            Interlocked.Add(ref _readbackTicks, Stopwatch.GetTimestamp() - started);
+            Interlocked.Increment(ref _framesRead);
+
+            Bitmap? previous;
+            lock (_latestLock)
+            {
+                previous = _latest;
+                _latest = bitmap;
+                Volatile.Write(ref _latestAt, Stopwatch.GetTimestamp());
+            }
+            previous?.Dispose();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The session is being torn down under us; the frame belongs to a pool that is going.
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Realtime monitor capture dropped a frame");
+        }
+    }
+
+    private void Recreate(SizeInt32 size)
+    {
+        lock (_sync)
+        {
+            if (_disposed || _pool is null) return;
+
+            _pool.Recreate(_device, DirectXPixelFormat.B8G8R8A8UIntNormalized, FrameBuffers, size);
+            _poolSize = size;
+            Interlocked.Increment(ref _rebuilds);
+            Log.Debug("Realtime monitor capture resized to {Width}x{Height}", size.Width, size.Height);
+        }
+    }
+
+    /// <summary>
+    /// Waits for one frame that was composed with the exclusion list in force, which is what makes
+    /// <see cref="IsIsolated"/> a fact rather than a request.
+    /// </summary>
+    /// <remarks>
+    /// Unlike a window, a monitor is always being composed, so this is not asking whether the source
+    /// has content — it is the last gate before the session is allowed to read the screen. A monitor
+    /// showing something perfectly still produces no new frames, which is why the iteration is what
+    /// is waited for and why the wait is generous: it is paid once.
+    /// </remarks>
+    private bool WaitForIsolatedFrame(TimeSpan timeout)
+    {
+        var started = Stopwatch.GetTimestamp();
+
+        while (Stopwatch.GetElapsedTime(started) < timeout)
+        {
+            // The readback is demand-driven and nothing has polled yet.
+            Volatile.Write(ref _lastGrabAt, Stopwatch.GetTimestamp());
+
+            lock (_latestLock)
+            {
+                if (_latest is not null) return true;
+            }
+
+            Thread.Sleep(50);
+        }
+
+        Log.Warn(
+            "Realtime monitor capture of hmonitor={Monitor:X} produced no frame at or after " +
+            "configuration iteration {Iteration} ({Discarded} discarded)",
+            _monitor, Volatile.Read(ref _isolatedFrom), Volatile.Read(ref _framesBeforeExclusion));
+        return false;
+    }
+
+    private bool HasFrame()
+    {
+        lock (_latestLock) return _latest is not null;
+    }
+
+    /// <summary>
+    /// The monitor's top-left corner in virtual-screen coordinates, which is where the frame's
+    /// (0,0) sits. Re-read every poll because it moves: a second monitor's origin changes when the
+    /// primary changes resolution, and negative coordinates are ordinary on a display to the left of
+    /// the primary.
+    /// </summary>
+    private bool TryGetFrameOrigin(out Point origin)
+    {
+        origin = Point.Empty;
+        var monitor = _monitor;
+        if (monitor == IntPtr.Zero) return false;
+
+        var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+        if (!GetMonitorInfo(monitor, ref info)) return false;
+
+        origin = new Point(info.rcMonitor.Left, info.rcMonitor.Top);
+        return true;
+    }
+
+    /// <summary>
+    /// The monitor is gone — unplugged, or replaced when the display mode changed. One attempt to
+    /// find it again, then the session is told it has lost its source.
+    /// </summary>
+    private void OnItemClosed(GraphicsCaptureItem sender, object args)
+    {
+        if (Volatile.Read(ref _disposed)) return;
+
+        Log.Warn("Realtime capture source monitor {Monitor:X} closed", _monitor);
+
+        try
+        {
+            var replacement = _resolveMonitor();
+            if (replacement != IntPtr.Zero && Attach(replacement))
+            {
+                Log.Info("Realtime capture re-attached to hmonitor={Monitor:X}", replacement);
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warn(ex, "Could not re-attach realtime capture after the source monitor closed");
+        }
+
+        // Deliberately no fallback to grabbing the desktop: that path is only safe where the
+        // overlays can hide themselves, and arriving at it silently is where the self-feed came from.
+        SourceLost?.Invoke(this, LocalizationService.Get("S.Realtime.CaptureSourceLost"));
+    }
+
+    // ── Teardown ─────────────────────────────────────────────────────────────────────────────────
+
+    private void DetachLocked()
+    {
+        if (_item is { } item) item.Closed -= OnItemClosed;
+        if (_pool is { } pool) pool.FrameArrived -= OnFrameArrived;
+
+        _session?.Dispose();
+        _pool?.Dispose();
+        _session = null;
+        _pool = null;
+        _item = null;
+        _excluded = [];
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            DetachLocked();
+        }
+
+        lock (_latestLock)
+        {
+            _latest?.Dispose();
+            _latest = null;
+        }
+
+        (_device as IDisposable)?.Dispose();
+        if (_rawDevice != IntPtr.Zero) Marshal.Release(_rawDevice);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MONITORINFO
+    {
+        public int cbSize;
+        public RECT rcMonitor;
+        public RECT rcWork;
+        public uint dwFlags;
+    }
+
+    private const uint MONITOR_DEFAULTTONEAREST = 2;
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetMonitorInfo(IntPtr monitor, ref MONITORINFO info);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromRect(ref RECT rect, uint flags);
+}

--- a/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
@@ -320,6 +320,17 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
         _excluded = [.. windows];
         Volatile.Write(ref _isolatedFrom, (long)applied);
         Interlocked.Increment(ref _exclusionUpdates);
+
+        // The frame in hand was composed under the previous list, which did not have whatever
+        // window has just been added to this one — so it may show that overlay, and handing it to
+        // the next poll would be the self-feed arriving by the back door. Dropped rather than kept
+        // as a stale-but-probably-fine picture: polls return nothing until a frame composed under
+        // the new list arrives, which is one screen refresh away.
+        lock (_latestLock)
+        {
+            _latest?.Dispose();
+            _latest = null;
+        }
         Log.Debug("Realtime monitor capture exclusion list: {Detail}", detail);
         return true;
     }

--- a/src/OverTranslate/Services/Realtime/Capture/WgcWindowExclusion.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcWindowExclusion.cs
@@ -1,0 +1,169 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Graphics.Capture;
+using Windows.UI;
+using WinRT;
+
+namespace OverTranslate.Services.Realtime.Capture;
+
+/// <summary>
+/// The window exclusion list: telling a capture session to leave named windows out of its frames,
+/// which is what lets a monitor capture serve a source that OverTranslate is drawing its own
+/// overlays on top of.
+/// </summary>
+/// <remarks>
+/// Hand-written for the same reason as <see cref="WgcInterop"/>, and one more. The API lives on
+/// <c>IDisplayGraphicsCaptureSession</c>, an interface the metadata does not declare
+/// <see cref="GraphicsCaptureSession"/> as implementing — a session gets it only when its item is a
+/// display, and only by asking for it at runtime. And the C# projection this project compiles
+/// against (Windows SDK 10.0.26100) does not have the interface at all: the first projection that
+/// does ships for net9.0 upwards, so reaching it from net8.0 means going to the ABI by hand. The
+/// system underneath has it regardless — <see cref="WgcCapability.SupportsWindowExclusion"/> asks
+/// the machine, not the projection.
+///
+/// Two things travel back from the ABI that the whole design rests on. The set call returns a
+/// <i>configuration iteration</i>, and every frame carries the iteration it was produced under
+/// (<c>IDirect3D11CaptureFrame3</c>): a frame numbered below the one the exclusion was accepted at
+/// was composed before it took effect and may still hold the overlays. That is the difference
+/// between this and <c>WDA_EXCLUDEFROMCAPTURE</c> — the request is not the promise, the frame is —
+/// and it is exactly what #94 got wrong.
+/// </remarks>
+[SupportedOSPlatform("windows10.0.18362.0")]
+internal static class WgcWindowExclusion
+{
+    // Windows.Graphics.Capture.IDisplayGraphicsCaptureSession, read out of the system's own
+    // Windows.Graphics.winmd rather than copied from a header, because nothing in the SDK this
+    // builds against declares it.
+    private static readonly Guid IidDisplayGraphicsCaptureSession = new("BB91F61B-218A-587D-8580-2701A74C0525");
+
+    // Windows.Graphics.Capture.IDirect3D11CaptureFrame3 — one property, the frame's iteration.
+    private static readonly Guid IidDirect3D11CaptureFrame3 = new("71616DC8-FEA5-5741-A3D8-591ACC39A9EE");
+
+    // Slots past IInspectable (IUnknown's three, then GetIids/GetRuntimeClassName/GetTrustLevel),
+    // in the order the interface declares them.
+    private const int SlotSetWindowExclusionList = 6;
+    private const int SlotGetWindowExclusionList = 7;
+    private const int SlotGetConfigurationIteration = 6;
+
+    /// <summary>
+    /// Asks <paramref name="session"/> to keep <paramref name="windows"/> out of its frames, and
+    /// returns the configuration iteration from which that holds — or null when the session refused,
+    /// which on a display session means this system does not have the API.
+    /// </summary>
+    public static unsafe ulong? TrySet(
+        GraphicsCaptureSession session, IReadOnlyCollection<IntPtr> windows, out string detail)
+    {
+        var sessionAbi = IntPtr.Zero;
+        var display = IntPtr.Zero;
+        var iterable = IntPtr.Zero;
+        try
+        {
+            sessionAbi = MarshalInspectable<GraphicsCaptureSession>.FromManaged(session);
+            var iid = IidDisplayGraphicsCaptureSession;
+            var hr = Marshal.QueryInterface(sessionAbi, ref iid, out display);
+            if (hr < 0)
+            {
+                detail = $"no display capture session (0x{hr:X8})";
+                return null;
+            }
+
+            // A window handle is a window id, one to one, which is the whole of the conversion —
+            // and the reason the list can be built here rather than travelling as WinRT types.
+            var ids = windows.Select(hwnd => new WindowId((ulong)hwnd.ToInt64())).ToList();
+            iterable = MarshalInterface<IEnumerable<WindowId>>.FromManaged(ids);
+
+            ulong iteration;
+            var vtable = *(void***)display;
+            hr = ((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, ulong*, int>)vtable[SlotSetWindowExclusionList])(
+                display, iterable, &iteration);
+
+            if (hr < 0)
+            {
+                detail = $"refused (0x{hr:X8})";
+                return null;
+            }
+
+            detail = $"applied from iteration {iteration} for {ids.Count} window(s)";
+            return iteration;
+        }
+        catch (Exception ex)
+        {
+            // Every way this can fail is a fact about the system, and the caller's response to all
+            // of them is the same: do not claim isolation.
+            detail = $"failed ({ex.GetType().Name}: {ex.Message.Trim()})";
+            return null;
+        }
+        finally
+        {
+            if (iterable != IntPtr.Zero) Marshal.Release(iterable);
+            if (display != IntPtr.Zero) Marshal.Release(display);
+            if (sessionAbi != IntPtr.Zero) Marshal.Release(sessionAbi);
+        }
+    }
+
+    /// <summary>
+    /// What the session says is currently excluded, which is not the same question as what was
+    /// asked for — the system is free to have taken fewer.
+    /// </summary>
+    public static unsafe IReadOnlyList<IntPtr> GetApplied(GraphicsCaptureSession session)
+    {
+        var sessionAbi = IntPtr.Zero;
+        var display = IntPtr.Zero;
+        var view = IntPtr.Zero;
+        try
+        {
+            sessionAbi = MarshalInspectable<GraphicsCaptureSession>.FromManaged(session);
+            var iid = IidDisplayGraphicsCaptureSession;
+            if (Marshal.QueryInterface(sessionAbi, ref iid, out display) < 0) return [];
+
+            var vtable = *(void***)display;
+            var hr = ((delegate* unmanaged[Stdcall]<IntPtr, IntPtr*, int>)vtable[SlotGetWindowExclusionList])(
+                display, &view);
+            if (hr < 0 || view == IntPtr.Zero) return [];
+
+            var ids = MarshalInterface<IReadOnlyList<WindowId>>.FromAbi(view);
+            return ids.Select(id => new IntPtr((long)id.Value)).ToList();
+        }
+        catch (Exception)
+        {
+            return [];
+        }
+        finally
+        {
+            if (view != IntPtr.Zero) Marshal.Release(view);
+            if (display != IntPtr.Zero) Marshal.Release(display);
+            if (sessionAbi != IntPtr.Zero) Marshal.Release(sessionAbi);
+        }
+    }
+
+    /// <summary>
+    /// Which configuration this frame was composed under, or null on a system whose frames do not
+    /// carry one — where no exclusion could have been set either.
+    /// </summary>
+    public static unsafe ulong? TryGetIteration(Direct3D11CaptureFrame frame)
+    {
+        var frameAbi = IntPtr.Zero;
+        var frame3 = IntPtr.Zero;
+        try
+        {
+            frameAbi = MarshalInspectable<Direct3D11CaptureFrame>.FromManaged(frame);
+            var iid = IidDirect3D11CaptureFrame3;
+            if (Marshal.QueryInterface(frameAbi, ref iid, out frame3) < 0) return null;
+
+            ulong iteration;
+            var vtable = *(void***)frame3;
+            var hr = ((delegate* unmanaged[Stdcall]<IntPtr, ulong*, int>)vtable[SlotGetConfigurationIteration])(
+                frame3, &iteration);
+            return hr < 0 ? null : iteration;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+        finally
+        {
+            if (frame3 != IntPtr.Zero) Marshal.Release(frame3);
+            if (frameAbi != IntPtr.Zero) Marshal.Release(frameAbi);
+        }
+    }
+}

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -86,6 +86,9 @@ internal sealed class RealtimeSessionController
     private Window? _hiddenShell;
 
     private readonly Dictionary<int, RealtimeBlockWindow> _blockWindows = [];
+    // Every window this session draws, as handles, for a capture backend that has to leave them out
+    // of its frames — see RefreshOverlayHandles. Written on the UI thread, read on the polling one.
+    private IReadOnlyList<IntPtr> _overlayHandles = [];
     private List<RealtimeBlockPlacement> _blocks = [];
     // UI updates are dispatched asynchronously. Carrying the session's generation here prevents an
     // update queued before a pause from restoring text after the screen was cleared.
@@ -196,6 +199,7 @@ internal sealed class RealtimeSessionController
         control.PauseToggleRequested += (_, _) => TogglePause();
         _control = control;
         control.Show();
+        RefreshOverlayHandles();
 
         EnterEditMode();
         StateChanged?.Invoke(this, EventArgs.Empty);
@@ -367,6 +371,7 @@ internal sealed class RealtimeSessionController
             control.ShowMessage(LocalizationService.Format("S.Realtime.TooManyBlocks", request.MaxBlocks));
         _edit = edit;
         edit.Show();
+        RefreshOverlayHandles();
 
         // Ownership, not a Topmost nudge: the edit layer covers the whole screen, so any moment it
         // is above the control the user's clicks on the bar land on the drawing canvas instead —
@@ -417,6 +422,10 @@ internal sealed class RealtimeSessionController
             _blockWindows[region.Id] = window;
             window.Show();
         }
+
+        // Before the backend, which asks for this list as it starts: the overlays are up, and the
+        // first frame it accepts must already be composed without them.
+        RefreshOverlayHandles();
 
         // Built here and not in Start: the layers exist and have handles now, which is the earliest
         // a backend can be asked whether it can keep them out of frame — and the last moment before
@@ -470,11 +479,96 @@ internal sealed class RealtimeSessionController
         if (request.CaptureMode is Models.RealtimeCaptureMode.Window)
             return CreateWindowCapture(request.SourceWindow, out refusal);
 
+        return CreateScreenCapture(request, out refusal);
+    }
+
+    /// <summary>
+    /// The whole screen, isolated the best way this system allows, or null when it allows neither.
+    /// </summary>
+    /// <remarks>
+    /// Two backends, in this order, and the order is the whole of the policy. A monitor capture with
+    /// the overlays in the session's window exclusion list is structural: the system composes the
+    /// screen without them, the set call says from which frame that holds, and frames older than
+    /// that are never read. The desktop grab is the older arrangement, where the overlays are asked
+    /// to hide themselves with <c>WDA_EXCLUDEFROMCAPTURE</c> and the session starts only if every
+    /// one of them agreed — which they cannot do before Windows 11 24H2 (#94).
+    ///
+    /// The exclusion list is far newer than 24H2, so the second is not dead code waiting to be
+    /// removed: it is the only full-screen path on every machine between those two Windows, and
+    /// today that is most of them. Dropping it with the first one in place would take a working
+    /// feature away from that whole band to tidy up a file.
+    ///
+    /// This is not the fallback #96 forbade. That one was silent and changed what the user was
+    /// reading — window capture quietly becoming a screen grab. Both of these <i>are</i> the screen
+    /// the user asked for, both refuse to start unless they can prove their own isolation, and which
+    /// one ran is named in the log.
+    /// </remarks>
+    private IRealtimeCaptureBackend? CreateScreenCapture(RealtimeStartRequest request, out string refusal)
+    {
+        refusal = "S.Realtime.CaptureNotIsolated";
+
+        if (WgcCapability.IsCaptureSupported && CreateMonitorCapture(request.ScreenBounds) is { } monitor)
+            return monitor;
+
         var desktop = new DesktopGrabCaptureBackend(OverlaysHiddenFromCapture());
         if (desktop.IsIsolated) return desktop;
 
         desktop.Dispose();
         return null;
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.18362.0")]
+    private WgcMonitorCaptureBackend? CreateMonitorCapture(System.Drawing.Rectangle screenBounds)
+    {
+        // The monitor is resolved again on every re-attach rather than captured once: a display that
+        // was unplugged and plugged back in, or that changed mode, is a different HMONITOR for the
+        // same rectangle.
+        var backend = WgcMonitorCaptureBackend.TryCreate(
+            () => WgcMonitorCaptureBackend.MonitorFor(screenBounds),
+            () => Volatile.Read(ref _overlayHandles));
+
+        if (backend is null) return null;
+
+        backend.SourceLost += OnCaptureSourceLost;
+        return backend;
+    }
+
+    /// <summary>
+    /// Records the handles of every window this session draws, for the capture backend to keep out
+    /// of its frames.
+    /// </summary>
+    /// <remarks>
+    /// Taken here and handed over as a snapshot because these are WPF windows: their handles may
+    /// only be read on the thread that owns them, and the backend asks from the polling thread. Kept
+    /// in a stable order — blocks by id, then the bar, then the edit layer — so the backend can tell
+    /// "the same windows as last time" from "a window appeared" by comparing the two lists.
+    ///
+    /// Called wherever one of those windows is created or closed, which is every time the answer can
+    /// change. Missing a call is not a silent hazard: the backend compares this list on every poll,
+    /// so a window that appeared without one is still excluded within a poll — and until the frames
+    /// catch up with the new list, nothing is read at all.
+    /// </remarks>
+    private void RefreshOverlayHandles()
+    {
+        var handles = new List<IntPtr>();
+
+        foreach (var id in _blockWindows.Keys.Order())
+            AddHandle(handles, _blockWindows[id]);
+
+        AddHandle(handles, _control);
+        AddHandle(handles, _edit);
+
+        Volatile.Write(ref _overlayHandles, handles);
+
+        static void AddHandle(List<IntPtr> handles, Window? window)
+        {
+            if (window is null) return;
+
+            // Zero until the window has been shown, which is not worth guarding elsewhere: an
+            // unrealised window is drawing nothing for a capture to pick up.
+            var hwnd = new System.Windows.Interop.WindowInteropHelper(window).Handle;
+            if (hwnd != IntPtr.Zero) handles.Add(hwnd);
+        }
     }
 
     /// <summary>
@@ -685,6 +779,7 @@ internal sealed class RealtimeSessionController
 
         CloseWindow(_edit, nameof(RealtimeEditWindow));
         _edit = null;
+        RefreshOverlayHandles();
     }
 
     private void CloseBlockWindows()
@@ -692,6 +787,7 @@ internal sealed class RealtimeSessionController
         foreach (var window in _blockWindows.Values)
             CloseWindow(window, nameof(RealtimeBlockWindow));
         _blockWindows.Clear();
+        RefreshOverlayHandles();
     }
 
     private void DisposeCapture()

--- a/tests/OverTranslate.Tests/MonitorResolutionTests.cs
+++ b/tests/OverTranslate.Tests/MonitorResolutionTests.cs
@@ -1,0 +1,50 @@
+using System.Drawing;
+using OverTranslate.Services.Realtime.Capture;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// Turning the one screen a realtime session runs on into the monitor its capture attaches to.
+/// </summary>
+/// <remarks>
+/// Almost everything about monitor capture needs a compositor and is measured with
+/// <c>WgcProbe exclusion</c> instead. This part does not: it is a rectangle going in and a handle
+/// coming out, and it is where a multi-screen desktop breaks things quietly — a display to the left
+/// of the primary has negative coordinates, and a remembered layout can name a screen that is no
+/// longer arranged the way it was.
+/// </remarks>
+public class MonitorResolutionTests
+{
+    private static Rectangle Primary =>
+        System.Windows.Forms.Screen.PrimaryScreen is { } screen
+            ? screen.Bounds
+            : new Rectangle(0, 0, 1920, 1080);
+
+    [Fact]
+    public void AScreenResolvesToAMonitor()
+    {
+        Assert.NotEqual(IntPtr.Zero, WgcMonitorCaptureBackend.MonitorFor(Primary));
+    }
+
+    [Fact]
+    public void ARectangleInsideAScreenIsOnThatScreensMonitor()
+    {
+        // What a session actually asks with: not the screen itself but a block drawn on it.
+        var block = new Rectangle(Primary.X + 100, Primary.Y + 100, 200, 80);
+
+        Assert.Equal(
+            WgcMonitorCaptureBackend.MonitorFor(Primary),
+            WgcMonitorCaptureBackend.MonitorFor(block));
+    }
+
+    [Fact]
+    public void ARectangleOffEveryScreenStillResolvesToTheNearestMonitor()
+    {
+        // The remembered-layout case: the screen this was saved against has been unplugged or moved,
+        // and refusing to start would be a worse answer than attaching to the display next to it.
+        var stranded = new Rectangle(-100_000, -100_000, 800, 600);
+
+        Assert.NotEqual(IntPtr.Zero, WgcMonitorCaptureBackend.MonitorFor(stranded));
+    }
+}

--- a/tools/WgcProbe/ExclusionTest.cs
+++ b/tools/WgcProbe/ExclusionTest.cs
@@ -64,7 +64,12 @@ internal static class ExclusionTest
         using var onScreen = control.GrabRegion(overlayBounds);
         if (onScreen is null) return Fail("the desktop grab produced nothing");
 
-        using var backend = WgcMonitorCaptureBackend.TryCreate(() => monitor, () => new[] { overlayHwnd });
+        // What the session hands the backend: a snapshot that changes as overlays come and go. Here
+        // it starts with the one overlay and gains a second one further down.
+        var overlays = new List<IntPtr> { overlayHwnd };
+
+        using var backend = WgcMonitorCaptureBackend.TryCreate(
+            () => monitor, () => Volatile.Read(ref overlays).ToArray());
         if (backend is null) return Fail("could not start monitor capture with the overlay excluded");
 
         // The backend has already waited for a frame composed with the exclusion in force, so this
@@ -111,6 +116,46 @@ internal static class ExclusionTest
         {
             Console.Error.WriteLine(
                 $"NO-GO: the excluded region does not show what is under it (black {blackShare:P1})");
+            return 1;
+        }
+
+        // A session creates and destroys overlays while it runs — a block added, the bar rebuilt —
+        // so an exclusion list set once at the start is a list of the windows that happened to exist
+        // then. This is the other half of the answer: a layer that appears afterwards has to be out
+        // of the frames too, and the frames composed before it was excluded must not be served.
+        var lateBounds = new Rectangle(
+            sourceBounds.X + 40, sourceBounds.Y + 40, sourceBounds.Width / 3, sourceBounds.Height / 4);
+        using var late = ProbeWindow.Show(lateBounds, opaqueWhite: false, out var lateHwnd);
+        Console.WriteLine($"late overlay           hwnd={lateHwnd:X} {lateBounds.Width}x{lateBounds.Height} at {lateBounds.X},{lateBounds.Y}");
+
+        Volatile.Write(ref overlays, [overlayHwnd, lateHwnd]);
+
+        var started = DateTime.UtcNow;
+        double lateShare = 1;
+        var polls = 0;
+        while (DateTime.UtcNow - started < TimeSpan.FromSeconds(5))
+        {
+            polls++;
+            using var poll = backend.GrabRegion(lateBounds);
+            if (poll is null)
+            {
+                // What the backend does while the frames catch up with the new list: nothing at all,
+                // which is the point.
+                Thread.Sleep(100);
+                continue;
+            }
+
+            lateShare = Share(poll, new Rectangle(0, 0, poll.Width, poll.Height), Marker);
+            if (lateShare <= 0.001) break;
+            Thread.Sleep(100);
+        }
+
+        Console.WriteLine($"late overlay excluded  {lateShare:P1} after {(DateTime.UtcNow - started).TotalMilliseconds:F0}ms over {polls} poll(s)");
+        Console.WriteLine($"backend                {backend.DescribeActivity()}");
+
+        if (lateShare > 0.001)
+        {
+            Console.Error.WriteLine("FAIL: an overlay created after the session started stayed in the frames");
             return 1;
         }
 

--- a/tools/WgcProbe/ExclusionTest.cs
+++ b/tools/WgcProbe/ExclusionTest.cs
@@ -1,0 +1,239 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX;
+using OverTranslate.Services.Realtime.Capture;
+
+namespace WgcProbe;
+
+/// <summary>
+/// The go/no-go for capturing a whole monitor with OverTranslate's own overlays excluded: does the
+/// excluded region come back showing what is <i>underneath</i> the overlay, or does it come back
+/// black?
+/// </summary>
+/// <remarks>
+/// Everything about that plan turns on this one answer and nothing in the documentation gives it. A
+/// subtitle layer sits directly over the text it translates, so an exclusion that punches a hole —
+/// leaving black, or the desktop background, or the last thing composed there — removes exactly the
+/// pixels recognition exists to read, and the whole approach is worth nothing. An exclusion that
+/// composes the scene without that window is worth everything: it is structural isolation for the
+/// full-screen path, the same kind the window path already has.
+///
+/// Built like <see cref="OverlayTest"/> and for the same reason: both windows are the probe's own,
+/// so the measurement cannot be invalidated by whatever the user does to their desktop mid-run. The
+/// source window is filled white with black text, the stand-in subtitle layer is filled a magenta
+/// nothing else on a screen produces, and the region under the layer is then counted three ways —
+/// magenta means the exclusion did not happen, black means it punched a hole, white means the scene
+/// was composed without the overlay.
+///
+/// The frame examined is not simply the next one. The set call returns the configuration iteration
+/// its answer holds from, frames carry the iteration they were composed under, and a frame from
+/// before that number legitimately still contains the overlay. Reading one of those would have this
+/// test report a failure the system did not commit.
+/// </remarks>
+[SupportedOSPlatform("windows10.0.18362.0")]
+internal static class ExclusionTest
+{
+    private static System.Drawing.Color Marker => ProbeWindow.Marker;
+
+    public static int Run(Rectangle sourceBounds, string outputDirectory)
+    {
+        if (!WgcCapability.SupportsWindowExclusion)
+        {
+            Console.Error.WriteLine("this system has no window exclusion list — nothing to measure");
+            return 2;
+        }
+
+        // Well inside the source window, so a few pixels of frame either way cannot decide anything.
+        var overlayBounds = Rectangle.Inflate(sourceBounds, -sourceBounds.Width / 4, -sourceBounds.Height / 4);
+
+        using var source = ProbeWindow.Show(sourceBounds, opaqueWhite: true, out var sourceHwnd);
+        Console.WriteLine($"source window          hwnd={sourceHwnd:X} {sourceBounds.Width}x{sourceBounds.Height} at {sourceBounds.X},{sourceBounds.Y}");
+
+        using var overlay = ProbeWindow.Show(overlayBounds, opaqueWhite: false, out var overlayHwnd);
+        Console.WriteLine($"overlay                hwnd={overlayHwnd:X} {overlayBounds.Width}x{overlayBounds.Height} at {overlayBounds.X},{overlayBounds.Y}");
+
+        var centre = new POINT
+        {
+            X = overlayBounds.X + (overlayBounds.Width / 2),
+            Y = overlayBounds.Y + (overlayBounds.Height / 2)
+        };
+        var monitor = MonitorFromPoint(centre, MONITOR_DEFAULTTONEAREST);
+        if (monitor == IntPtr.Zero) return Fail("no monitor under the overlay");
+
+        var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+        if (!GetMonitorInfo(monitor, ref info)) return Fail("could not read the monitor's rectangle");
+
+        var monitorOrigin = new Point(info.rcMonitor.Left, info.rcMonitor.Top);
+        Console.WriteLine($"monitor                hmonitor={monitor:X} at {monitorOrigin.X},{monitorOrigin.Y} " +
+                          $"{info.rcMonitor.Right - info.rcMonitor.Left}x{info.rcMonitor.Bottom - info.rcMonitor.Top}");
+
+        var item = WgcInterop.CreateItemForMonitor(monitor);
+        if (item is null) return Fail("the monitor refused capture");
+
+        var device = WgcInterop.CreateDirect3DDevice(out var rawDevice);
+        using var pool = Direct3D11CaptureFramePool.CreateFreeThreaded(
+            device, DirectXPixelFormat.B8G8R8A8UIntNormalized, 2, item.Size);
+        using var session = pool.CreateCaptureSession(item);
+
+        try
+        {
+            // The pointer would otherwise land in the measured region and be counted as neither the
+            // overlay nor the source window.
+            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 19041)) session.IsCursorCaptureEnabled = false;
+            session.StartCapture();
+            Console.WriteLine($"itemSize               {item.Size.Width}x{item.Size.Height}");
+
+            // Before: the control. The overlay must be in this one, or the measurement after it
+            // proves nothing at all.
+            using var before = WaitForFrame(pool, minimumIteration: null);
+            if (before is null) return Fail("no frame arrived before the exclusion was set");
+
+            var iteration = WgcWindowExclusion.TrySet(session, [overlayHwnd], out var detail);
+            Console.WriteLine($"exclusion              {detail}");
+            if (iteration is not { } applied) return Fail("the exclusion list was not applied");
+
+            var readBack = WgcWindowExclusion.GetApplied(session);
+            Console.WriteLine($"reported as excluded   {string.Join(", ", readBack.Select(h => h.ToString("X")))}");
+
+            using var after = WaitForFrame(pool, applied);
+            if (after is null) return Fail($"no frame reached configuration iteration {applied}");
+
+            var region = new Rectangle(
+                overlayBounds.X - monitorOrigin.X, overlayBounds.Y - monitorOrigin.Y,
+                overlayBounds.Width, overlayBounds.Height);
+
+            var beforeShare = Share(before, region, Marker);
+            var afterShare = Share(after, region, Marker);
+            var blackShare = Share(after, region, System.Drawing.Color.Black);
+            var whiteShare = Share(after, region, System.Drawing.Color.White);
+
+            Directory.CreateDirectory(outputDirectory);
+            var stamp = DateTime.Now.ToString("HHmmss");
+            before.Save(Path.Combine(outputDirectory, $"exclusion-before-{stamp}.png"), ImageFormat.Png);
+            after.Save(Path.Combine(outputDirectory, $"exclusion-after-{stamp}.png"), ImageFormat.Png);
+
+            Console.WriteLine($"overlay before         {beforeShare:P1}");
+            Console.WriteLine($"overlay after          {afterShare:P1}");
+            Console.WriteLine($"black after            {blackShare:P1}");
+            Console.WriteLine($"source content after   {whiteShare:P1}");
+            Console.WriteLine($"written                {outputDirectory}");
+
+            if (beforeShare < 0.5)
+                return Fail("the overlay never reached the monitor capture — the test proved nothing");
+
+            if (afterShare > 0.001)
+            {
+                Console.Error.WriteLine("NO-GO: the overlay is still in the frame after the exclusion");
+                return 1;
+            }
+
+            if (whiteShare < 0.5)
+            {
+                Console.Error.WriteLine(
+                    $"NO-GO: the excluded region does not show what is under it (black {blackShare:P1})");
+                return 1;
+            }
+
+            Console.WriteLine("GO: the excluded region shows the source window underneath the overlay");
+            return 0;
+        }
+        finally
+        {
+            (device as IDisposable)?.Dispose();
+            if (rawDevice != IntPtr.Zero) Marshal.Release(rawDevice);
+        }
+    }
+
+    /// <summary>
+    /// The next frame composed at or after <paramref name="minimumIteration"/>, read back onto the
+    /// CPU. Null when none arrived in time.
+    /// </summary>
+    private static Bitmap? WaitForFrame(Direct3D11CaptureFramePool pool, ulong? minimumIteration)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var frame = pool.TryGetNextFrame();
+            if (frame is null)
+            {
+                Thread.Sleep(50);
+                continue;
+            }
+
+            var iteration = WgcWindowExclusion.TryGetIteration(frame);
+            if (minimumIteration is { } wanted && (iteration is null || iteration < wanted))
+            {
+                Thread.Sleep(50);
+                continue;
+            }
+
+            return WgcInterop.ReadBack(frame.Surface, frame.ContentSize.Width, frame.ContentSize.Height);
+        }
+
+        return null;
+    }
+
+    /// <summary>How much of one rectangle of a frame is exactly this colour.</summary>
+    private static double Share(Bitmap frame, Rectangle region, System.Drawing.Color colour)
+    {
+        var area = Rectangle.Intersect(region, new Rectangle(0, 0, frame.Width, frame.Height));
+        if (area.Width <= 0 || area.Height <= 0) return 0;
+
+        var hits = 0;
+        var total = 0;
+        for (var y = area.Top; y < area.Bottom; y += 4)
+        {
+            for (var x = area.Left; x < area.Right; x += 4)
+            {
+                total++;
+                var pixel = frame.GetPixel(x, y);
+                if (pixel.R == colour.R && pixel.G == colour.G && pixel.B == colour.B) hits++;
+            }
+        }
+
+        return total == 0 ? 0 : (double)hits / total;
+    }
+
+    private static int Fail(string message)
+    {
+        Console.Error.WriteLine(message);
+        return 2;
+    }
+
+    private const uint MONITOR_DEFAULTTONEAREST = 2;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MONITORINFO
+    {
+        public int cbSize;
+        public RECT rcMonitor;
+        public RECT rcWork;
+        public uint dwFlags;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromPoint(POINT point, uint flags);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetMonitorInfo(IntPtr monitor, ref MONITORINFO info);
+}

--- a/tools/WgcProbe/ExclusionTest.cs
+++ b/tools/WgcProbe/ExclusionTest.cs
@@ -1,8 +1,8 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Windows.Forms;
 using OverTranslate.Services.Realtime.Capture;
 
 namespace WgcProbe;
@@ -68,9 +68,24 @@ internal static class ExclusionTest
         // it starts with the one overlay and gains a second one further down.
         var overlays = new List<IntPtr> { overlayHwnd };
 
+        // What the screen looks like around its own edge before anything is captured, for the
+        // indicator measurement below.
+        using var ringBefore = GrabScreenRing(overlayBounds);
+
         using var backend = WgcMonitorCaptureBackend.TryCreate(
             () => monitor, () => Volatile.Read(ref overlays).ToArray());
         if (backend is null) return Fail("could not start monitor capture with the overlay excluded");
+
+        // Windows draws a coloured frame around anything being captured. Around one window that is a
+        // cost; around the whole screen it is a border the user stares at for the length of a
+        // session, so it is measured here rather than discovered by them. Reported, not judged — the
+        // numbers only say something changed, and the written PNGs are what to look at.
+        using var ringAfter = GrabScreenRing(overlayBounds);
+        Console.WriteLine($"screen edge changed    {RingChange(ringBefore, ringAfter):P1}");
+        Directory.CreateDirectory(outputDirectory);
+        var ringStamp = DateTime.Now.ToString("HHmmss");
+        ringBefore.Save(Path.Combine(outputDirectory, $"exclusion-edge-before-{ringStamp}.png"), ImageFormat.Png);
+        ringAfter.Save(Path.Combine(outputDirectory, $"exclusion-edge-after-{ringStamp}.png"), ImageFormat.Png);
 
         // The backend has already waited for a frame composed with the exclusion in force, so this
         // is a poll rather than a wait — but the region is asked for a few times, because a poll can
@@ -161,6 +176,42 @@ internal static class ExclusionTest
 
         Console.WriteLine("GO: the excluded region shows the source window underneath the overlay");
         return 0;
+    }
+
+    /// <summary>
+    /// A band just inside the monitor's own edge, off the screen. Inset because the capture
+    /// indicator is drawn on the edge itself rather than outside it — a comparison of the pixels
+    /// beyond the screen measures nothing at all.
+    /// </summary>
+    private static Bitmap GrabScreenRing(Rectangle onThatMonitor)
+    {
+        var bounds = Screen.FromRectangle(onThatMonitor).Bounds;
+        var band = new Rectangle(bounds.X, bounds.Y, bounds.Width, 12);
+
+        var bitmap = new Bitmap(band.Width, band.Height, PixelFormat.Format32bppArgb);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.CopyFromScreen(band.Left, band.Top, 0, 0, band.Size, CopyPixelOperation.SourceCopy);
+        return bitmap;
+    }
+
+    /// <summary>How many of two bands' pixels differ.</summary>
+    private static double RingChange(Bitmap before, Bitmap after)
+    {
+        var width = Math.Min(before.Width, after.Width);
+        var height = Math.Min(before.Height, after.Height);
+
+        var changed = 0;
+        var total = 0;
+        for (var y = 0; y < height; y += 2)
+        {
+            for (var x = 0; x < width; x += 2)
+            {
+                total++;
+                if (before.GetPixel(x, y).ToArgb() != after.GetPixel(x, y).ToArgb()) changed++;
+            }
+        }
+
+        return total == 0 ? 0 : (double)changed / total;
     }
 
     /// <summary>How much of one rectangle of a frame is exactly this colour.</summary>

--- a/tools/WgcProbe/ExclusionTest.cs
+++ b/tools/WgcProbe/ExclusionTest.cs
@@ -3,8 +3,6 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using Windows.Graphics.Capture;
-using Windows.Graphics.DirectX;
 using OverTranslate.Services.Realtime.Capture;
 
 namespace WgcProbe;
@@ -15,24 +13,25 @@ namespace WgcProbe;
 /// black?
 /// </summary>
 /// <remarks>
-/// Everything about that plan turns on this one answer and nothing in the documentation gives it. A
+/// Everything about that path turned on this one answer and nothing in the documentation gave it. A
 /// subtitle layer sits directly over the text it translates, so an exclusion that punches a hole —
 /// leaving black, or the desktop background, or the last thing composed there — removes exactly the
 /// pixels recognition exists to read, and the whole approach is worth nothing. An exclusion that
 /// composes the scene without that window is worth everything: it is structural isolation for the
 /// full-screen path, the same kind the window path already has.
 ///
+/// Measured through <see cref="WgcMonitorCaptureBackend"/> itself rather than a chain assembled
+/// here, so what is being answered for is the code a session runs on — the exclusion list, the
+/// refusal to read a frame composed before it took effect, and the crop from the monitor's origin,
+/// which is the part that goes wrong quietly on a display to the left of the primary.
+///
 /// Built like <see cref="OverlayTest"/> and for the same reason: both windows are the probe's own,
 /// so the measurement cannot be invalidated by whatever the user does to their desktop mid-run. The
 /// source window is filled white with black text, the stand-in subtitle layer is filled a magenta
 /// nothing else on a screen produces, and the region under the layer is then counted three ways —
 /// magenta means the exclusion did not happen, black means it punched a hole, white means the scene
-/// was composed without the overlay.
-///
-/// The frame examined is not simply the next one. The set call returns the configuration iteration
-/// its answer holds from, frames carry the iteration they were composed under, and a frame from
-/// before that number legitimately still contains the overlay. Reading one of those would have this
-/// test report a failure the system did not commit.
+/// was composed without the overlay. The desktop grab of the same rectangle is the control: it must
+/// see the layer, or nothing was proved.
 /// </remarks>
 [SupportedOSPlatform("windows10.0.18362.0")]
 internal static class ExclusionTest
@@ -56,125 +55,67 @@ internal static class ExclusionTest
         using var overlay = ProbeWindow.Show(overlayBounds, opaqueWhite: false, out var overlayHwnd);
         Console.WriteLine($"overlay                hwnd={overlayHwnd:X} {overlayBounds.Width}x{overlayBounds.Height} at {overlayBounds.X},{overlayBounds.Y}");
 
-        var centre = new POINT
-        {
-            X = overlayBounds.X + (overlayBounds.Width / 2),
-            Y = overlayBounds.Y + (overlayBounds.Height / 2)
-        };
-        var monitor = MonitorFromPoint(centre, MONITOR_DEFAULTTONEAREST);
+        var monitor = WgcMonitorCaptureBackend.MonitorFor(overlayBounds);
         if (monitor == IntPtr.Zero) return Fail("no monitor under the overlay");
+        Console.WriteLine($"monitor                hmonitor={monitor:X}");
 
-        var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
-        if (!GetMonitorInfo(monitor, ref info)) return Fail("could not read the monitor's rectangle");
+        // The control, with the overlay up: what anything reading the screen sees today.
+        using var control = new DesktopGrabCaptureBackend(overlaysHiddenFromCapture: true);
+        using var onScreen = control.GrabRegion(overlayBounds);
+        if (onScreen is null) return Fail("the desktop grab produced nothing");
 
-        var monitorOrigin = new Point(info.rcMonitor.Left, info.rcMonitor.Top);
-        Console.WriteLine($"monitor                hmonitor={monitor:X} at {monitorOrigin.X},{monitorOrigin.Y} " +
-                          $"{info.rcMonitor.Right - info.rcMonitor.Left}x{info.rcMonitor.Bottom - info.rcMonitor.Top}");
+        using var backend = WgcMonitorCaptureBackend.TryCreate(() => monitor, () => new[] { overlayHwnd });
+        if (backend is null) return Fail("could not start monitor capture with the overlay excluded");
 
-        var item = WgcInterop.CreateItemForMonitor(monitor);
-        if (item is null) return Fail("the monitor refused capture");
-
-        var device = WgcInterop.CreateDirect3DDevice(out var rawDevice);
-        using var pool = Direct3D11CaptureFramePool.CreateFreeThreaded(
-            device, DirectXPixelFormat.B8G8R8A8UIntNormalized, 2, item.Size);
-        using var session = pool.CreateCaptureSession(item);
-
-        try
+        // The backend has already waited for a frame composed with the exclusion in force, so this
+        // is a poll rather than a wait — but the region is asked for a few times, because a poll can
+        // legitimately come back empty while the chain is settling.
+        Bitmap? captured = null;
+        for (var attempt = 0; attempt < 30 && captured is null; attempt++)
         {
-            // The pointer would otherwise land in the measured region and be counted as neither the
-            // overlay nor the source window.
-            if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 19041)) session.IsCursorCaptureEnabled = false;
-            session.StartCapture();
-            Console.WriteLine($"itemSize               {item.Size.Width}x{item.Size.Height}");
-
-            // Before: the control. The overlay must be in this one, or the measurement after it
-            // proves nothing at all.
-            using var before = WaitForFrame(pool, minimumIteration: null);
-            if (before is null) return Fail("no frame arrived before the exclusion was set");
-
-            var iteration = WgcWindowExclusion.TrySet(session, [overlayHwnd], out var detail);
-            Console.WriteLine($"exclusion              {detail}");
-            if (iteration is not { } applied) return Fail("the exclusion list was not applied");
-
-            var readBack = WgcWindowExclusion.GetApplied(session);
-            Console.WriteLine($"reported as excluded   {string.Join(", ", readBack.Select(h => h.ToString("X")))}");
-
-            using var after = WaitForFrame(pool, applied);
-            if (after is null) return Fail($"no frame reached configuration iteration {applied}");
-
-            var region = new Rectangle(
-                overlayBounds.X - monitorOrigin.X, overlayBounds.Y - monitorOrigin.Y,
-                overlayBounds.Width, overlayBounds.Height);
-
-            var beforeShare = Share(before, region, Marker);
-            var afterShare = Share(after, region, Marker);
-            var blackShare = Share(after, region, System.Drawing.Color.Black);
-            var whiteShare = Share(after, region, System.Drawing.Color.White);
-
-            Directory.CreateDirectory(outputDirectory);
-            var stamp = DateTime.Now.ToString("HHmmss");
-            before.Save(Path.Combine(outputDirectory, $"exclusion-before-{stamp}.png"), ImageFormat.Png);
-            after.Save(Path.Combine(outputDirectory, $"exclusion-after-{stamp}.png"), ImageFormat.Png);
-
-            Console.WriteLine($"overlay before         {beforeShare:P1}");
-            Console.WriteLine($"overlay after          {afterShare:P1}");
-            Console.WriteLine($"black after            {blackShare:P1}");
-            Console.WriteLine($"source content after   {whiteShare:P1}");
-            Console.WriteLine($"written                {outputDirectory}");
-
-            if (beforeShare < 0.5)
-                return Fail("the overlay never reached the monitor capture — the test proved nothing");
-
-            if (afterShare > 0.001)
-            {
-                Console.Error.WriteLine("NO-GO: the overlay is still in the frame after the exclusion");
-                return 1;
-            }
-
-            if (whiteShare < 0.5)
-            {
-                Console.Error.WriteLine(
-                    $"NO-GO: the excluded region does not show what is under it (black {blackShare:P1})");
-                return 1;
-            }
-
-            Console.WriteLine("GO: the excluded region shows the source window underneath the overlay");
-            return 0;
-        }
-        finally
-        {
-            (device as IDisposable)?.Dispose();
-            if (rawDevice != IntPtr.Zero) Marshal.Release(rawDevice);
-        }
-    }
-
-    /// <summary>
-    /// The next frame composed at or after <paramref name="minimumIteration"/>, read back onto the
-    /// CPU. Null when none arrived in time.
-    /// </summary>
-    private static Bitmap? WaitForFrame(Direct3D11CaptureFramePool pool, ulong? minimumIteration)
-    {
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-        while (DateTime.UtcNow < deadline)
-        {
-            using var frame = pool.TryGetNextFrame();
-            if (frame is null)
-            {
-                Thread.Sleep(50);
-                continue;
-            }
-
-            var iteration = WgcWindowExclusion.TryGetIteration(frame);
-            if (minimumIteration is { } wanted && (iteration is null || iteration < wanted))
-            {
-                Thread.Sleep(50);
-                continue;
-            }
-
-            return WgcInterop.ReadBack(frame.Surface, frame.ContentSize.Width, frame.ContentSize.Height);
+            captured = backend.GrabRegion(overlayBounds);
+            if (captured is null) Thread.Sleep(100);
         }
 
-        return null;
+        if (captured is null) return Fail("the monitor capture produced no frame for the region");
+
+        var whole = new Rectangle(0, 0, captured.Width, captured.Height);
+        var onScreenShare = Share(onScreen, new Rectangle(0, 0, onScreen.Width, onScreen.Height), Marker);
+        var capturedShare = Share(captured, whole, Marker);
+        var blackShare = Share(captured, whole, System.Drawing.Color.Black);
+        var whiteShare = Share(captured, whole, System.Drawing.Color.White);
+
+        Directory.CreateDirectory(outputDirectory);
+        var stamp = DateTime.Now.ToString("HHmmss");
+        onScreen.Save(Path.Combine(outputDirectory, $"exclusion-onscreen-{stamp}.png"), ImageFormat.Png);
+        captured.Save(Path.Combine(outputDirectory, $"exclusion-captured-{stamp}.png"), ImageFormat.Png);
+        captured.Dispose();
+
+        Console.WriteLine($"overlay on screen      {onScreenShare:P1}");
+        Console.WriteLine($"overlay in capture     {capturedShare:P1}");
+        Console.WriteLine($"black in capture       {blackShare:P1}");
+        Console.WriteLine($"source content         {whiteShare:P1}");
+        Console.WriteLine($"backend                {backend.DescribeActivity()}");
+        Console.WriteLine($"written                {outputDirectory}");
+
+        if (onScreenShare < 0.5)
+            return Fail("the overlay is not on the screen — the test proved nothing");
+
+        if (capturedShare > 0.001)
+        {
+            Console.Error.WriteLine("NO-GO: the overlay is still in the frame after the exclusion");
+            return 1;
+        }
+
+        if (whiteShare < 0.5)
+        {
+            Console.Error.WriteLine(
+                $"NO-GO: the excluded region does not show what is under it (black {blackShare:P1})");
+            return 1;
+        }
+
+        Console.WriteLine("GO: the excluded region shows the source window underneath the overlay");
+        return 0;
     }
 
     /// <summary>How much of one rectangle of a frame is exactly this colour.</summary>
@@ -203,37 +144,4 @@ internal static class ExclusionTest
         Console.Error.WriteLine(message);
         return 2;
     }
-
-    private const uint MONITOR_DEFAULTTONEAREST = 2;
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct POINT
-    {
-        public int X;
-        public int Y;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct RECT
-    {
-        public int Left;
-        public int Top;
-        public int Right;
-        public int Bottom;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct MONITORINFO
-    {
-        public int cbSize;
-        public RECT rcMonitor;
-        public RECT rcWork;
-        public uint dwFlags;
-    }
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr MonitorFromPoint(POINT point, uint flags);
-
-    [DllImport("user32.dll")]
-    private static extern bool GetMonitorInfo(IntPtr monitor, ref MONITORINFO info);
 }

--- a/tools/WgcProbe/Program.cs
+++ b/tools/WgcProbe/Program.cs
@@ -65,6 +65,13 @@ internal static class Program
                       capture saw. The go/no-go test: the desktop grab must see it and the
                       window capture must not. Defaults to 200,200 1200x600.
 
+                  WgcProbe exclusion [x y w h] [outputDir]
+                      Capture the whole monitor with a stand-in subtitle layer excluded from the
+                      frame, and report what the excluded region came back as: the layer still
+                      there, black, or the source window underneath it. The go/no-go for
+                      capturing the screen without needing the overlays hidden. Defaults to
+                      200,200 1200x600.
+
                   WgcProbe border [x y w h] [outputDir]
                       Put up a source window, start capturing it, and measure whether the system
                       draws its capture indicator around it — the cost window capture adds to
@@ -82,6 +89,7 @@ internal static class Program
                 "window" => CaptureWindow(args),
                 "region" => CaptureRegion(args),
                 "overlay" => RunOverlayTest(args),
+                "exclusion" => RunExclusionTest(args),
                 "border" => RunBorderTest(args),
                 _ => Fail($"unknown command '{args[0]}'")
             };
@@ -153,6 +161,13 @@ internal static class Program
         if (!WgcCapability.IsCaptureSupported) return Fail("Windows.Graphics.Capture is not supported here");
 
         return OverlayTest.Run(ProbeBounds(args), OutputDirectory(args, args.Length >= 5 ? 5 : 1));
+    }
+
+    private static int RunExclusionTest(string[] args)
+    {
+        if (!WgcCapability.IsCaptureSupported) return Fail("Windows.Graphics.Capture is not supported here");
+
+        return ExclusionTest.Run(ProbeBounds(args), OutputDirectory(args, args.Length >= 5 ? 5 : 1));
     }
 
     private static int RunBorderTest(string[] args)

--- a/tools/WgcProbe/README.md
+++ b/tools/WgcProbe/README.md
@@ -47,6 +47,29 @@ PASS: the overlay is absent from the window capture
 
 兩個視窗都是 probe 自己的，這是刻意的：第一版拿桌面上的 Edge 當來源，跑到一半視窗被拖到另一個螢幕，量測直接失效。要對真實應用程式測請用 `region`。
 
+### `exclusion` — 整個螢幕的 go/no-go
+
+```bash
+WgcProbe.exe exclusion [x y w h] [輸出目錄]
+```
+
+跟 `overlay` 同一組視窗，改問另一半的問題：**擷取整個螢幕、並把字幕層放進 session 的 window exclusion list，那塊區域讀回來的是什麼？**
+
+這一題沒有文件可查，而整條「整個螢幕」的路成不成立全看它。字幕層本來就蓋在原文上，如果排除之後那塊變成純黑，OCR 讀到的就是黑色，等於什麼都沒解決。
+
+```
+overlay on screen      98.5%
+overlay in capture      0.0%
+black in capture        0.6%
+source content         98.1%
+backend                hmonitor=10073 received=5 read=1 avgReadback=24.7ms discardedBeforeExclusion=0 exclusionUpdates=1 excluded=1 rebuilds=0
+GO: the excluded region shows the source window underneath the overlay
+```
+
+`source content` 是關鍵那一行：**露出來的是底下來源視窗的內容，不是黑洞**（`black` 那 0.6% 是來源視窗自己的黑字）。
+
+走的是 `WgcMonitorCaptureBackend` 本人，不是這裡另外搭的鏈路——所以連同「不讀 exclusion 生效前的那幾幀」與「從螢幕原點裁切」一起被量到。後者在主螢幕左邊的顯示器上會安靜地錯掉，自足測試看不出來。
+
 ### `list` / `window` / `region` — 對真實應用程式
 
 ```bash

--- a/tools/WgcProbe/README.md
+++ b/tools/WgcProbe/README.md
@@ -58,6 +58,7 @@ WgcProbe.exe exclusion [x y w h] [輸出目錄]
 這一題沒有文件可查，而整條「整個螢幕」的路成不成立全看它。字幕層本來就蓋在原文上，如果排除之後那塊變成純黑，OCR 讀到的就是黑色，等於什麼都沒解決。
 
 ```
+screen edge changed    33.5%
 overlay on screen      98.5%
 overlay in capture      0.0%
 black in capture        0.6%
@@ -65,6 +66,8 @@ source content         98.1%
 backend                hmonitor=10073 received=5 read=1 avgReadback=24.7ms discardedBeforeExclusion=0 exclusionUpdates=1 excluded=1 rebuilds=0
 GO: the excluded region shows the source window underneath the overlay
 ```
+
+`screen edge changed` 是**擷取指示框**：整個螢幕擷取會讓 Windows 沿著整片螢幕的邊緣畫一圈黃線，整段 session 都在（視窗擷取只框住那個視窗）。數字只說邊緣有東西變了，判定請看寫出來的 `exclusion-edge-*.png`。
 
 `source content` 是關鍵那一行：**露出來的是底下來源視窗的內容，不是黑洞**（`black` 那 0.6% 是來源視窗自己的黑字）。
 


### PR DESCRIPTION
Closes #102

「整個螢幕」原本走 `Graphics.CopyFromScreen`，隔離全靠 `WDA_EXCLUDEFROMCAPTURE`。這次把它換成 `CreateForMonitor` + `SetWindowExclusionList`：由擷取 session 自己把 OverTranslate 的疊圖排除在 frame 之外，隔離變成擷取來源的性質，而不是拜託疊圖自己躲起來。

## go/no-go 先驗過

票上那個「被排除的區域會不會變成純黑」的問題沒有文件可查，整張票成立與否全看它。`WgcProbe exclusion` 實測（走 `WgcMonitorCaptureBackend` 本人，不是另搭的鏈路）：

```
overlay on screen      98.5%
overlay in capture      0.0%
black in capture        0.6%
source content         98.1%
```

露出來的是底下來源視窗的內容，不是黑洞（那 0.6% 是來源視窗自己的黑字）。

## 一個票上沒寫到的坑

Windows SDK 10.0.26100 的 C# 投影**沒有** `SetWindowExclusionList`（最新 26100.87 才有，而且只出 net9.0）。`WgcCapability.SupportsWindowExclusion` 回 True 是問 OS，不是問投影。所以照 `WgcInterop` 既有做法手寫 COM，IID 與 vtable 版位從 `C:\Windows\System32\WinMetadata\Windows.Graphics.winmd` 取得。

## 隔離是「幀」而不是「請求」

set 呼叫回傳 configuration iteration，每一幀也帶著自己是在哪個 iteration 合成的（`IDirect3D11CaptureFrame3`）。後端只讀編號 ≥ 該值的幀，其餘丟掉——這正是 #94 缺的那一半：那時只發出請求就當成功。

排除清單每次 poll 比對疊圖清單，不靠呼叫端記得通知；清單一變，手上那幀（舊清單下合成、可能含新疊圖）也一起丟掉。實測 session 中途新增的疊圖在 110ms／2 次 poll 內被排除，中間那次 poll 回傳 null 而不是舊畫面。

## WDA 那條路先留著

exclusion list 比 24H2 新很多，所以 24H2～沒有該 API 之間的機器，今天唯一能用的整個螢幕就是 WDA 那條。這次讓 monitor+exclusion 優先、沒有該 API 才落到既有的 DesktopGrab，兩條都一樣要 `IsIsolated` 成立才啟動，log 寫明走了哪條。這不是 #96 禁止的隱藏落回：那個是靜靜把視窗擷取換成螢幕擷取，這兩條都是使用者選的「整個螢幕」。

（收掉這一層是另一張票的事。）

## 量到的其他東西

- 擷取指示黃框會沿著**整片螢幕**邊緣畫，整段 session 都在（`screen edge changed 33.5%`，見 `exclusion-edge-*.png`）。維持現狀不關，跟視窗模式一致。
- 全螢幕 2560x1440 readback 約 15ms，對照視窗擷取 1992x1273 的 12.8ms。

## 驗證

- `WgcProbe exclusion`：GO，含 session 中途新增疊圖那半
- 真機跑了五次 session：`capture="WgcMonitor" excluded=2`、`discardedBeforeExclusion=0 exclusionUpdates=1 rebuilds=0`、全程 0 WARN／0 ERROR，送進 OCR 的尺寸固定 1677x259（#94 的病徵是這個數字會一代代膨脹）
- 副螢幕正常
- 519 個測試通過（新增 3 個：螢幕矩形 → HMONITOR，含負座標與 layout 已改變的情形）
