### PR TITLE
fix: 即時翻譯自然背景在英文來源下的擦除缺陷

### DIFF
--- a/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
@@ -32,6 +32,77 @@ internal static class RealtimeNaturalBackground
     private const int MinErasePadTop = 8;
     private const int MinErasePadBottom = 4;
 
+    /// <summary>Every line a patch has to erase, from the blocks the window is drawing.</summary>
+    /// <remarks>
+    /// All of them, not only the block whose patch is being built. A patch is a fresh copy of the
+    /// picture under it, so a line reaching into it that is left alone is reprinted over the repair
+    /// its own block's patch made — and lines do reach into each other's patches, because each patch
+    /// is grown by a guard margin and a Latin detection box is tall enough to overlap its neighbour
+    /// before that. Two stacked English subtitle lines measured 765..835 and 827..901: the lower
+    /// patch begins above the upper line's baseline and used to reprint the bottom half of it.
+    ///
+    /// Blocks with nothing translated are left out. Nothing was drawn over them, so their text is
+    /// still on screen to be read, and erasing the part of it that falls in someone else's patch
+    /// would rub out half a line the user can still read the rest of.
+    /// </remarks>
+    public static IReadOnlyList<WpfRect> EraseTargets(IReadOnlyList<TranslatedBlock> blocks) =>
+    [
+        .. blocks
+            .Where(block => !string.IsNullOrWhiteSpace(block.TranslatedText))
+            .SelectMany(block => (block.SourceLineBounds is { Count: > 0 } lines ? lines : [block.Bounds])
+                .Select(line => GlyphBounds(line, block.SourceGlyphHeight)))
+    ];
+
+    /// <summary>The part of a line rectangle its glyphs actually occupy.</summary>
+    /// <remarks>
+    /// A Latin source keeps the detector's box unshrunk, because the translation drawn over it is
+    /// sized to cover the taller original glyphs; only the glyph height travels separately. Erasing
+    /// that whole box is what this is for. Measured over the English subtitle corpus, at the size
+    /// realtime reads a subtitle strip at, the box is 66–125px tall for glyphs of 33–49px — so the
+    /// repair was being asked to invent a strip three times the height of the text it replaced, and
+    /// interpolating that far turns whatever the line sits on into one smeared band.
+    ///
+    /// Centred, because the box is concentric with the text: over the same corpus the box's vertical
+    /// centre and that of the same line read as CJK — which does shrink its box — agreed to within
+    /// half a pixel on every line, while the widths were identical. The looseness is in height only,
+    /// and it is symmetric.
+    ///
+    /// The padding <see cref="EraseSourceText"/> adds is what covers the rest: an outline, an
+    /// ascender, the antialiasing around them.
+    /// </remarks>
+    public static WpfRect GlyphBounds(WpfRect line, double? glyphHeight)
+    {
+        if (glyphHeight is not { } height || height <= 0 || height >= line.Height)
+            return line;
+
+        double top = line.Y + (line.Height - height) / 2;
+        double bottom = Math.Min(line.Bottom, top + height * (1 + DescenderAllowance));
+        return new WpfRect(line.X, top, line.Width, bottom - top);
+    }
+
+    /// <summary>How much further down than its glyph height a Latin line reaches, as a fraction.</summary>
+    /// <remarks>
+    /// The glyph height is measured from the line's average pitch, which is the body of the text: it
+    /// does not know about the tail of a g, j, p, q or y, nor about the outline drawn around it. Left
+    /// out, that tail is not merely missed — the row band is read from immediately below the strip,
+    /// so the band lands ON the tail, and a stroke a few pixels wide is drawn the height of the fill
+    /// as a black column. It is the most visible way this repair fails on English subtitles.
+    ///
+    /// Swept over the English corpus at 0.00/0.15/0.20/0.25/0.30/0.35/0.50 and read off the repaired
+    /// frames: the columns are obvious to 0.20, faint at 0.25, and gone at 0.30 on every frame that
+    /// had a descender. Above that nothing improves and the strip only invents more of the picture.
+    ///
+    /// Latin only, because it applies to a rectangle that carries a glyph height, and CJK does not —
+    /// its box already sits on its glyphs, which have no descender to reach past it.
+    /// </remarks>
+    private const double DescenderAllowance = 0.30;
+
+    /// <param name="sourceLineBounds">
+    /// Every line to erase out of this patch, as the rectangles its glyphs occupy — see
+    /// <see cref="GlyphBounds"/>. Lines belonging to neighbouring blocks count: a patch is a copy of
+    /// the picture, so any line reaching into it that is left alone is reprinted over whatever
+    /// repaired it.
+    /// </param>
     public static Bitmap? CreatePatch(
         Bitmap frame,
         Rectangle patchBounds,

--- a/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
@@ -113,17 +113,27 @@ internal static class RealtimeNaturalBackground
         if (clippedPatch.Width <= 0 || clippedPatch.Height <= 0)
             return null;
 
+        var sources = new Rectangle[sourceLineBounds.Count];
+        for (int i = 0; i < sourceLineBounds.Count; i++)
+            sources[i] = Rectangle.FromLTRB(
+                (int)Math.Floor(sourceLineBounds[i].Left),
+                (int)Math.Floor(sourceLineBounds[i].Top),
+                (int)Math.Ceiling(sourceLineBounds[i].Right),
+                (int)Math.Ceiling(sourceLineBounds[i].Bottom));
+
+        var work = Rectangle.Intersect(frameBounds, WorkingArea(clippedPatch, sources));
+
         Bitmap patch;
         try
         {
-            patch = frame.Clone(clippedPatch, PixelFormat.Format32bppArgb);
+            patch = frame.Clone(work, PixelFormat.Format32bppArgb);
         }
         catch
         {
             return null;
         }
 
-        if (sourceLineBounds.Count == 0)
+        if (sources.Length == 0)
             return patch;
 
         // One lock and one copy each way for the whole patch, however many lines are erased into it.
@@ -142,14 +152,9 @@ internal static class RealtimeNaturalBackground
             for (int y = 0; y < patch.Height; y++)
                 Marshal.Copy(IntPtr.Add(data.Scan0, y * data.Stride), pixels, y * stride, stride);
 
-            foreach (var source in sourceLineBounds)
+            foreach (var source in sources)
             {
-                var local = Rectangle.FromLTRB(
-                    (int)Math.Floor(source.Left) - clippedPatch.Left,
-                    (int)Math.Floor(source.Top) - clippedPatch.Top,
-                    (int)Math.Ceiling(source.Right) - clippedPatch.Left,
-                    (int)Math.Ceiling(source.Bottom) - clippedPatch.Top);
-
+                var local = source with { X = source.X - work.X, Y = source.Y - work.Y };
                 EraseSourceText(pixels, stride, patch.Width, patch.Height, local);
             }
 
@@ -161,7 +166,54 @@ internal static class RealtimeNaturalBackground
             patch.UnlockBits(data);
         }
 
-        return patch;
+        if (work == clippedPatch)
+            return patch;
+
+        using (patch)
+        {
+            var inside = new Rectangle(
+                clippedPatch.X - work.X, clippedPatch.Y - work.Y, clippedPatch.Width, clippedPatch.Height);
+            try
+            {
+                return patch.Clone(inside, PixelFormat.Format32bppArgb);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The area the repair is carried out in: the patch, grown to hold whole every line that reaches
+    /// into it.
+    /// </summary>
+    /// <remarks>
+    /// A patch is a crop of the picture, and a fill cut off by the edge of one is not the same fill:
+    /// with no rows beyond the cut to read, <see cref="EraseSourceText"/> falls back to extending the
+    /// one edge it has, which paints a flat block. Two patches that overlap then disagree about the
+    /// line they share, and the one painted second leaves its version behind as a rectangle with a
+    /// visible edge — the seam between two stacked subtitle lines.
+    ///
+    /// Repairing in an area that contains the whole line makes the fill for a line the same wherever
+    /// it is drawn, because it is computed from the same pixels either way. The patch itself is cut
+    /// out of the result afterwards.
+    /// </remarks>
+    private static Rectangle WorkingArea(Rectangle patch, IReadOnlyList<Rectangle> sources)
+    {
+        var work = patch;
+
+        foreach (var source in sources)
+        {
+            var area = ErasedArea(source);
+            if (!area.IntersectsWith(patch)) continue;
+
+            // The row above and below, and the column either side: what the fill is read from.
+            area.Inflate(1, 1);
+            work = Rectangle.Union(work, area);
+        }
+
+        return work;
     }
 
     /// <summary>
@@ -240,6 +292,21 @@ internal static class RealtimeNaturalBackground
         return OverlayTextColor.Tune(sampled, background);
     }
 
+    /// <summary>The area a line's fill covers: its glyphs, and the padding this repair adds.</summary>
+    private static Rectangle ErasedArea(Rectangle source)
+    {
+        int heightBasis = Math.Clamp(source.Height, 12, 72);
+        int padX = Math.Max(MinErasePadX, (int)Math.Ceiling(heightBasis * 0.16));
+        int padTop = Math.Max(MinErasePadTop, (int)Math.Ceiling(heightBasis * 0.34));
+        int padBottom = Math.Max(MinErasePadBottom, (int)Math.Ceiling(heightBasis * 0.16));
+
+        return Rectangle.FromLTRB(
+            source.Left - padX,
+            source.Top - padTop,
+            source.Right + padX,
+            source.Bottom + padBottom);
+    }
+
     /// <summary>
     /// Fills one source line's rectangle with colour interpolated from its surroundings.
     /// </summary>
@@ -250,17 +317,7 @@ internal static class RealtimeNaturalBackground
     /// </remarks>
     private static void EraseSourceText(byte[] pixels, int stride, int width, int height, Rectangle source)
     {
-        int heightBasis = Math.Clamp(source.Height, 12, 72);
-        int padX = Math.Max(MinErasePadX, (int)Math.Ceiling(heightBasis * 0.16));
-        int padTop = Math.Max(MinErasePadTop, (int)Math.Ceiling(heightBasis * 0.34));
-        int padBottom = Math.Max(MinErasePadBottom, (int)Math.Ceiling(heightBasis * 0.16));
-
-        var expanded = Rectangle.FromLTRB(
-            source.Left - padX,
-            source.Top - padTop,
-            source.Right + padX,
-            source.Bottom + padBottom);
-        var rect = Rectangle.Intersect(new Rectangle(0, 0, width, height), expanded);
+        var rect = Rectangle.Intersect(new Rectangle(0, 0, width, height), ErasedArea(source));
         if (rect.Width <= 0 || rect.Height <= 0) return;
 
         bool hasTopBottom = rect.Top > 0 && rect.Bottom < height;

--- a/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
@@ -208,8 +208,8 @@ internal static class RealtimeNaturalBackground
             var area = ErasedArea(source);
             if (!area.IntersectsWith(patch)) continue;
 
-            // The row above and below, and the column either side: what the fill is read from.
-            area.Inflate(1, 1);
+            // The rows and columns the fill is read from, which is as deep as one band goes.
+            area.Inflate(BandDepth, BandDepth);
             work = Rectangle.Union(work, area);
         }
 
@@ -311,81 +311,188 @@ internal static class RealtimeNaturalBackground
     /// Fills one source line's rectangle with colour interpolated from its surroundings.
     /// </summary>
     /// <remarks>
-    /// Reads only outside the rectangle it writes: the row above and below, or the column either
-    /// side, or the ring around it. That is what lets several lines share one buffer — there is no
-    /// order in which one line's fill can be read as though it were the picture underneath.
+    /// Reads only outside the rectangle it writes, and reads all of it before writing any of it.
+    /// That is what lets several lines share one buffer — there is no order in which one line's
+    /// fill can be read as though it were the picture underneath.
     /// </remarks>
     private static void EraseSourceText(byte[] pixels, int stride, int width, int height, Rectangle source)
     {
         var rect = Rectangle.Intersect(new Rectangle(0, 0, width, height), ErasedArea(source));
         if (rect.Width <= 0 || rect.Height <= 0) return;
 
-        bool hasTopBottom = rect.Top > 0 && rect.Bottom < height;
-        bool hasLeftRight = rect.Left > 0 && rect.Right < width;
+        var above = rect.Top > 0 ? RowBand(pixels, stride, height, rect, above: true) : null;
+        var below = rect.Bottom < height ? RowBand(pixels, stride, height, rect, above: false) : null;
 
-        if (hasTopBottom)
+        // Interpolating between two real edges beats extending one of them, whichever axis it is on,
+        // so both two-sided cases are tried before either one-sided one. A line rect is wide and
+        // short, which is why the rows come first: reaching across its width from a single column
+        // either side is a smear the length of the sentence.
+        if (above is not null && below is not null)
         {
-            int topRow = (rect.Top - 1) * stride;
-            int bottomRow = rect.Bottom * stride;
+            FillFromRows(pixels, stride, rect, above, below);
+            return;
+        }
 
-            for (int y = rect.Top; y < rect.Bottom; y++)
+        var left = rect.Left > 0 ? ColumnBand(pixels, stride, width, rect, left: true) : null;
+        var right = rect.Right < width ? ColumnBand(pixels, stride, width, rect, left: false) : null;
+
+        if (left is not null && right is not null)
+        {
+            FillFromColumns(pixels, stride, rect, left, right);
+            return;
+        }
+
+        if (above is not null || below is not null)
+        {
+            FillFromRows(pixels, stride, rect, above, below);
+            return;
+        }
+
+        if (left is not null || right is not null)
+        {
+            FillFromColumns(pixels, stride, rect, left, right);
+            return;
+        }
+
+        // Nothing outside the rectangle is left to read from, so there is nothing to interpolate.
+        // Taken before anything is written, which is also why it can read the same buffer: every
+        // pixel it averages lies outside the rectangle about to be filled.
+        var fill = BorderAverage(pixels, stride, width, height, rect);
+
+        for (int y = rect.Top; y < rect.Bottom; y++)
+        {
+            int row = y * stride;
+            for (int x = rect.Left; x < rect.Right; x++)
             {
-                double t = (y - rect.Top + 1.0) / (rect.Height + 1.0);
-                int dstRow = y * stride;
-
-                for (int x = rect.Left; x < rect.Right; x++)
-                {
-                    int dst = dstRow + x * 4;
-                    int a = topRow + x * 4;
-                    int b = bottomRow + x * 4;
-                    pixels[dst] = Lerp(pixels[a], pixels[b], t);
-                    pixels[dst + 1] = Lerp(pixels[a + 1], pixels[b + 1], t);
-                    pixels[dst + 2] = Lerp(pixels[a + 2], pixels[b + 2], t);
-                    pixels[dst + 3] = 255;
-                }
+                int dst = row + x * 4;
+                pixels[dst] = fill.B;
+                pixels[dst + 1] = fill.G;
+                pixels[dst + 2] = fill.R;
+                pixels[dst + 3] = 255;
             }
         }
-        else if (hasLeftRight)
+    }
+
+    /// <summary>How deep, in rows or columns, one edge of the rectangle is read.</summary>
+    /// <remarks>
+    /// Three, reduced to their median rather than averaged. The padding around a line is sized for
+    /// the glyph body, so an outline, a shadow or a Japanese mark can still reach the first row
+    /// outside it — and one lit pixel there, carried the whole height of the fill, is a bright line
+    /// down the middle of the repair. A median discards that row's value as long as the other two
+    /// agree, so the line is never drawn in the first place. An average would not: it would let the
+    /// stray pixel through at a third of its strength, which is a fainter line, not no line.
+    ///
+    /// It costs nothing in sharpness, which is what separates it from spreading the band sideways —
+    /// the other half of the attempt this came from, and the half that made repairs visibly blurry.
+    ///
+    /// Three exactly: <see cref="Median"/> is written for three and nothing else.
+    /// </remarks>
+    private const int BandDepth = 3;
+
+    /// <summary>The rows above or below the rectangle, reduced to one B,G,R per column of it.</summary>
+    private static byte[] RowBand(byte[] pixels, int stride, int height, Rectangle rect, bool above)
+    {
+        var band = new byte[rect.Width * 3];
+        var samples = new byte[BandDepth];
+
+        for (int i = 0; i < rect.Width; i++)
         {
-            int leftX = rect.Left - 1;
-            int rightX = rect.Right;
-
-            for (int y = rect.Top; y < rect.Bottom; y++)
+            int x = rect.Left + i;
+            for (int channel = 0; channel < 3; channel++)
             {
-                int row = y * stride;
-                int left = row + leftX * 4;
-                int right = row + rightX * 4;
-
-                for (int x = rect.Left; x < rect.Right; x++)
+                for (int depth = 0; depth < BandDepth; depth++)
                 {
-                    double t = (x - rect.Left + 1.0) / (rect.Width + 1.0);
-                    int dst = row + x * 4;
-                    pixels[dst] = Lerp(pixels[left], pixels[right], t);
-                    pixels[dst + 1] = Lerp(pixels[left + 1], pixels[right + 1], t);
-                    pixels[dst + 2] = Lerp(pixels[left + 2], pixels[right + 2], t);
-                    pixels[dst + 3] = 255;
+                    int y = Math.Clamp(above ? rect.Top - 1 - depth : rect.Bottom + depth, 0, height - 1);
+                    samples[depth] = pixels[y * stride + x * 4 + channel];
                 }
+
+                band[i * 3 + channel] = Median(samples);
             }
         }
-        else
-        {
-            // Taken before anything is written, which is also why it can read the same buffer: every
-            // pixel it averages lies outside the rectangle about to be filled.
-            var fill = BorderAverage(pixels, stride, width, height, rect);
 
-            for (int y = rect.Top; y < rect.Bottom; y++)
+        return band;
+    }
+
+    /// <summary>The columns left or right of the rectangle, reduced to one B,G,R per row of it.</summary>
+    private static byte[] ColumnBand(byte[] pixels, int stride, int width, Rectangle rect, bool left)
+    {
+        var band = new byte[rect.Height * 3];
+        var samples = new byte[BandDepth];
+
+        for (int i = 0; i < rect.Height; i++)
+        {
+            int row = (rect.Top + i) * stride;
+            for (int channel = 0; channel < 3; channel++)
             {
-                int row = y * stride;
-                for (int x = rect.Left; x < rect.Right; x++)
+                for (int depth = 0; depth < BandDepth; depth++)
                 {
-                    int dst = row + x * 4;
-                    pixels[dst] = fill.B;
-                    pixels[dst + 1] = fill.G;
-                    pixels[dst + 2] = fill.R;
-                    pixels[dst + 3] = 255;
+                    int x = Math.Clamp(left ? rect.Left - 1 - depth : rect.Right + depth, 0, width - 1);
+                    samples[depth] = pixels[row + x * 4 + channel];
                 }
+
+                band[i * 3 + channel] = Median(samples);
             }
         }
+
+        return band;
+    }
+
+    private static void FillFromRows(byte[] pixels, int stride, Rectangle rect, byte[]? above, byte[]? below)
+    {
+        for (int y = rect.Top; y < rect.Bottom; y++)
+        {
+            double t = (y - rect.Top + 1.0) / (rect.Height + 1.0);
+            int row = y * stride;
+
+            for (int i = 0; i < rect.Width; i++)
+            {
+                int dst = row + (rect.Left + i) * 4;
+                int at = i * 3;
+
+                for (int channel = 0; channel < 3; channel++)
+                    pixels[dst + channel] = Blend(above, below, at + channel, t);
+
+                pixels[dst + 3] = 255;
+            }
+        }
+    }
+
+    private static void FillFromColumns(byte[] pixels, int stride, Rectangle rect, byte[]? left, byte[]? right)
+    {
+        for (int y = rect.Top; y < rect.Bottom; y++)
+        {
+            int row = y * stride;
+            int at = (y - rect.Top) * 3;
+
+            for (int x = rect.Left; x < rect.Right; x++)
+            {
+                double t = (x - rect.Left + 1.0) / (rect.Width + 1.0);
+                int dst = row + x * 4;
+
+                for (int channel = 0; channel < 3; channel++)
+                    pixels[dst + channel] = Blend(left, right, at + channel, t);
+
+                pixels[dst + 3] = 255;
+            }
+        }
+    }
+
+    /// <summary>
+    /// One channel of the fill: between the two edges where both exist, and the one that does where
+    /// only one does — the rectangle runs to the edge of the picture and there is nothing beyond it.
+    /// </summary>
+    private static byte Blend(byte[]? start, byte[]? end, int at, double t) =>
+        start is null ? end![at]
+        : end is null ? start[at]
+        : Lerp(start[at], end[at], t);
+
+    /// <summary>The middle of three, which is <see cref="BandDepth"/> and only that.</summary>
+    private static byte Median(byte[] samples)
+    {
+        byte a = samples[0], b = samples[1], c = samples[2];
+        return a > b
+            ? (b > c ? b : a > c ? c : a)
+            : (a > c ? a : b > c ? c : b);
     }
 
     private static GdiColor BorderAverage(

--- a/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
@@ -255,7 +255,7 @@ public partial class RealtimeBlockWindow : Window
             // nothing to follow, and recording one here would have the refresh below replace it with
             // a patch the user never asked for.
             if (_naturalBackground)
-                patches.Add(new NaturalPatchVisual(visual.Background, line, visual.PatchBounds));
+                patches.Add(new NaturalPatchVisual(visual.Background, visual.PatchBounds));
         }
 
         Volatile.Write(ref _naturalPatches, [.. patches]);
@@ -269,7 +269,7 @@ public partial class RealtimeBlockWindow : Window
         Border Background, Border Text, System.Drawing.Rectangle PatchBounds);
 
     private readonly record struct NaturalPatchVisual(
-        Border Surface, TranslatedBlock Line, System.Drawing.Rectangle PatchBounds);
+        Border Surface, System.Drawing.Rectangle PatchBounds);
 
     private LineVisual? BuildLine(
         TranslatedBlock line, double canvasWidth, double canvasHeight, System.Drawing.Bitmap? frame)
@@ -412,7 +412,7 @@ public partial class RealtimeBlockWindow : Window
             double guardHeight = Math.Max(0, guardBottom - guardTop);
 
             naturalBrush = BuildNaturalBrush(
-                frame, line, ToPhysicalPatchBounds(guardLeft, guardTop, guardWidth, guardHeight));
+                frame, ToPhysicalPatchBounds(guardLeft, guardTop, guardWidth, guardHeight), _lines);
 
             // Capture can fail on protected/UAC surfaces. Keep the compact band in that case rather
             // than painting the much larger guard with a flat colour.
@@ -544,6 +544,7 @@ public partial class RealtimeBlockWindow : Window
             {
                 var generation = Volatile.Read(ref _patchGeneration);
                 var patches = Volatile.Read(ref _naturalPatches);
+                var blocks = _lines;
                 if (patches.Length == 0) continue;
 
                 using var frame = CaptureUnderlyingRegion();
@@ -559,7 +560,7 @@ public partial class RealtimeBlockWindow : Window
                 foreach (var patch in patches)
                 {
                     token.ThrowIfCancellationRequested();
-                    if (BuildNaturalBrush(frame, patch.Line, patch.PatchBounds) is { } brush)
+                    if (BuildNaturalBrush(frame, patch.PatchBounds, blocks) is { } brush)
                         repainted.Add((patch.Surface, brush));
                 }
 
@@ -642,18 +643,16 @@ public partial class RealtimeBlockWindow : Window
         return System.Drawing.Rectangle.FromLTRB(x1, y1, x2, y2);
     }
 
+    /// <param name="blocks">Every block this window draws — see RealtimeNaturalBackground.EraseTargets.</param>
     private static ImageBrush? BuildNaturalBrush(
         System.Drawing.Bitmap? frame,
-        TranslatedBlock line,
-        System.Drawing.Rectangle patchBounds)
+        System.Drawing.Rectangle patchBounds,
+        IReadOnlyList<TranslatedBlock> blocks)
     {
         if (frame is null || patchBounds.Width <= 0 || patchBounds.Height <= 0) return null;
 
-        var sourceLines = line.SourceLineBounds is { Count: > 0 } lines
-            ? lines
-            : (IReadOnlyList<System.Windows.Rect>)[line.Bounds];
-
-        using var patch = RealtimeNaturalBackground.CreatePatch(frame, patchBounds, sourceLines);
+        using var patch = RealtimeNaturalBackground.CreatePatch(
+            frame, patchBounds, RealtimeNaturalBackground.EraseTargets(blocks));
         if (patch is null) return null;
 
         var image = BitmapInterop.ToBitmapSource(patch);

--- a/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using OverTranslate.Services;
 using OverTranslate.Services.Realtime;
 using Xunit;
 
@@ -57,6 +58,90 @@ public class RealtimeNaturalBackgroundTests
         Assert.True(repairedMark.R < 100);
         Assert.True(repairedMark.G < 140);
         Assert.True(repairedMark.B < 120);
+    }
+
+    /// <summary>
+    /// A Latin line arrives as a box roughly three times the height of the text in it, with the
+    /// glyph height carried separately, so the repair must erase the glyphs and leave the rest of
+    /// the box as the picture it is.
+    /// </summary>
+    [Fact]
+    public void CreatePatch_ErasesTheGlyphsRatherThanTheWholeLooseLineBox()
+    {
+        using var frame = new Bitmap(160, 120);
+        for (int y = 0; y < frame.Height; y++)
+            for (int x = 0; x < frame.Width; x++)
+                frame.SetPixel(x, y, Color.FromArgb(255, 10 + y, 200 - y, 60 + y % 7 * 6));
+
+        using (var g = Graphics.FromImage(frame))
+        {
+            g.FillRectangle(Brushes.White, 40, 50, 80, 20);
+            // The tail of a g, which the glyph height does not account for.
+            g.FillRectangle(Brushes.White, 55, 70, 5, 7);
+        }
+
+        var looseBox = new System.Windows.Rect(40, 30, 80, 60);
+        var patchBounds = new Rectangle(20, 10, 120, 100);
+
+        using var patch = RealtimeNaturalBackground.CreatePatch(
+            frame, patchBounds, [RealtimeNaturalBackground.GlyphBounds(looseBox, 20)]);
+
+        Assert.NotNull(patch);
+
+        // The glyphs are gone, tail included — left behind, it is read as the picture below the
+        // line and drawn the height of the fill as a bright column.
+        var repaired = patch!.GetPixel(60 - 20, 60 - 10);
+        Assert.True(repaired.R < 200);
+
+        var repairedTail = patch.GetPixel(57 - 20, 74 - 10);
+        Assert.True(repairedTail.R < 200);
+
+        // The picture the box merely surrounded is still the picture, not part of the fill.
+        Assert.Equal(frame.GetPixel(60, 35), patch.GetPixel(60 - 20, 35 - 10));
+        Assert.Equal(frame.GetPixel(60, 85), patch.GetPixel(60 - 20, 85 - 10));
+    }
+
+    /// <summary>
+    /// Two stacked English subtitle lines, at the boxes they were measured at: each patch is a copy
+    /// of the picture and reaches over its neighbour, so a patch that erased only its own line put
+    /// half of the other one back.
+    /// </summary>
+    [Fact]
+    public void EraseTargets_CoverEveryTranslatedBlockRatherThanOnePatchesOwn()
+    {
+        var upper = new TranslatedBlock(
+            "like an explosive force", "像是一股爆炸力",
+            new System.Windows.Rect(300, 765, 569, 70), SourceGlyphHeight: 37);
+        var lower = new TranslatedBlock(
+            "hurtling into the sky!", "衝向天空！",
+            new System.Windows.Rect(310, 827, 542, 74), SourceGlyphHeight: 37);
+
+        var targets = RealtimeNaturalBackground.EraseTargets([upper, lower]);
+
+        Assert.Equal(2, targets.Count);
+        Assert.Contains(targets, rect => rect.Top < 790 && rect.Bottom > 810);   // the upper line
+        Assert.Contains(targets, rect => rect.Top < 852 && rect.Bottom > 872);   // the lower one
+    }
+
+    /// <summary>
+    /// A block with no translation drawn over it is still on screen to be read, so a neighbouring
+    /// patch must not rub out the part of it that happens to fall inside.
+    /// </summary>
+    [Fact]
+    public void EraseTargets_LeaveBlocksNothingWasDrawnOver()
+    {
+        var translated = new TranslatedBlock(
+            "like an explosive force", "像是一股爆炸力",
+            new System.Windows.Rect(300, 765, 569, 70), SourceGlyphHeight: 37);
+        var untranslated = new TranslatedBlock(
+            "hurtling into the sky!", "  ",
+            new System.Windows.Rect(310, 827, 542, 74), SourceGlyphHeight: 37);
+
+        var targets = RealtimeNaturalBackground.EraseTargets([translated, untranslated]);
+
+        Assert.Single(targets);
+        // The one that is left is the translated line's, inside its own box.
+        Assert.True(targets[0].Top >= 765 && targets[0].Bottom <= 835);
     }
 
     [Fact]

--- a/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
@@ -102,6 +102,37 @@ public class RealtimeNaturalBackgroundTests
     }
 
     /// <summary>
+    /// Two patches over the same line — one holding it whole, one cut across it — must repair it the
+    /// same way, or the one painted second leaves its own version behind as a visible rectangle.
+    /// </summary>
+    [Fact]
+    public void CreatePatch_RepairsALineTheSameWayWhicheverPatchItFallsIn()
+    {
+        using var frame = new Bitmap(200, 200);
+        for (int y = 0; y < frame.Height; y++)
+            for (int x = 0; x < frame.Width; x++)
+                frame.SetPixel(x, y, Color.FromArgb(255, 30 + y, 90 + x % 5 * 9, 150 - y / 2));
+
+        using (var g = Graphics.FromImage(frame))
+            g.FillRectangle(Brushes.White, 50, 95, 100, 16);
+
+        var line = new System.Windows.Rect(50, 95, 100, 16);
+
+        // The second patch stops halfway down the line, which is what a neighbouring block's patch
+        // does to it.
+        using var whole = RealtimeNaturalBackground.CreatePatch(frame, new Rectangle(40, 60, 120, 90), [line]);
+        using var cut = RealtimeNaturalBackground.CreatePatch(frame, new Rectangle(40, 103, 120, 60), [line]);
+
+        Assert.NotNull(whole);
+        Assert.NotNull(cut);
+
+        // The rows they share, read out of each: same picture or the seam is visible.
+        for (int y = 103; y < 150; y++)
+            for (int x = 45; x < 155; x++)
+                Assert.Equal(whole!.GetPixel(x - 40, y - 60), cut!.GetPixel(x - 40, y - 103));
+    }
+
+    /// <summary>
     /// Two stacked English subtitle lines, at the boxes they were measured at: each patch is a copy
     /// of the picture and reaches over its neighbour, so a patch that erased only its own line put
     /// half of the other one back.


### PR DESCRIPTION
即時翻譯「自然背景」在英文來源時的三個缺陷，各自獨立、按發現順序修正。日文來源不受影響。

## 1. 擦除框用的是寬鬆偵測框，不是字高

`OnnxOcrEngine.NormalizeBlock` 對兩種來源語言做不同的事，而分岔條件只看**使用者選的來源語言**：CJK 會把偵測框縮到字高並重新置中後寫回 `Bounds`；Latin 則保留寬鬆框（為了讓譯文氣泡蓋住較高的原文），只把字高另外放在 `SourceGlyphHeight`。修補拿到的是前者，於是英文來源時被要求無中生有一整條。

拿 `region-subtitle-en` 的 15 行實測，同一張圖只換來源語言：

| 來源語言 | 框高 | 字高 | 實際擦除高 |
|---|---|---|---|
| JA | 36–54 | — | 53–82 |
| EN | 66–125 | 33–49.5 | 100–162 |

擦除區是真實字高的 3.1 倍。新增 `GlyphBounds` 把行框收到字高、對框中心對齊——置中是量出來的：15 行的 EN 框中心與 JA 框中心誤差都在 0.5px 內，寬度完全相同，寬鬆只發生在高度且對稱。

另加 `DescenderAllowance = 0.30`：字高由字距推算，不含 `g j p q y` 的尾巴與外框黑邊；尾巴留在外面會讓邊帶取樣**讀在墨跡上**，再整條往上帶成一根黑柱。掃 0.00/0.15/0.20/0.25/0.30/0.35/0.50 讀修補後的實圖，0.30 是最小的乾淨值，再往上只是多編造畫面還會啃到鄰近物件。

## 2. 每塊 patch 只擦自己那一行

patch 是原圖的副本。兩行英文字幕的框本來就會重疊（實測 `765..835` 與 `827..901`），每塊 patch 又各自外加 guard，於是下面那塊把上面那行墨跡的下半段原封不動貼了回去，蓋掉上面那塊已修好的結果。

以前不會發生，是因為舊的擦除框夠大，順手把鄰行殘餘一起吃掉——是巧合掩蓋，不是本來就對。

新增 `EraseTargets`：一塊 patch 要擦掉視窗裡**所有已翻譯區塊**伸進它範圍的行。沒有譯文的區塊排除在外，那些原文還在畫面上讓使用者讀，擦掉一半更糟。

## 3. 被 patch 邊界切斷的行，修補結果會不一致

當某行的擦除區被 patch 邊界切斷，`EraseSourceText` 在切斷側找不到取樣列，退回單邊延伸，畫出一塊平坦色塊。兩塊重疊的 patch 對同一行算出不同答案，後畫的留下硬邊矩形——就是雙行之間那條接縫。

修補改在一個**包得住整行**的工作區進行（含 padding 與取樣列），完成後才裁出 patch 該有的範圍。同一行不論被畫進哪一塊 patch，都由同一批像素算出同一個結果。

## 4. 邊帶改讀三列取中位數

借鑒 `fix/realtime-natural-background` 分支，但**只取中位數邊帶，不含橫向平滑**——平滑是那次讓畫面變糊的原因，中位數不影響銳利度。單一列殘留筆畫不再被當成背景整條帶下去。實測最深的那些黑柱明顯變少變淡。

## 測試

523 過 / 0 失敗。四條新測試分別釘住：擦的是字（含下伸部）而非整個寬鬆框、框內其餘畫面逐像素保持原樣、鄰行也要擦、沒譯文的不要動、以及同一行在不同 patch 範圍下修補結果必須逐像素相同。每一條都在關掉對應修正後確認會失敗。最後那條在移植中位數邊帶時立刻抓到真的耦合（工作區外擴量必須跟著 `BandDepth` 走）。

## 已知未解

背景本身的垂直結構（草地、條紋牆、建築）被上下內插拉長成長條，仍然存在。那是這個修補方法的固有極限，不在本次範圍。
