### PR TITLE
feat: 即時翻譯編輯模式可暫停框選，工具列改為圖示

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -10,7 +10,6 @@
          Prefer the noun ("Shortcut", "Provider") over the sentence. -->
 
     <!-- ── Shared ── -->
-    <sys:String x:Key="S.Common.Edit">Edit</sys:String>
     <sys:String x:Key="S.Common.Reset">Reset</sys:String>
     <sys:String x:Key="S.Common.Close">Close</sys:String>
     <sys:String x:Key="S.Common.Configure">Configure</sys:String>
@@ -195,6 +194,10 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.Paused">Paused</sys:String>
     <sys:String x:Key="S.Realtime.Pause">Pause realtime translation</sys:String>
     <sys:String x:Key="S.Realtime.Resume">Resume realtime translation</sys:String>
+    <sys:String x:Key="S.Realtime.EditBlocks">Edit blocks</sys:String>
+    <sys:String x:Key="S.Realtime.CrosshairOff">Pause framing and use the app underneath</sys:String>
+    <sys:String x:Key="S.Realtime.CrosshairOn">Resume framing</sys:String>
+    <sys:String x:Key="S.Realtime.CrosshairOffHint">Framing paused — the app underneath takes the mouse</sys:String>
 
     <!-- Control bar and edit window messages -->
     <sys:String x:Key="S.Realtime.MovedToFront">Realtime windows brought to the front</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -7,7 +7,6 @@
          are composite formats consumed through LocalizationService.Format. -->
 
     <!-- ── Shared ── -->
-    <sys:String x:Key="S.Common.Edit">編輯</sys:String>
     <sys:String x:Key="S.Common.Reset">重設</sys:String>
     <sys:String x:Key="S.Common.Close">關閉</sys:String>
     <sys:String x:Key="S.Common.Configure">設定</sys:String>
@@ -207,6 +206,10 @@
     <sys:String x:Key="S.Realtime.Paused">已暫停</sys:String>
     <sys:String x:Key="S.Realtime.Pause">暫停即時翻譯</sys:String>
     <sys:String x:Key="S.Realtime.Resume">繼續即時翻譯</sys:String>
+    <sys:String x:Key="S.Realtime.EditBlocks">編輯翻譯區塊</sys:String>
+    <sys:String x:Key="S.Realtime.CrosshairOff">暫停框選，改為操作下方畫面</sys:String>
+    <sys:String x:Key="S.Realtime.CrosshairOn">恢復框選</sys:String>
+    <sys:String x:Key="S.Realtime.CrosshairOffHint">已暫停框選，可直接操作下方畫面</sys:String>
 
     <!-- Control bar and edit window messages -->
     <sys:String x:Key="S.Realtime.MovedToFront">已將即時翻譯視窗移至最上層</sys:String>

--- a/src/OverTranslate/Services/WindowStyles.cs
+++ b/src/OverTranslate/Services/WindowStyles.cs
@@ -59,6 +59,21 @@ internal static class WindowStyles
     }
 
     /// <summary>
+    /// Turns click-through on or off on a window that is already on screen, for a layer that has to
+    /// hand the mouse back to the application underneath and later take it again.
+    /// </summary>
+    /// <remarks>
+    /// WS_EX_LAYERED is only ever added, never taken away: it is also what AllowsTransparency renders
+    /// through, so clearing it along with the transparency bit would leave the layer unable to draw
+    /// itself at all.
+    /// </remarks>
+    public static void SetClickThrough(Window window, bool enabled)
+    {
+        if (enabled) Add(window, WS_EX_TRANSPARENT | WS_EX_LAYERED);
+        else Remove(window, WS_EX_TRANSPARENT);
+    }
+
+    /// <summary>
     /// Adds bits to the existing extended style rather than replacing it: WPF has already put its own
     /// there — WS_EX_TOOLWINDOW from ShowInTaskbar, WS_EX_LAYERED from AllowsTransparency — and
     /// overwriting them would undo settings made in XAML.
@@ -69,5 +84,14 @@ internal static class WindowStyles
         if (hwnd == IntPtr.Zero) return;
 
         SetWindowLong(hwnd, GWL_EXSTYLE, GetWindowLong(hwnd, GWL_EXSTYLE) | exStyle);
+    }
+
+    /// <summary>Clears bits from the extended style, leaving everything else where it was.</summary>
+    private static void Remove(Window window, int exStyle)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero) return;
+
+        SetWindowLong(hwnd, GWL_EXSTYLE, GetWindowLong(hwnd, GWL_EXSTYLE) & ~exStyle);
     }
 }

--- a/src/OverTranslate/Themes/DarkTheme.xaml
+++ b/src/OverTranslate/Themes/DarkTheme.xaml
@@ -71,6 +71,14 @@
     <!-- Toolbar specific -->
     <SolidColorBrush x:Key="ToolbarBg"         Color="#2A2A2A"/>
     <SolidColorBrush x:Key="ToolbarBorder"     Color="#484848"/>
+
+    <!-- The action group on the realtime edit bar: a slightly raised tray holding the two buttons the
+         user chooses between, so they read as one control rather than as more window furniture. Its
+         buttons need their own hover and pressed steps because the bar's are measured against the
+         bar, and against this tray they would be all but invisible. -->
+    <SolidColorBrush x:Key="ToolbarGroupBg"        Color="#363636"/>
+    <SolidColorBrush x:Key="ToolbarGroupHoverBg"   Color="#464646"/>
+    <SolidColorBrush x:Key="ToolbarGroupPressedBg" Color="#505050"/>
     <Color x:Key="ToolbarShadowColor"          >#000000</Color>
 
     <!-- Toast — same in both themes (always dark) -->

--- a/src/OverTranslate/Themes/LightTheme.xaml
+++ b/src/OverTranslate/Themes/LightTheme.xaml
@@ -68,6 +68,14 @@
     <!-- Toolbar specific -->
     <SolidColorBrush x:Key="ToolbarBg"         Color="#FAFAFA"/>
     <SolidColorBrush x:Key="ToolbarBorder"     Color="#D0D0D0"/>
+
+    <!-- The action group on the realtime edit bar: a slightly raised tray holding the two buttons the
+         user chooses between, so they read as one control rather than as more window furniture. Its
+         buttons need their own hover and pressed steps because the bar's are measured against the
+         bar, and against this tray they would be all but invisible. -->
+    <SolidColorBrush x:Key="ToolbarGroupBg"        Color="#EDEDED"/>
+    <SolidColorBrush x:Key="ToolbarGroupHoverBg"   Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="ToolbarGroupPressedBg" Color="#D4D4D4"/>
     <Color x:Key="ToolbarShadowColor"          >#000000</Color>
 
     <!-- Toast — same in both themes (always dark) -->

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1170,13 +1170,36 @@
         <Setter Property="FontSize"    Value="13"/>
     </Style>
 
-    <!-- A primary action reduced to its icon: same square as ToolbarIconButton so it sits in the row
-         without breaking its rhythm, but keeping the accent fill, because losing the label is not the
-         same as stepping down from being the one thing on the bar to press. -->
-    <Style x:Key="ToolbarAccentIconButton" TargetType="Button" BasedOn="{StaticResource ToolbarAccentButton}">
-        <Setter Property="Width"       Value="28"/>
-        <Setter Property="Height"      Value="28"/>
-        <Setter Property="Padding"     Value="0"/>
+    <!-- Icon buttons that sit inside a raised group tray rather than directly on the bar. Their
+         template is repeated rather than inherited for the same reason ToastIconButton repeats it:
+         BasedOn cannot reach the hover and pressed brushes named inside it, and against the tray the
+         bar's own steps are too close to its surface to be seen. -->
+    <Style x:Key="ToolbarGroupIconButton" TargetType="Button" BasedOn="{StaticResource ToolbarIconButton}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="7">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource ToolbarGroupHoverBg}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource ToolbarGroupPressedBg}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- The toast is dark in both themes, so its buttons need their own brushes rather than the

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1170,6 +1170,15 @@
         <Setter Property="FontSize"    Value="13"/>
     </Style>
 
+    <!-- A primary action reduced to its icon: same square as ToolbarIconButton so it sits in the row
+         without breaking its rhythm, but keeping the accent fill, because losing the label is not the
+         same as stepping down from being the one thing on the bar to press. -->
+    <Style x:Key="ToolbarAccentIconButton" TargetType="Button" BasedOn="{StaticResource ToolbarAccentButton}">
+        <Setter Property="Width"       Value="28"/>
+        <Setter Property="Height"      Value="28"/>
+        <Setter Property="Padding"     Value="0"/>
+    </Style>
+
     <!-- The toast is dark in both themes, so its buttons need their own brushes rather than the
          themed ones IconButton carries. Its template is repeated instead of inherited because
          BasedOn cannot reach the hover and pressed brushes named inside that template. -->

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
@@ -66,48 +66,66 @@
 
                     <Separator Style="{StaticResource VerticalSeparator}"/>
 
-                    <!-- Framing on or off, without leaving edit mode. The icon is what pressing it
-                         does, the same way the pause button works: while framing is on it shows a
-                         plain pointer — press to hand the mouse back to whatever is playing
-                         underneath — and while it is off it shows the crosshair it would bring back.
-                         Drawn as a Path rather than typed as an icon-font glyph because neither
-                         shape exists in Segoe Fluent Icons; a Path also has no font fallback to lose.
-                         Its stroke follows the button's own foreground so hover and theme changes
-                         reach it, which a hard-coded brush would not. -->
-                    <Button x:Name="CrosshairBtn"
-                            Style="{StaticResource ToolbarIconButton}"
-                            Margin="0,0,4,0"
-                            Click="CrosshairBtn_Click">
-                        <Path x:Name="CrosshairGlyph"
-                              Width="16" Height="16"
-                              Stretch="None"
-                              Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
-                              StrokeThickness="1.3"
-                              StrokeStartLineCap="Round"
-                              StrokeEndLineCap="Round"
-                              StrokeLineJoin="Round"/>
-                    </Button>
+                    <!-- The two buttons the user chooses between while framing, in a tray of their
+                         own: whether to keep drawing or to start translating is one decision, and
+                         set loose on the bar they read as two more pieces of furniture next to ✕.
+                         ✕ stays outside it — ending the session is not part of that decision. -->
+                    <Border Background="{DynamicResource ToolbarGroupBg}"
+                            CornerRadius="10"
+                            Padding="3"
+                            Margin="0,0,6,0">
+                        <StackPanel Orientation="Horizontal">
+                            <!-- Framing on or off, without leaving edit mode. A dashed marquee, which
+                                 is the shape the user has just been dragging out on screen — a
+                                 crosshair says "precision" without saying what it would do. Unlike
+                                 the pause button, this icon is the state rather than the action: the
+                                 marquee while framing is on, a plain pointer while the mouse belongs
+                                 to whatever is underneath. A toggle whose icon flipped to the other
+                                 mode would leave the bar showing a pointer at the exact moment the
+                                 screen is showing a marquee. The tooltip carries the action.
+                                 Drawn as a Path because neither shape exists in Segoe MDL2, which is
+                                 all Windows 10 has; a Path also has no font fallback to lose. Its
+                                 stroke follows the button's own foreground so hover and theme
+                                 changes reach it. -->
+                            <Button x:Name="CrosshairBtn"
+                                    Style="{StaticResource ToolbarGroupIconButton}"
+                                    Foreground="{DynamicResource AppTextPrimary}"
+                                    Margin="0,0,2,0"
+                                    Click="CrosshairBtn_Click">
+                                <Path x:Name="CrosshairGlyph"
+                                      Width="16" Height="16"
+                                      Stretch="None"
+                                      Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      StrokeThickness="1.3"
+                                      StrokeStartLineCap="Round"
+                                      StrokeEndLineCap="Round"
+                                      StrokeLineJoin="Round"/>
+                            </Button>
 
-                    <!-- Icon-only like the rest of the row, but still the accent one: it is the only
-                         thing on this bar the user is meant to press when they are done framing.
-                         A solid triangle, not the outline the pause button's resume state uses —
-                         white outline on a filled accent square reads thin, and the two are never on
-                         screen together to be confused. Drawn rather than typed for the same reason
-                         as the crosshair beside it: the solid play glyph (F5B0) only exists in Segoe
-                         Fluent Icons, which Windows 10 does not ship, and there it would fall back to
-                         MDL2 and come out as a missing-glyph box. The nose sits a touch right of the
-                         box's centre, where a triangle looks centred rather than measuring so. -->
-                    <Button x:Name="StartBtn"
-                            Style="{StaticResource ToolbarAccentIconButton}"
-                            Margin="0,0,4,0"
-                            ToolTip="{DynamicResource S.Realtime.StartTranslating}"
-                            AutomationProperties.Name="{DynamicResource S.Realtime.StartTranslating}"
-                            Click="StartBtn_Click">
-                        <Path Width="16" Height="16"
-                              Stretch="None"
-                              Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
-                              Data="M5.8,2.6 L13.4,8 L5.8,13.4 Z"/>
-                    </Button>
+                            <!-- The accent is carried by the glyph rather than by a filled pill: a
+                                 solid accent square in a row of quiet icons was the one thing on the
+                                 bar shouting, and this bar floats over whatever the user is actually
+                                 watching. Colour alone still makes it the only coloured thing here.
+                                 A solid triangle, not the outline the resume button uses — an
+                                 outline at 16px reads as a hollow shape rather than as play, and the
+                                 two are never on screen together. Drawn rather than typed because
+                                 the solid play glyph (F5B0) is Segoe Fluent Icons only, and on
+                                 Windows 10 it would fall back to MDL2 as a missing-glyph box. The
+                                 nose sits a touch right of centre, where a triangle looks centred
+                                 rather than measures so. -->
+                            <Button x:Name="StartBtn"
+                                    Style="{StaticResource ToolbarGroupIconButton}"
+                                    Foreground="{DynamicResource AppAccent}"
+                                    ToolTip="{DynamicResource S.Realtime.StartTranslating}"
+                                    AutomationProperties.Name="{DynamicResource S.Realtime.StartTranslating}"
+                                    Click="StartBtn_Click">
+                                <Path Width="16" Height="16"
+                                      Stretch="None"
+                                      Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      Data="M5.8,2.6 L13.4,8 L5.8,13.4 Z"/>
+                            </Button>
+                        </StackPanel>
+                    </Border>
 
                     <Button Content="✕"
                             Style="{StaticResource ToolbarIconButton}"

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
@@ -66,6 +66,28 @@
 
                     <Separator Style="{StaticResource VerticalSeparator}"/>
 
+                    <!-- Framing on or off, without leaving edit mode. The icon is what pressing it
+                         does, the same way the pause button works: while framing is on it shows a
+                         plain pointer — press to hand the mouse back to whatever is playing
+                         underneath — and while it is off it shows the crosshair it would bring back.
+                         Drawn as a Path rather than typed as an icon-font glyph because neither
+                         shape exists in Segoe Fluent Icons; a Path also has no font fallback to lose.
+                         Its stroke follows the button's own foreground so hover and theme changes
+                         reach it, which a hard-coded brush would not. -->
+                    <Button x:Name="CrosshairBtn"
+                            Style="{StaticResource ToolbarIconButton}"
+                            Margin="0,0,4,0"
+                            Click="CrosshairBtn_Click">
+                        <Path x:Name="CrosshairGlyph"
+                              Width="16" Height="16"
+                              Stretch="None"
+                              Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                              StrokeThickness="1.3"
+                              StrokeStartLineCap="Round"
+                              StrokeEndLineCap="Round"
+                              StrokeLineJoin="Round"/>
+                    </Button>
+
                     <Button x:Name="StartBtn"
                             Content="{DynamicResource S.Realtime.StartTranslating}"
                             Style="{StaticResource ToolbarAccentButton}"
@@ -162,9 +184,18 @@
                             AutomationProperties.Name="{DynamicResource S.Realtime.Pause}"
                             Click="PauseBtn_Click"/>
 
-                    <Button Content="{DynamicResource S.Common.Edit}"
-                            Style="{StaticResource ToolbarFlatButton}"
+                    <!-- Icon-only, like the two buttons either side of it: the capsule is meant to
+                         be read at a glance and one word set in a flat button among icons was the
+                         only thing on it drawing the eye. The pencil is the same one Windows uses
+                         for edit everywhere else, and the tooltip carries the word it replaced. -->
+                    <Button x:Name="EditBtn"
+                            Style="{StaticResource ToolbarIconButton}"
+                            FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                            FontSize="13"
+                            Content="&#xE70F;"
                             Margin="0,0,4,0"
+                            ToolTip="{DynamicResource S.Realtime.EditBlocks}"
+                            AutomationProperties.Name="{DynamicResource S.Realtime.EditBlocks}"
                             Click="EditBtn_Click"/>
 
                     <Button Content="✕"

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
@@ -88,11 +88,26 @@
                               StrokeLineJoin="Round"/>
                     </Button>
 
+                    <!-- Icon-only like the rest of the row, but still the accent one: it is the only
+                         thing on this bar the user is meant to press when they are done framing.
+                         A solid triangle, not the outline the pause button's resume state uses —
+                         white outline on a filled accent square reads thin, and the two are never on
+                         screen together to be confused. Drawn rather than typed for the same reason
+                         as the crosshair beside it: the solid play glyph (F5B0) only exists in Segoe
+                         Fluent Icons, which Windows 10 does not ship, and there it would fall back to
+                         MDL2 and come out as a missing-glyph box. The nose sits a touch right of the
+                         box's centre, where a triangle looks centred rather than measuring so. -->
                     <Button x:Name="StartBtn"
-                            Content="{DynamicResource S.Realtime.StartTranslating}"
-                            Style="{StaticResource ToolbarAccentButton}"
+                            Style="{StaticResource ToolbarAccentIconButton}"
                             Margin="0,0,4,0"
-                            Click="StartBtn_Click"/>
+                            ToolTip="{DynamicResource S.Realtime.StartTranslating}"
+                            AutomationProperties.Name="{DynamicResource S.Realtime.StartTranslating}"
+                            Click="StartBtn_Click">
+                        <Path Width="16" Height="16"
+                              Stretch="None"
+                              Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                              Data="M5.8,2.6 L13.4,8 L5.8,13.4 Z"/>
+                    </Button>
 
                     <Button Content="✕"
                             Style="{StaticResource ToolbarIconButton}"

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
@@ -75,14 +75,13 @@
                             Padding="3"
                             Margin="0,0,6,0">
                         <StackPanel Orientation="Horizontal">
-                            <!-- Framing on or off, without leaving edit mode. A dashed marquee, which
-                                 is the shape the user has just been dragging out on screen — a
-                                 crosshair says "precision" without saying what it would do. Unlike
-                                 the pause button, this icon is the state rather than the action: the
-                                 marquee while framing is on, a plain pointer while the mouse belongs
-                                 to whatever is underneath. A toggle whose icon flipped to the other
-                                 mode would leave the bar showing a pointer at the exact moment the
-                                 screen is showing a marquee. The tooltip carries the action.
+                            <!-- Framing on or off, without leaving edit mode. The icon is what
+                                 pressing it does, the same way the pause button works: a plain
+                                 pointer while framing is on — press to hand the mouse back to
+                                 whatever is playing underneath — and the dashed marquee it would
+                                 bring back while it is off. A marquee rather than a crosshair
+                                 because it is the shape the user drags out on screen; a crosshair
+                                 says "precision" without saying what it would do.
                                  Drawn as a Path because neither shape exists in Segoe MDL2, which is
                                  all Windows 10 has; a Path also has no font fallback to lose. Its
                                  stroke follows the button's own foreground so hover and theme

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
@@ -46,14 +46,29 @@ public partial class RealtimeControlWindow : Window
     private readonly DispatcherTimer _messageTimer;
 
     /// <summary>
-    /// The crosshair icon the button shows while framing is off, and the pointer it shows while
-    /// framing is on. Coordinates are in a 16×16 box drawn at its own size — see the Path in XAML.
+    /// The marquee the framing button shows while framing is on, and the pointer it shows while the
+    /// mouse belongs to whatever is underneath. Coordinates are in a 16×16 box drawn at its own size
+    /// — see the Path in XAML.
     /// </summary>
-    private const string CrosshairIcon =
-        "M8,1.6 V6.2 M8,9.8 V14.4 M1.6,8 H6.2 M9.8,8 H14.4 "
-        + "M4.6,8 A3.4,3.4 0 1 0 11.4,8 A3.4,3.4 0 1 0 4.6,8";
+    private const string MarqueeIcon =
+        "M4.5,2.5 H11.5 A2,2 0 0 1 13.5,4.5 V11.5 A2,2 0 0 1 11.5,13.5 "
+        + "H4.5 A2,2 0 0 1 2.5,11.5 V4.5 A2,2 0 0 1 4.5,2.5 Z";
 
     private const string PointerIcon = "M4.2,2.2 L4.2,12.9 L7,10.2 L8.9,14.4 L10.7,13.5 L8.9,9.6 L12.6,9.4 Z";
+
+    /// <summary>
+    /// Dash pattern for the marquee, in multiples of the stroke width. The same broken outline the
+    /// drag preview draws on screen, which is what makes the icon read as that gesture rather than
+    /// as a plain box.
+    /// </summary>
+    private static readonly DoubleCollection MarqueeDashes = Freeze([2.2, 1.8]);
+
+    private static DoubleCollection Freeze(double[] values)
+    {
+        var collection = new DoubleCollection(values);
+        collection.Freeze();
+        return collection;
+    }
 
     private RealtimeControlMode _mode = RealtimeControlMode.Edit;
     private static string EditHint => LocalizationService.Get("S.Realtime.EditHint");
@@ -399,8 +414,10 @@ public partial class RealtimeControlWindow : Window
 
     private void ApplyCrosshairButton()
     {
-        // The icon is the action, not the state — see the button's comment in XAML.
-        CrosshairGlyph.Data = Geometry.Parse(_crosshairEnabled ? PointerIcon : CrosshairIcon);
+        // The icon is the state, not the action — see the button's comment in XAML. The dashes go
+        // with the marquee and have to come off the pointer, which is one continuous outline.
+        CrosshairGlyph.Data = Geometry.Parse(_crosshairEnabled ? MarqueeIcon : PointerIcon);
+        CrosshairGlyph.StrokeDashArray = _crosshairEnabled ? MarqueeDashes : null;
 
         var label = LocalizationService.Get(
             _crosshairEnabled ? "S.Realtime.CrosshairOff" : "S.Realtime.CrosshairOn");

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
@@ -46,9 +46,8 @@ public partial class RealtimeControlWindow : Window
     private readonly DispatcherTimer _messageTimer;
 
     /// <summary>
-    /// The marquee the framing button shows while framing is on, and the pointer it shows while the
-    /// mouse belongs to whatever is underneath. Coordinates are in a 16×16 box drawn at its own size
-    /// — see the Path in XAML.
+    /// The marquee the framing button shows while framing is off, and the pointer it shows while it
+    /// is on. Coordinates are in a 16×16 box drawn at its own size — see the Path in XAML.
     /// </summary>
     private const string MarqueeIcon =
         "M4.5,2.5 H11.5 A2,2 0 0 1 13.5,4.5 V11.5 A2,2 0 0 1 11.5,13.5 "
@@ -414,10 +413,10 @@ public partial class RealtimeControlWindow : Window
 
     private void ApplyCrosshairButton()
     {
-        // The icon is the state, not the action — see the button's comment in XAML. The dashes go
+        // The icon is the action, not the state — see the button's comment in XAML. The dashes go
         // with the marquee and have to come off the pointer, which is one continuous outline.
-        CrosshairGlyph.Data = Geometry.Parse(_crosshairEnabled ? MarqueeIcon : PointerIcon);
-        CrosshairGlyph.StrokeDashArray = _crosshairEnabled ? MarqueeDashes : null;
+        CrosshairGlyph.Data = Geometry.Parse(_crosshairEnabled ? PointerIcon : MarqueeIcon);
+        CrosshairGlyph.StrokeDashArray = _crosshairEnabled ? null : MarqueeDashes;
 
         var label = LocalizationService.Get(
             _crosshairEnabled ? "S.Realtime.CrosshairOff" : "S.Realtime.CrosshairOn");

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
@@ -45,8 +45,22 @@ public partial class RealtimeControlWindow : Window
     private readonly System.Drawing.Rectangle _screenBounds;
     private readonly DispatcherTimer _messageTimer;
 
+    /// <summary>
+    /// The crosshair icon the button shows while framing is off, and the pointer it shows while
+    /// framing is on. Coordinates are in a 16×16 box drawn at its own size — see the Path in XAML.
+    /// </summary>
+    private const string CrosshairIcon =
+        "M8,1.6 V6.2 M8,9.8 V14.4 M1.6,8 H6.2 M9.8,8 H14.4 "
+        + "M4.6,8 A3.4,3.4 0 1 0 11.4,8 A3.4,3.4 0 1 0 4.6,8";
+
+    private const string PointerIcon = "M4.2,2.2 L4.2,12.9 L7,10.2 L8.9,14.4 L10.7,13.5 L8.9,9.6 L12.6,9.4 Z";
+
     private RealtimeControlMode _mode = RealtimeControlMode.Edit;
     private static string EditHint => LocalizationService.Get("S.Realtime.EditHint");
+    // Stands in for the framing instruction while framing is off, because that instruction is then
+    // wrong: dragging does nothing, and a bar still telling the user to drag reads as the layer
+    // having broken rather than as a state they asked for.
+    private static string CrosshairOffHint => LocalizationService.Get("S.Realtime.CrosshairOffHint");
     // What the capsule says before SetLanguages has named the pair. A transient message borrows the
     // same slot and RestoreText brings whichever of the two applies back.
     private static string RunStatus => LocalizationService.Get("S.Realtime.Running");
@@ -56,6 +70,10 @@ public partial class RealtimeControlWindow : Window
     private static string PausedStatus => LocalizationService.Get("S.Realtime.Paused");
     private bool _hasLanguages;
     private bool _isPaused;
+
+    // Whether the edit layer is still taking the mouse. Owned here rather than by the layer: the
+    // button that changes it lives on this bar, and the bar has to say so in its own hint text.
+    private bool _crosshairEnabled = true;
 
     // Whether a message is standing in for the bar's own text. Kept explicitly rather than read off
     // the timer, which stopped being the same question once a message could be sticky: a sticky one
@@ -88,6 +106,7 @@ public partial class RealtimeControlWindow : Window
 
         _screenBounds = screenBounds;
         ApplyPauseButton();
+        ApplyCrosshairButton();
         RestoreText();
 
         _messageTimer = new DispatcherTimer { Interval = MessageDuration };
@@ -131,6 +150,12 @@ public partial class RealtimeControlWindow : Window
     public event EventHandler? EditRequested;
     public event EventHandler? CloseRequested;
     public event EventHandler? PauseToggleRequested;
+
+    /// <summary>
+    /// Raised with the state framing should be in from now on: true to take the mouse back for
+    /// drawing blocks, false to hand it to whatever is underneath.
+    /// </summary>
+    public event EventHandler<bool>? CrosshairToggleRequested;
 
     protected override void OnSourceInitialized(EventArgs e)
     {
@@ -252,6 +277,12 @@ public partial class RealtimeControlWindow : Window
         _isPaused = false;
         ApplyPauseButton();
 
+        // Every trip into edit mode starts with the crosshair, whatever the last one ended on: the
+        // layer is rebuilt each time, so it opens taking the mouse, and the user pressed 編輯
+        // because they came to draw. Off is the temporary state, not the one to inherit.
+        _crosshairEnabled = true;
+        ApplyCrosshairButton();
+
         _messageTimer.Stop();
         RestoreText();
         SetBusy(false);
@@ -333,7 +364,7 @@ public partial class RealtimeControlWindow : Window
     private void RestoreText()
     {
         _messageShowing = false;
-        EditHintText.Text = EditHint;
+        EditHintText.Text = _crosshairEnabled ? EditHint : CrosshairOffHint;
 
         RunStatusText.Text = _isPaused ? PausedStatus : RunStatus;
 
@@ -364,6 +395,17 @@ public partial class RealtimeControlWindow : Window
         PauseBtn.ToolTip = RealtimePauseHint.ForControlTooltip(RealtimePauseHint.CurrentHotkey, _isPaused);
         System.Windows.Automation.AutomationProperties.SetName(
             PauseBtn, LocalizationService.Get(_isPaused ? "S.Realtime.Resume" : "S.Realtime.Pause"));
+    }
+
+    private void ApplyCrosshairButton()
+    {
+        // The icon is the action, not the state — see the button's comment in XAML.
+        CrosshairGlyph.Data = Geometry.Parse(_crosshairEnabled ? PointerIcon : CrosshairIcon);
+
+        var label = LocalizationService.Get(
+            _crosshairEnabled ? "S.Realtime.CrosshairOff" : "S.Realtime.CrosshairOn");
+        CrosshairBtn.ToolTip = label;
+        System.Windows.Automation.AutomationProperties.SetName(CrosshairBtn, label);
     }
 
     // ── Placement and dragging ───────────────────────────────────────────────────────────────────
@@ -454,6 +496,19 @@ public partial class RealtimeControlWindow : Window
     private void EditBtn_Click(object sender, RoutedEventArgs e) => EditRequested?.Invoke(this, EventArgs.Empty);
 
     private void PauseBtn_Click(object sender, RoutedEventArgs e) => PauseToggleRequested?.Invoke(this, EventArgs.Empty);
+
+    private void CrosshairBtn_Click(object sender, RoutedEventArgs e)
+    {
+        _crosshairEnabled = !_crosshairEnabled;
+        ApplyCrosshairButton();
+
+        // A message from before the toggle was answering something else, and the hint underneath it
+        // has just changed — the same reason SetPaused drops one.
+        _messageTimer.Stop();
+        RestoreText();
+
+        CrosshairToggleRequested?.Invoke(this, _crosshairEnabled);
+    }
 
     private void CloseBtn_Click(object sender, RoutedEventArgs e) => CloseRequested?.Invoke(this, EventArgs.Empty);
 }

--- a/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeEditWindow.xaml.cs
@@ -21,8 +21,9 @@ namespace OverTranslate.Views.Realtime;
 
 /// <summary>
 /// Edit mode: a transparent layer over one screen on which the user draws, moves and resizes the
-/// areas to watch. Interactive for as long as it exists — the click-through, drawing half of the
-/// feature is <see cref="RealtimeBlockWindow"/>, and the two are never on screen together.
+/// areas to watch. Interactive unless framing is switched off — see
+/// <see cref="SetCrosshairEnabled"/>; the click-through, drawing half of the feature is
+/// <see cref="RealtimeBlockWindow"/>, and the two are never on screen together.
 /// </summary>
 /// <remarks>
 /// The window never takes activation (WS_EX_NOACTIVATE). Dragging a block out over a running game
@@ -134,6 +135,11 @@ public partial class RealtimeEditWindow : Window
     private Point _drawOrigin;
     private Shape? _drawPreview;
 
+    /// <summary>
+    /// Whether the layer is taking the mouse. See <see cref="SetCrosshairEnabled"/>.
+    /// </summary>
+    private bool _crosshairEnabled = true;
+
     public RealtimeEditWindow(
         System.Drawing.Rectangle physBounds,
         IReadOnlyList<RealtimeBlockPlacement> initialBlocks,
@@ -164,6 +170,40 @@ public partial class RealtimeEditWindow : Window
 
             RaiseBlocksChanged();
         };
+    }
+
+    /// <summary>
+    /// Turns framing off without leaving edit mode: no crosshair, no drawing, and every click lands
+    /// on whatever is playing underneath instead of on this layer.
+    /// </summary>
+    /// <remarks>
+    /// Done with the window style rather than by swapping the cursor, because the cursor was never
+    /// the whole complaint. This layer covers the entire screen and swallows every click on it, so
+    /// while it is up the user cannot touch the thing they are framing — pause the video, scrub back
+    /// to the line they want, answer the game. The only way out was to start translating and come
+    /// back, which throws away nothing but costs a round trip through both other modes.
+    ///
+    /// The blocks stay on screen while it is off: they are what the user is coming back to adjust,
+    /// and a layer that emptied itself would read as having lost them. Their own handles go inert
+    /// along with everything else, which is the point — nothing on this layer answers the mouse
+    /// until framing is turned back on.
+    ///
+    /// The control bar is unaffected: it is its own window, owned by this one rather than drawn on
+    /// it, so it keeps taking clicks and stays the way back.
+    /// </remarks>
+    public void SetCrosshairEnabled(bool enabled)
+    {
+        if (_crosshairEnabled == enabled) return;
+
+        _crosshairEnabled = enabled;
+
+        // A drag cannot be in flight — the press that got here landed on the bar — but a capture
+        // left behind by a lost mouse-up owns every click on the screen, and handing the mouse to
+        // the application underneath while still holding one is the one state worth not entering.
+        AbandonDraw();
+
+        BlockCanvas.Cursor = enabled ? Cursors.Cross : Cursors.Arrow;
+        WindowStyles.SetClickThrough(this, !enabled);
     }
 
     /// <summary>Raised whenever a block is added, removed, moved or resized.</summary>

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -196,6 +196,10 @@ internal sealed class RealtimeSessionController
         control.EditRequested += (_, _) => EnterEditMode();
         control.CloseRequested += (_, _) => Stop();
         control.PauseToggleRequested += (_, _) => TogglePause();
+        // Wired here rather than in EnterEditMode, which runs again on every trip back into framing
+        // and would stack a fresh handler each time. The layer it talks to is whichever one is up:
+        // there is none while translating, and the button that raises this is not on screen then.
+        control.CrosshairToggleRequested += (_, enabled) => _edit?.SetCrosshairEnabled(enabled);
         _control = control;
         control.Show();
         RefreshOverlayHandles();


### PR DESCRIPTION
## 動機

進入編輯模式後，整個編輯圖層蓋住整個螢幕並吃掉所有點擊，十字準心沒辦法暫時關閉。想暫停影片、拉進度條、或回應遊戲，只能先「開始翻譯」再按「編輯」繞一圈回來。

## 內容

### 1. 框選開關（編輯模式列）

- 按下後編輯圖層加上 `WS_EX_TRANSPARENT`，滑鼠完全穿透到底下的影片／遊戲，但**不退出編輯模式**；已框好的區塊留在畫面上，只是連同把手一起變成不吃滑鼠。
- 浮動列是獨立視窗（owned by 編輯圖層），不受影響，仍然是回去的路。
- 圖示表示「按下去會變成什麼」，與暫停鍵一致：框選開啟中顯示箭頭游標，關閉後顯示虛線選取框。關閉期間提示文字改為「已暫停框選，可直接操作下方畫面」。
- 每次重新進入編輯模式一律回到框選開啟狀態。

### 2. 編輯列與膠囊列改為圖示

- 「開始翻譯」→ 藍色實心播放三角形，「編輯」→ 鉛筆圖示。
- 框選與開始兩顆收進一個圓角容器，讀起來是一組抉擇；✕ 留在容器外，結束工作階段不屬於那個抉擇。
- 新增 `ToolbarGroupBg` 系列色票與 `ToolbarGroupIconButton` 樣式：容器內的按鈕需要自己的 hover／pressed 階，原本那組是對著整條 bar 調的，疊在這個微微抬起的托盤上幾乎看不出來。

播放三角形與選取框都用 `Path` 繪製而非圖示字型：實心播放（F5B0）只存在於 Segoe Fluent Icons，而本專案 `SupportedOSPlatformVersion` 為 Windows 10 1809，在那裡會 fallback 成 MDL2 的缺字方框。

`S.Common.Edit` 因改為圖示後無人引用，依字串 parity 測試一併移除。

## 驗證

- 建置成功，523 個測試通過。
- 以拋棄式 WPF probe 離線 render 真正的 `RealtimeControlWindow`，確認深色／淺色主題下編輯列（兩種狀態）與翻譯中膠囊列的排版與配色。
- 滑鼠穿透行為需實機操作驗收。
