### PR TITLE
feat: 截圖翻譯工具列新增朗讀原文並重新設計按鈕區

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -98,6 +98,14 @@ Translation failed: {1}</sys:String>
     <sys:String x:Key="S.Toolbar.ShowTranslation">Show translation</sys:String>
     <sys:String x:Key="S.Toolbar.Screenshot">Screenshot</sys:String>
     <sys:String x:Key="S.Toolbar.OpenWindow">Open in window</sys:String>
+    <sys:String x:Key="S.Toolbar.Swap">Swap source and target languages</sys:String>
+    <sys:String x:Key="S.Toolbar.Close">End screenshot translation</sys:String>
+    <sys:String x:Key="S.Toolbar.Speak">Speak</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakStopLabel">Stop</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakHint">Read the recognised source text aloud</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakStop">Stop reading</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakAutomatic">Cannot read aloud while the source language is Automatic. Choose the actual language first.</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakNoText">No recognised text to read yet</sys:String>
     <sys:String x:Key="S.Toolbar.BackupBadge">⚡Backup {0}</sys:String>
     <sys:String x:Key="S.Toolbar.BackupTooltip">"{0}" could not translate everything, so "{1}" filled in the rest.
 Actually used this time: {2}</sys:String>
@@ -139,6 +147,8 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Main.CopiedSaveFailedBody">Copied to the clipboard, but could not be saved: {0}</sys:String>
     <sys:String x:Key="S.Main.CopyFailedTitle">Copy failed</sys:String>
     <sys:String x:Key="S.Main.CopyFailedBody">Could not copy the screenshot: {0}</sys:String>
+    <sys:String x:Key="S.Main.SpeakFailedTitle">Could not read aloud</sys:String>
+    <sys:String x:Key="S.Main.SpeakFailedBody">This text could not be read aloud: {0}</sys:String>
 
     <!-- ── Realtime translation ── -->
     <sys:String x:Key="S.Realtime.Title">Realtime translation</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -103,6 +103,16 @@
     <sys:String x:Key="S.Toolbar.ShowTranslation">顯示譯文</sys:String>
     <sys:String x:Key="S.Toolbar.Screenshot">截圖</sys:String>
     <sys:String x:Key="S.Toolbar.OpenWindow">開啟翻譯視窗</sys:String>
+    <sys:String x:Key="S.Toolbar.Swap">對調原文與譯文語言</sys:String>
+    <sys:String x:Key="S.Toolbar.Close">結束截圖翻譯</sys:String>
+    <sys:String x:Key="S.Toolbar.Speak">朗讀</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakStopLabel">停止</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakHint">朗讀辨識到的原文</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakStop">停止朗讀</sys:String>
+    <!-- 朗讀鈕在自動模式下是停用的，這句就是使用者唯一能得知原因的地方－－辨識可以在「自動」下進行，
+         因為它是對看得見的字形做選擇；聲音沒有東西可以看。 -->
+    <sys:String x:Key="S.Toolbar.SpeakAutomatic">原文語言為「自動」時無法朗讀，請先選擇實際的語言</sys:String>
+    <sys:String x:Key="S.Toolbar.SpeakNoText">尚未辨識到可朗讀的文字</sys:String>
     <sys:String x:Key="S.Toolbar.BackupBadge">⚡備援 {0}</sys:String>
     <sys:String x:Key="S.Toolbar.BackupTooltip">「{0}」未能完整翻譯，已由備援「{1}」進行部分翻譯。
 本次實際翻譯：{2}</sys:String>
@@ -145,6 +155,8 @@
     <sys:String x:Key="S.Main.CopiedSaveFailedBody">已複製到剪貼簿，但無法儲存到本機：{0}</sys:String>
     <sys:String x:Key="S.Main.CopyFailedTitle">複製失敗</sys:String>
     <sys:String x:Key="S.Main.CopyFailedBody">無法複製截圖：{0}</sys:String>
+    <sys:String x:Key="S.Main.SpeakFailedTitle">朗讀失敗</sys:String>
+    <sys:String x:Key="S.Main.SpeakFailedBody">無法朗讀這段文字：{0}</sys:String>
 
     <!-- ── Realtime translation ── -->
     <sys:String x:Key="S.Realtime.Title">即時翻譯</sys:String>

--- a/src/OverTranslate/Themes/DarkTheme.xaml
+++ b/src/OverTranslate/Themes/DarkTheme.xaml
@@ -25,9 +25,17 @@
     <SolidColorBrush x:Key="AppTextSecondary"  Color="#AAAAAA"/>
 
     <!-- Accent -->
-    <SolidColorBrush x:Key="AppAccent"         Color="#60CDFF"/>
+    <!-- A step deeper than the #60CDFF this used to be. The accent is filled into large flat areas
+         here — a switch track, a checked box — and a light colour spread over one reads lighter than
+         the same colour does as a word or as a hairline, so the on state came out looking washed
+         rather than on. One token rather than a second brush for the filled case: the places that
+         draw with it are the same places, and a second blue to keep in step with the first is the
+         kind of pair that drifts. Kept to a small step so the accent stays legible where it is text
+         on a dark ground, which is the other half of what it does. Pressed follows it down, or it
+         would no longer read as darker than the resting state it answers. -->
+    <SolidColorBrush x:Key="AppAccent"         Color="#52C4FA"/>
     <SolidColorBrush x:Key="AppAccentHover"    Color="#7AD7FF"/>
-    <SolidColorBrush x:Key="AppAccentPressed"  Color="#4BBFEE"/>
+    <SolidColorBrush x:Key="AppAccentPressed"  Color="#3EB2E6"/>
     <SolidColorBrush x:Key="AppAccentFg"       Color="#000000"/>
 
     <!-- The knob of a switch that is on. White in both themes rather than AppAccentFg,

--- a/src/OverTranslate/Themes/DarkTheme.xaml
+++ b/src/OverTranslate/Themes/DarkTheme.xaml
@@ -72,6 +72,17 @@
     <SolidColorBrush x:Key="ToolbarBg"         Color="#2A2A2A"/>
     <SolidColorBrush x:Key="ToolbarBorder"     Color="#484848"/>
 
+    <!-- The primary action on a floating toolbar. Its own blue rather than AppAccent, for the one
+         place the accent cannot serve: this bar is dark in the dark theme, and there AppAccent is a
+         pale cyan that takes black text — correct Fluent for a filled button on a page, a bright
+         patch shouting off a bar that floats over whatever the user is actually looking at. A blue
+         deep enough to carry white text sits on the bar instead of on top of it. In the light theme
+         the accent already is that blue and already carries white, so there it is the accent. -->
+    <SolidColorBrush x:Key="ToolbarPrimaryBg"        Color="#3B82F6"/>
+    <SolidColorBrush x:Key="ToolbarPrimaryHoverBg"   Color="#5693F8"/>
+    <SolidColorBrush x:Key="ToolbarPrimaryPressedBg" Color="#2F6FE0"/>
+    <SolidColorBrush x:Key="ToolbarPrimaryFg"        Color="#FFFFFF"/>
+
     <!-- The action group on the realtime edit bar: a slightly raised tray holding the two buttons the
          user chooses between, so they read as one control rather than as more window furniture. Its
          buttons need their own hover and pressed steps because the bar's are measured against the

--- a/src/OverTranslate/Themes/LightTheme.xaml
+++ b/src/OverTranslate/Themes/LightTheme.xaml
@@ -69,6 +69,17 @@
     <SolidColorBrush x:Key="ToolbarBg"         Color="#FAFAFA"/>
     <SolidColorBrush x:Key="ToolbarBorder"     Color="#D0D0D0"/>
 
+    <!-- The primary action on a floating toolbar. Its own blue rather than AppAccent, for the one
+         place the accent cannot serve: this bar is dark in the dark theme, and there AppAccent is a
+         pale cyan that takes black text — correct Fluent for a filled button on a page, a bright
+         patch shouting off a bar that floats over whatever the user is actually looking at. A blue
+         deep enough to carry white text sits on the bar instead of on top of it. In the light theme
+         the accent already is that blue and already carries white, so there it is the accent. -->
+    <SolidColorBrush x:Key="ToolbarPrimaryBg"        Color="#0078D4"/>
+    <SolidColorBrush x:Key="ToolbarPrimaryHoverBg"   Color="#106EBE"/>
+    <SolidColorBrush x:Key="ToolbarPrimaryPressedBg" Color="#005A9E"/>
+    <SolidColorBrush x:Key="ToolbarPrimaryFg"        Color="#FFFFFF"/>
+
     <!-- The action group on the realtime edit bar: a slightly raised tray holding the two buttons the
          user chooses between, so they read as one control rather than as more window furniture. Its
          buttons need their own hover and pressed steps because the bar's are measured against the

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1148,8 +1148,136 @@
     <!--  TOOLBAR VARIANTS (compact height=28)       -->
     <!-- ═══════════════════════════════════════════ -->
     <Style x:Key="ToolbarComboBox" TargetType="ComboBox" BasedOn="{StaticResource ModernComboBox}">
-        <Setter Property="Height"      Value="28"/>
-        <Setter Property="FontSize"    Value="12"/>
+        <Setter Property="Height"      Value="34"/>
+        <Setter Property="FontSize"    Value="12.5"/>
+    </Style>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!--  CAPTURE TOOLBAR                            -->
+    <!-- ═══════════════════════════════════════════ -->
+
+    <!-- The one button on the capture toolbar that starts work. A full-radius pill rather than the
+         6px corner every other button here has: colour alone stopped separating it once the actions
+         beside it grew their own icons, and shape survives being looked at out of the corner of an
+         eye, which is how a bar floating over the user's own screen is read. -->
+    <Style x:Key="ToolbarPrimaryButton" TargetType="Button" BasedOn="{StaticResource AccentButton}">
+        <Setter Property="Height"   Value="38"/>
+        <Setter Property="Padding"  Value="16,0"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="19"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppAccentHover}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppAccentPressed}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- A secondary action on the capture toolbar: its icon over its name, both centred. The label
+         stays because none of these icons is standard enough to be read cold — and a toolbar the
+         user meets mid-task, over their own screen, is the wrong place to make them hover to find
+         out. The icon carries the accent and the label stays plain text, so a row of them reads as
+         one rhythm instead of four coloured words. -->
+    <Style x:Key="ToolbarStackButton" TargetType="Button">
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"        Value="11.5"/>
+        <Setter Property="Foreground"      Value="{DynamicResource AppTextPrimary}"/>
+        <Setter Property="Background"      Value="Transparent"/>
+        <Setter Property="BorderBrush"     Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="MinWidth"        Value="54"/>
+        <Setter Property="Height"          Value="46"/>
+        <Setter Property="Padding"         Value="8,0"/>
+        <Setter Property="Cursor"          Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="9"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppButtonHoverBg}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppButtonPressedBg}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- The same shape on a raised surface, for the one secondary action that ends the capture
+         session rather than acting inside it. Given an edge of its own so that leaving is not one
+         more thing in the row of things that stay. -->
+    <Style x:Key="ToolbarStackRaisedButton" TargetType="Button" BasedOn="{StaticResource ToolbarStackButton}">
+        <Setter Property="Background"      Value="{DynamicResource ToolbarGroupBg}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource ToolbarBorder}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding"         Value="12,0"/>
+        <!-- Its own template, for the same reason ToastIconButton has one: BasedOn cannot reach the
+             hover and pressed brushes named inside the inherited one, and the bar's steps are
+             measured against the bar — against this raised surface the light theme's would be a
+             four-value change nobody can see. -->
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="9"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource ToolbarGroupHoverBg}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource ToolbarGroupPressedBg}"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="ToolbarFlatButton" TargetType="Button" BasedOn="{StaticResource FlatButton}">

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1166,25 +1166,35 @@
         <Setter Property="FontSize"   Value="12.5"/>
         <Setter Property="Foreground" Value="{DynamicResource ToolbarPrimaryFg}"/>
         <Setter Property="Background" Value="{DynamicResource ToolbarPrimaryBg}"/>
-        <!-- A little of its own colour cast on the bar under it, so the pill reads as sitting on the
-             bar rather than as a shape laid over it. Hardcoded like the bar's own shadow: an Effect
-             takes a Color, not a Brush, so it cannot follow a themed resource — and this one is the
-             same blue in both themes. -->
-        <Setter Property="Effect">
-            <Setter.Value>
-                <DropShadowEffect BlurRadius="14" ShadowDepth="0" Opacity="0.5" Color="#3B82F6"/>
-            </Setter.Value>
-        </Setter>
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <Border x:Name="Root"
-                            Background="{TemplateBinding Background}"
-                            CornerRadius="16"
-                            Padding="{TemplateBinding Padding}">
-                        <ContentPresenter HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"/>
-                    </Border>
+                    <Grid>
+                        <!-- A little of the pill's own colour cast on the bar under it, so it reads
+                             as sitting on the bar rather than as a shape laid over it. On a twin
+                             behind the button rather than on the button: an Effect rasterises what
+                             it is set on, and ClearType cannot run over that - which would have cost
+                             this label the crispness the whole bar was just given. Hardcoded because
+                             an Effect takes a Color and not a Brush, so it cannot follow a themed
+                             resource; it is the same blue in both themes. -->
+                        <Border Background="{TemplateBinding Background}"
+                                Margin="3"
+                                CornerRadius="13">
+                            <Border.Effect>
+                                <DropShadowEffect BlurRadius="14" ShadowDepth="0" Opacity="0.5" Color="#3B82F6"/>
+                            </Border.Effect>
+                        </Border>
+
+                        <Border x:Name="Root"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="16"
+                                Padding="{TemplateBinding Padding}"
+                                RenderOptions.ClearTypeHint="Enabled">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"/>
+                        </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Root" Property="Background"

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -528,7 +528,7 @@
         <Setter Property="Background"      Value="{DynamicResource AppButtonBg}"/>
         <Setter Property="BorderBrush"     Value="{DynamicResource AppButtonBorder}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Padding"         Value="12,0"/>
+        <Setter Property="Padding"         Value="9,0"/>
         <Setter Property="Height"          Value="32"/>
         <Setter Property="Cursor"          Value="Hand"/>
         <Setter Property="Template">
@@ -1148,8 +1148,8 @@
     <!--  TOOLBAR VARIANTS (compact height=28)       -->
     <!-- ═══════════════════════════════════════════ -->
     <Style x:Key="ToolbarComboBox" TargetType="ComboBox" BasedOn="{StaticResource ModernComboBox}">
-        <Setter Property="Height"      Value="34"/>
-        <Setter Property="FontSize"    Value="12.5"/>
+        <Setter Property="Height"      Value="30"/>
+        <Setter Property="FontSize"    Value="12"/>
     </Style>
 
     <!-- ═══════════════════════════════════════════ -->
@@ -1161,15 +1161,26 @@
          beside it grew their own icons, and shape survives being looked at out of the corner of an
          eye, which is how a bar floating over the user's own screen is read. -->
     <Style x:Key="ToolbarPrimaryButton" TargetType="Button" BasedOn="{StaticResource AccentButton}">
-        <Setter Property="Height"   Value="38"/>
-        <Setter Property="Padding"  Value="16,0"/>
-        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Height"     Value="32"/>
+        <Setter Property="Padding"    Value="14,0"/>
+        <Setter Property="FontSize"   Value="12.5"/>
+        <Setter Property="Foreground" Value="{DynamicResource ToolbarPrimaryFg}"/>
+        <Setter Property="Background" Value="{DynamicResource ToolbarPrimaryBg}"/>
+        <!-- A little of its own colour cast on the bar under it, so the pill reads as sitting on the
+             bar rather than as a shape laid over it. Hardcoded like the bar's own shadow: an Effect
+             takes a Color, not a Brush, so it cannot follow a themed resource — and this one is the
+             same blue in both themes. -->
+        <Setter Property="Effect">
+            <Setter.Value>
+                <DropShadowEffect BlurRadius="14" ShadowDepth="0" Opacity="0.5" Color="#3B82F6"/>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
                     <Border x:Name="Root"
                             Background="{TemplateBinding Background}"
-                            CornerRadius="19"
+                            CornerRadius="16"
                             Padding="{TemplateBinding Padding}">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"/>
@@ -1177,11 +1188,11 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Root" Property="Background"
-                                    Value="{DynamicResource AppAccentHover}"/>
+                                    Value="{DynamicResource ToolbarPrimaryHoverBg}"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="Root" Property="Background"
-                                    Value="{DynamicResource AppAccentPressed}"/>
+                                    Value="{DynamicResource ToolbarPrimaryPressedBg}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.45"/>
@@ -1197,16 +1208,26 @@
          user meets mid-task, over their own screen, is the wrong place to make them hover to find
          out. The icon carries the accent and the label stays plain text, so a row of them reads as
          one rhythm instead of four coloured words. -->
+    <!-- The icon in front of an action's name on the capture toolbar. A style rather than four
+         copies of the same three properties, so the row cannot end up with one icon a point off. -->
+    <Style x:Key="ToolbarActionGlyph" TargetType="TextBlock">
+        <Setter Property="FontFamily"         Value="Segoe Fluent Icons, Segoe MDL2 Assets"/>
+        <Setter Property="FontSize"           Value="14"/>
+        <Setter Property="Margin"             Value="0,0,5,0"/>
+        <Setter Property="VerticalAlignment"  Value="Center"/>
+        <Setter Property="Foreground"         Value="{DynamicResource AppAccent}"/>
+    </Style>
+
     <Style x:Key="ToolbarStackButton" TargetType="Button">
         <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
-        <Setter Property="FontSize"        Value="11.5"/>
+        <Setter Property="FontSize"        Value="11"/>
         <Setter Property="Foreground"      Value="{DynamicResource AppTextPrimary}"/>
         <Setter Property="Background"      Value="Transparent"/>
         <Setter Property="BorderBrush"     Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="MinWidth"        Value="54"/>
-        <Setter Property="Height"          Value="46"/>
-        <Setter Property="Padding"         Value="8,0"/>
+        <Setter Property="MinWidth"        Value="0"/>
+        <Setter Property="Height"          Value="32"/>
+        <Setter Property="Padding"         Value="9,0"/>
         <Setter Property="Cursor"          Value="Hand"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -1215,7 +1236,7 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="9"
+                            CornerRadius="8"
                             Padding="{TemplateBinding Padding}">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"/>
@@ -1257,7 +1278,7 @@
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="9"
+                            CornerRadius="8"
                             Padding="{TemplateBinding Padding}">
                         <ContentPresenter HorizontalAlignment="Center"
                                           VerticalAlignment="Center"/>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
@@ -12,166 +12,183 @@
 
     <!-- Margin gives room for the drop shadow to render outside the visual -->
     <Border Margin="8,6,8,10">
-        <Border Background="{DynamicResource ToolbarBg}"
-                BorderBrush="{DynamicResource ToolbarBorder}"
-                BorderThickness="1"
-                CornerRadius="16"
-                Padding="8,8">
-            <Border.Effect>
-                <!-- Shadow color is black in both themes; hardcoded avoids Freezable binding edge cases -->
-                <DropShadowEffect BlurRadius="18" ShadowDepth="3" Opacity="0.18" Color="#000000"/>
-            </Border.Effect>
+        <Grid>
+            <!-- The shadow rides an empty twin of the bar rather than the bar itself. An Effect makes
+                 WPF rasterise the element it is set on into an intermediate surface, and ClearType
+                 sub-pixel antialiasing cannot run over a surface that may be transparent - so a
+                 shadow on the bar quietly dropped every label on it to greyscale antialiasing, which
+                 at 11-12px CJK is the difference between text that reads and text that looks thin
+                 and hard. Blurring an empty rectangle costs the same and leaves the bar itself
+                 un-rasterised. The same trick as ShellWindow's content host, for the same reason. -->
+            <Border Background="{DynamicResource ToolbarBg}"
+                    Margin="2"
+                    CornerRadius="14">
+                <Border.Effect>
+                    <!-- Shadow color is black in both themes; hardcoded avoids Freezable binding edge cases -->
+                    <DropShadowEffect BlurRadius="18" ShadowDepth="3" Opacity="0.18" Color="#000000"/>
+                </Border.Effect>
+            </Border>
 
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <!-- ClearTypeHint on top of an opaque background: the window itself is layered
+                 (AllowsTransparency), which is the other thing that turns ClearType off. The hint is
+                 how WPF is told this particular surface really is opaque. -->
+            <Border Background="{DynamicResource ToolbarBg}"
+                    BorderBrush="{DynamicResource ToolbarBorder}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    Padding="8,8"
+                    RenderOptions.ClearTypeHint="Enabled">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
 
-                <!-- At the head of the bar, in front of the source picker, because that picker is
-                     what it reads with and what switches it off: this reads the original, never the
-                     translation. Sat among the actions on the right it was one more thing to do to
-                     the result, and the only way to say which text it meant would have been to spell
-                     it out in the label — four characters for a button on a bar already short of
-                     room. Position says it in none.
+                    <!-- At the head of the bar, in front of the source picker, because that picker is
+                         what it reads with and what switches it off: this reads the original, never the
+                         translation. Sat among the actions on the right it was one more thing to do to
+                         the result, and the only way to say which text it meant would have been to spell
+                         it out in the label — four characters for a button on a bar already short of
+                         room. Position says it in none.
 
-                     Reads the recognised source text as one piece, not block by block: the blocks
-                     are how the picture was cut up for recognition, not how the sentence was
-                     written, and read one at a time they come out as fragments. Same text the
-                     translation window is opened with. -->
-                <Button x:Name="TtsBtn"
-                        Style="{StaticResource ToolbarStackButton}"
-                        IsEnabled="False"
-                        Margin="0,0,4,0"
-                        Click="TtsBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock x:Name="TtsGlyph"
-                                   Text="&#xE767;"
-                                   Style="{StaticResource ToolbarActionGlyph}"/>
-                        <TextBlock x:Name="TtsLabel"
-                                   VerticalAlignment="Center"
-                                   Text="{DynamicResource S.Toolbar.Speak}"/>
-                    </StackPanel>
-                </Button>
+                         Reads the recognised source text as one piece, not block by block: the blocks
+                         are how the picture was cut up for recognition, not how the sentence was
+                         written, and read one at a time they come out as fragments. Same text the
+                         translation window is opened with. -->
+                    <Button x:Name="TtsBtn"
+                            Style="{StaticResource ToolbarStackButton}"
+                            IsEnabled="False"
+                            Margin="0,0,4,0"
+                            Click="TtsBtn_Click">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock x:Name="TtsGlyph"
+                                       Text="&#xE767;"
+                                       Style="{StaticResource ToolbarActionGlyph}"/>
+                            <TextBlock x:Name="TtsLabel"
+                                       VerticalAlignment="Center"
+                                       Text="{DynamicResource S.Toolbar.Speak}"/>
+                        </StackPanel>
+                    </Button>
 
-                <!-- Source language (140px - fits longest entry + arrow) -->
-                <ComboBox x:Name="SrcLangBox"
-                          Style="{StaticResource ToolbarComboBox}"
-                          Width="132"
-                          SelectedValuePath="Code"
-                          VerticalContentAlignment="Center"/>
+                    <!-- Source language (140px - fits longest entry + arrow) -->
+                    <ComboBox x:Name="SrcLangBox"
+                              Style="{StaticResource ToolbarComboBox}"
+                              Width="132"
+                              SelectedValuePath="Code"
+                              VerticalContentAlignment="Center"/>
 
-                <!-- Swap -->
-                <Button Content="&#xE8AB;"
-                        Style="{StaticResource ToolbarIconButton}"
-                        FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                        FontSize="14"
-                        Margin="1,0"
-                        ToolTip="{DynamicResource S.Toolbar.Swap}"
-                        AutomationProperties.Name="{DynamicResource S.Toolbar.Swap}"
-                        Click="SwapBtn_Click"/>
+                    <!-- Swap -->
+                    <Button Content="&#xE8AB;"
+                            Style="{StaticResource ToolbarIconButton}"
+                            FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                            FontSize="14"
+                            Margin="1,0"
+                            ToolTip="{DynamicResource S.Toolbar.Swap}"
+                            AutomationProperties.Name="{DynamicResource S.Toolbar.Swap}"
+                            Click="SwapBtn_Click"/>
 
-                <!-- Target language -->
-                <ComboBox x:Name="TgtLangBox"
-                          Style="{StaticResource ToolbarComboBox}"
-                          Width="132"
-                          Margin="0,0,6,0"
-                          SelectedValuePath="Code"
-                          VerticalContentAlignment="Center"/>
-
-                <!-- Provider -->
-                <ComboBox x:Name="ProviderBox"
-                          Style="{StaticResource ToolbarComboBox}"
-                          Width="142"
-                          SelectedValuePath="Provider"
-                          VerticalContentAlignment="Center"/>
-
-                <!-- Fallback badge: shown only when a backup engine actually served the batch -->
-                <Border x:Name="EngineBadge"
-                        Visibility="Collapsed"
-                        Background="#33F59E0B"
-                        BorderBrush="#F59E0B"
-                        BorderThickness="1"
-                        CornerRadius="6"
-                        Padding="6,1"
-                        Margin="6,0,0,0"
-                        VerticalAlignment="Center">
-                    <TextBlock x:Name="EngineBadgeText"
-                               Foreground="#F59E0B"
-                               FontSize="12"
-                               VerticalAlignment="Center"/>
-                </Border>
-
-                <!-- No rule between the settings and the actions: the gap says it, and a bar this
-                     wide floating over the user's own screen does not need more lines drawn on it. -->
-
-                <!-- Translate -->
-                <Button x:Name="TranslateBtn"
-                        Style="{StaticResource ToolbarPrimaryButton}"
-                        Margin="10,0,6,0"
-                        Click="TranslateBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <!-- Drawn rather than typed: there is no sparkle in Segoe MDL2, which is all
-                             Windows 10 has, and a missing glyph on the primary button is the worst
-                             place for one. -->
-                        <Path Width="13" Height="13"
-                              Stretch="None"
-                              VerticalAlignment="Center"
+                    <!-- Target language -->
+                    <ComboBox x:Name="TgtLangBox"
+                              Style="{StaticResource ToolbarComboBox}"
+                              Width="132"
                               Margin="0,0,6,0"
-                              Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
-                              Data="M7,0.6 C7.7,4.2 9.8,6.3 13.4,7 C9.8,7.7 7.7,9.8 7,13.4 C6.3,9.8 4.2,7.7 0.6,7 C4.2,6.3 6.3,4.2 7,0.6 Z M12.1,9.6 C12.3,10.8 12.6,11.1 13.8,11.3 C12.6,11.5 12.3,11.8 12.1,13 C11.9,11.8 11.6,11.5 10.4,11.3 C11.6,11.1 11.9,10.8 12.1,9.6 Z"/>
-                        <TextBlock x:Name="TranslateLabel"
-                                   VerticalAlignment="Center"
-                                   Text="{DynamicResource S.Toolbar.Translate}"/>
-                    </StackPanel>
-                </Button>
+                              SelectedValuePath="Code"
+                              VerticalContentAlignment="Center"/>
 
-                <!-- Toggle original / translated bubbles -->
-                <Button x:Name="ToggleBtn"
-                        Style="{StaticResource ToolbarStackButton}"
-                        IsEnabled="False"
-                        Click="ToggleBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock x:Name="ToggleGlyph"
-                                   Text="&#xE890;"
-                                   Style="{StaticResource ToolbarActionGlyph}"/>
-                        <TextBlock x:Name="ToggleLabel"
-                                   VerticalAlignment="Center"
-                                   Text="{DynamicResource S.Toolbar.ShowSource}"/>
-                    </StackPanel>
-                </Button>
+                    <!-- Provider -->
+                    <ComboBox x:Name="ProviderBox"
+                              Style="{StaticResource ToolbarComboBox}"
+                              Width="142"
+                              SelectedValuePath="Provider"
+                              VerticalContentAlignment="Center"/>
 
-                <!-- Copy current selection screenshot to clipboard -->
-                <Button x:Name="CopyShotBtn"
-                        Style="{StaticResource ToolbarStackButton}"
-                        Click="CopyShotBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="&#xE8FF;"
-                                   Style="{StaticResource ToolbarActionGlyph}"/>
-                        <TextBlock VerticalAlignment="Center"
-                                   Text="{DynamicResource S.Toolbar.Screenshot}"/>
-                    </StackPanel>
-                </Button>
+                    <!-- Fallback badge: shown only when a backup engine actually served the batch -->
+                    <Border x:Name="EngineBadge"
+                            Visibility="Collapsed"
+                            Background="#33F59E0B"
+                            BorderBrush="#F59E0B"
+                            BorderThickness="1"
+                            CornerRadius="6"
+                            Padding="6,1"
+                            Margin="6,0,0,0"
+                            VerticalAlignment="Center">
+                        <TextBlock x:Name="EngineBadgeText"
+                                   Foreground="#F59E0B"
+                                   FontSize="12"
+                                   VerticalAlignment="Center"/>
+                    </Border>
 
-                <!-- Open translation window -->
-                <Button x:Name="OpenWindowBtn"
-                        Style="{StaticResource ToolbarStackRaisedButton}"
-                        Margin="6,0,0,0"
-                        Click="OpenWindowBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="&#xE8A7;"
-                                   Style="{StaticResource ToolbarActionGlyph}"/>
-                        <TextBlock VerticalAlignment="Center"
-                                   Text="{DynamicResource S.Toolbar.OpenWindow}"/>
-                    </StackPanel>
-                </Button>
+                    <!-- No rule between the settings and the actions: the gap says it, and a bar this
+                         wide floating over the user's own screen does not need more lines drawn on it. -->
 
-                <!-- Close, set apart by the gap: everything left of it acts inside the session. -->
-                <Button Content="&#x2715;"
-                        Style="{StaticResource ToolbarIconButton}"
-                        Width="30" Height="30"
-                        Margin="8,0,0,0"
-                        ToolTip="{DynamicResource S.Toolbar.Close}"
-                        AutomationProperties.Name="{DynamicResource S.Toolbar.Close}"
-                        Click="CloseBtn_Click"/>
+                    <!-- Translate -->
+                    <Button x:Name="TranslateBtn"
+                            Style="{StaticResource ToolbarPrimaryButton}"
+                            Margin="10,0,6,0"
+                            Click="TranslateBtn_Click">
+                        <StackPanel Orientation="Horizontal">
+                            <!-- Drawn rather than typed: there is no sparkle in Segoe MDL2, which is all
+                                 Windows 10 has, and a missing glyph on the primary button is the worst
+                                 place for one. -->
+                            <Path Width="13" Height="13"
+                                  Stretch="None"
+                                  VerticalAlignment="Center"
+                                  Margin="0,0,6,0"
+                                  Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                  Data="M7,0.6 C7.7,4.2 9.8,6.3 13.4,7 C9.8,7.7 7.7,9.8 7,13.4 C6.3,9.8 4.2,7.7 0.6,7 C4.2,6.3 6.3,4.2 7,0.6 Z M12.1,9.6 C12.3,10.8 12.6,11.1 13.8,11.3 C12.6,11.5 12.3,11.8 12.1,13 C11.9,11.8 11.6,11.5 10.4,11.3 C11.6,11.1 11.9,10.8 12.1,9.6 Z"/>
+                            <TextBlock x:Name="TranslateLabel"
+                                       VerticalAlignment="Center"
+                                       Text="{DynamicResource S.Toolbar.Translate}"/>
+                        </StackPanel>
+                    </Button>
 
-            </StackPanel>
-        </Border>
+                    <!-- Toggle original / translated bubbles -->
+                    <Button x:Name="ToggleBtn"
+                            Style="{StaticResource ToolbarStackButton}"
+                            IsEnabled="False"
+                            Click="ToggleBtn_Click">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock x:Name="ToggleGlyph"
+                                       Text="&#xE890;"
+                                       Style="{StaticResource ToolbarActionGlyph}"/>
+                            <TextBlock x:Name="ToggleLabel"
+                                       VerticalAlignment="Center"
+                                       Text="{DynamicResource S.Toolbar.ShowSource}"/>
+                        </StackPanel>
+                    </Button>
+
+                    <!-- Copy current selection screenshot to clipboard -->
+                    <Button x:Name="CopyShotBtn"
+                            Style="{StaticResource ToolbarStackButton}"
+                            Click="CopyShotBtn_Click">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE8FF;"
+                                       Style="{StaticResource ToolbarActionGlyph}"/>
+                            <TextBlock VerticalAlignment="Center"
+                                       Text="{DynamicResource S.Toolbar.Screenshot}"/>
+                        </StackPanel>
+                    </Button>
+
+                    <!-- Open translation window -->
+                    <Button x:Name="OpenWindowBtn"
+                            Style="{StaticResource ToolbarStackRaisedButton}"
+                            Margin="6,0,0,0"
+                            Click="OpenWindowBtn_Click">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE8A7;"
+                                       Style="{StaticResource ToolbarActionGlyph}"/>
+                            <TextBlock VerticalAlignment="Center"
+                                       Text="{DynamicResource S.Toolbar.OpenWindow}"/>
+                        </StackPanel>
+                    </Button>
+
+                    <!-- Close, set apart by the gap: everything left of it acts inside the session. -->
+                    <Button Content="&#x2715;"
+                            Style="{StaticResource ToolbarIconButton}"
+                            Width="30" Height="30"
+                            Margin="8,0,0,0"
+                            ToolTip="{DynamicResource S.Toolbar.Close}"
+                            AutomationProperties.Name="{DynamicResource S.Toolbar.Close}"
+                            Click="CloseBtn_Click"/>
+
+                </StackPanel>
+            </Border>
+        </Grid>
     </Border>
 </Window>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
@@ -15,28 +15,45 @@
         <Border Background="{DynamicResource ToolbarBg}"
                 BorderBrush="{DynamicResource ToolbarBorder}"
                 BorderThickness="1"
-                CornerRadius="18"
-                Padding="10,8">
+                CornerRadius="16"
+                Padding="8,8">
             <Border.Effect>
                 <!-- Shadow color is black in both themes; hardcoded avoids Freezable binding edge cases -->
-                <DropShadowEffect BlurRadius="22" ShadowDepth="4" Opacity="0.22" Color="#000000"/>
+                <DropShadowEffect BlurRadius="18" ShadowDepth="3" Opacity="0.18" Color="#000000"/>
             </Border.Effect>
 
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
 
-                <!-- Marks the pair that follows as the languages, so neither picker has to carry the
-                     word. Muted rather than accent: it names a group, it is not something to press. -->
-                <TextBlock Text="&#xE774;"
-                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                           FontSize="15"
-                           Margin="4,0,8,0"
-                           VerticalAlignment="Center"
-                           Foreground="{DynamicResource AppTextSecondary}"/>
+                <!-- At the head of the bar, in front of the source picker, because that picker is
+                     what it reads with and what switches it off: this reads the original, never the
+                     translation. Sat among the actions on the right it was one more thing to do to
+                     the result, and the only way to say which text it meant would have been to spell
+                     it out in the label — four characters for a button on a bar already short of
+                     room. Position says it in none.
+
+                     Reads the recognised source text as one piece, not block by block: the blocks
+                     are how the picture was cut up for recognition, not how the sentence was
+                     written, and read one at a time they come out as fragments. Same text the
+                     translation window is opened with. -->
+                <Button x:Name="TtsBtn"
+                        Style="{StaticResource ToolbarStackButton}"
+                        IsEnabled="False"
+                        Margin="0,0,4,0"
+                        Click="TtsBtn_Click">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="TtsGlyph"
+                                   Text="&#xE767;"
+                                   Style="{StaticResource ToolbarActionGlyph}"/>
+                        <TextBlock x:Name="TtsLabel"
+                                   VerticalAlignment="Center"
+                                   Text="{DynamicResource S.Toolbar.Speak}"/>
+                    </StackPanel>
+                </Button>
 
                 <!-- Source language (140px - fits longest entry + arrow) -->
                 <ComboBox x:Name="SrcLangBox"
                           Style="{StaticResource ToolbarComboBox}"
-                          Width="140"
+                          Width="132"
                           SelectedValuePath="Code"
                           VerticalContentAlignment="Center"/>
 
@@ -44,8 +61,8 @@
                 <Button Content="&#xE8AB;"
                         Style="{StaticResource ToolbarIconButton}"
                         FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                        FontSize="15"
-                        Margin="4,0"
+                        FontSize="14"
+                        Margin="1,0"
                         ToolTip="{DynamicResource S.Toolbar.Swap}"
                         AutomationProperties.Name="{DynamicResource S.Toolbar.Swap}"
                         Click="SwapBtn_Click"/>
@@ -53,15 +70,15 @@
                 <!-- Target language -->
                 <ComboBox x:Name="TgtLangBox"
                           Style="{StaticResource ToolbarComboBox}"
-                          Width="140"
-                          Margin="0,0,8,0"
+                          Width="132"
+                          Margin="0,0,6,0"
                           SelectedValuePath="Code"
                           VerticalContentAlignment="Center"/>
 
                 <!-- Provider -->
                 <ComboBox x:Name="ProviderBox"
                           Style="{StaticResource ToolbarComboBox}"
-                          Width="150"
+                          Width="142"
                           SelectedValuePath="Provider"
                           VerticalContentAlignment="Center"/>
 
@@ -87,16 +104,16 @@
                 <!-- Translate -->
                 <Button x:Name="TranslateBtn"
                         Style="{StaticResource ToolbarPrimaryButton}"
-                        Margin="14,0,10,0"
+                        Margin="10,0,6,0"
                         Click="TranslateBtn_Click">
                     <StackPanel Orientation="Horizontal">
                         <!-- Drawn rather than typed: there is no sparkle in Segoe MDL2, which is all
                              Windows 10 has, and a missing glyph on the primary button is the worst
                              place for one. -->
-                        <Path Width="14" Height="14"
+                        <Path Width="13" Height="13"
                               Stretch="None"
                               VerticalAlignment="Center"
-                              Margin="0,0,7,0"
+                              Margin="0,0,6,0"
                               Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
                               Data="M7,0.6 C7.7,4.2 9.8,6.3 13.4,7 C9.8,7.7 7.7,9.8 7,13.4 C6.3,9.8 4.2,7.7 0.6,7 C4.2,6.3 6.3,4.2 7,0.6 Z M12.1,9.6 C12.3,10.8 12.6,11.1 13.8,11.3 C12.6,11.5 12.3,11.8 12.1,13 C11.9,11.8 11.6,11.5 10.4,11.3 C11.6,11.1 11.9,10.8 12.1,9.6 Z"/>
                         <TextBlock x:Name="TranslateLabel"
@@ -110,38 +127,13 @@
                         Style="{StaticResource ToolbarStackButton}"
                         IsEnabled="False"
                         Click="ToggleBtn_Click">
-                    <StackPanel>
-                        <TextBlock Text="&#xE890;"
-                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="16"
-                                   HorizontalAlignment="Center"
-                                   Foreground="{DynamicResource AppAccent}"/>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="ToggleGlyph"
+                                   Text="&#xE890;"
+                                   Style="{StaticResource ToolbarActionGlyph}"/>
                         <TextBlock x:Name="ToggleLabel"
-                                   Margin="0,3,0,0"
-                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
                                    Text="{DynamicResource S.Toolbar.ShowSource}"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Reads the recognised source text aloud. The whole text at once, not block by
-                     block: the blocks are how the picture was cut up for recognition, not how the
-                     sentence was written, and read one at a time they come out as fragments. Same
-                     text the translation window is opened with. -->
-                <Button x:Name="TtsBtn"
-                        Style="{StaticResource ToolbarStackButton}"
-                        IsEnabled="False"
-                        Click="TtsBtn_Click">
-                    <StackPanel>
-                        <TextBlock x:Name="TtsGlyph"
-                                   Text="&#xE767;"
-                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="16"
-                                   HorizontalAlignment="Center"
-                                   Foreground="{DynamicResource AppAccent}"/>
-                        <TextBlock x:Name="TtsLabel"
-                                   Margin="0,3,0,0"
-                                   HorizontalAlignment="Center"
-                                   Text="{DynamicResource S.Toolbar.Speak}"/>
                     </StackPanel>
                 </Button>
 
@@ -149,14 +141,10 @@
                 <Button x:Name="CopyShotBtn"
                         Style="{StaticResource ToolbarStackButton}"
                         Click="CopyShotBtn_Click">
-                    <StackPanel>
+                    <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE8FF;"
-                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="16"
-                                   HorizontalAlignment="Center"
-                                   Foreground="{DynamicResource AppAccent}"/>
-                        <TextBlock Margin="0,3,0,0"
-                                   HorizontalAlignment="Center"
+                                   Style="{StaticResource ToolbarActionGlyph}"/>
+                        <TextBlock VerticalAlignment="Center"
                                    Text="{DynamicResource S.Toolbar.Screenshot}"/>
                     </StackPanel>
                 </Button>
@@ -164,16 +152,12 @@
                 <!-- Open translation window -->
                 <Button x:Name="OpenWindowBtn"
                         Style="{StaticResource ToolbarStackRaisedButton}"
-                        Margin="8,0,0,0"
+                        Margin="6,0,0,0"
                         Click="OpenWindowBtn_Click">
-                    <StackPanel>
+                    <StackPanel Orientation="Horizontal">
                         <TextBlock Text="&#xE8A7;"
-                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="16"
-                                   HorizontalAlignment="Center"
-                                   Foreground="{DynamicResource AppAccent}"/>
-                        <TextBlock Margin="0,3,0,0"
-                                   HorizontalAlignment="Center"
+                                   Style="{StaticResource ToolbarActionGlyph}"/>
+                        <TextBlock VerticalAlignment="Center"
                                    Text="{DynamicResource S.Toolbar.OpenWindow}"/>
                     </StackPanel>
                 </Button>
@@ -181,8 +165,8 @@
                 <!-- Close, set apart by the gap: everything left of it acts inside the session. -->
                 <Button Content="&#x2715;"
                         Style="{StaticResource ToolbarIconButton}"
-                        Width="34" Height="34"
-                        Margin="12,0,0,0"
+                        Width="30" Height="30"
+                        Margin="8,0,0,0"
                         ToolTip="{DynamicResource S.Toolbar.Close}"
                         AutomationProperties.Name="{DynamicResource S.Toolbar.Close}"
                         Click="CloseBtn_Click"/>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
@@ -15,44 +15,53 @@
         <Border Background="{DynamicResource ToolbarBg}"
                 BorderBrush="{DynamicResource ToolbarBorder}"
                 BorderThickness="1"
-                CornerRadius="10"
-                Padding="8,5">
+                CornerRadius="18"
+                Padding="10,8">
             <Border.Effect>
                 <!-- Shadow color is black in both themes; hardcoded avoids Freezable binding edge cases -->
-                <DropShadowEffect BlurRadius="18" ShadowDepth="3" Opacity="0.18" Color="#000000"/>
+                <DropShadowEffect BlurRadius="22" ShadowDepth="4" Opacity="0.22" Color="#000000"/>
             </Border.Effect>
 
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
 
-                <!-- Source language (140px — fits longest entry + arrow) -->
+                <!-- Marks the pair that follows as the languages, so neither picker has to carry the
+                     word. Muted rather than accent: it names a group, it is not something to press. -->
+                <TextBlock Text="&#xE774;"
+                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                           FontSize="15"
+                           Margin="4,0,8,0"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource AppTextSecondary}"/>
+
+                <!-- Source language (140px - fits longest entry + arrow) -->
                 <ComboBox x:Name="SrcLangBox"
                           Style="{StaticResource ToolbarComboBox}"
                           Width="140"
-                          
                           SelectedValuePath="Code"
                           VerticalContentAlignment="Center"/>
 
                 <!-- Swap -->
-                <Button Content="⇄"
+                <Button Content="&#xE8AB;"
                         Style="{StaticResource ToolbarIconButton}"
-                        Margin="2,0"
+                        FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                        FontSize="15"
+                        Margin="4,0"
+                        ToolTip="{DynamicResource S.Toolbar.Swap}"
+                        AutomationProperties.Name="{DynamicResource S.Toolbar.Swap}"
                         Click="SwapBtn_Click"/>
 
                 <!-- Target language -->
                 <ComboBox x:Name="TgtLangBox"
                           Style="{StaticResource ToolbarComboBox}"
                           Width="140"
-                          
+                          Margin="0,0,8,0"
                           SelectedValuePath="Code"
                           VerticalContentAlignment="Center"/>
 
-                <Separator Style="{StaticResource VerticalSeparator}"/>
-
-                <!-- Provider (longest entry is "DeepL 翻譯（需 API Key）" ≈ 145px) -->
+                <!-- Provider -->
                 <ComboBox x:Name="ProviderBox"
                           Style="{StaticResource ToolbarComboBox}"
                           Width="150"
-
                           SelectedValuePath="Provider"
                           VerticalContentAlignment="Center"/>
 
@@ -72,42 +81,110 @@
                                VerticalAlignment="Center"/>
                 </Border>
 
-                <Separator Style="{StaticResource VerticalSeparator}"/>
+                <!-- No rule between the settings and the actions: the gap says it, and a bar this
+                     wide floating over the user's own screen does not need more lines drawn on it. -->
 
                 <!-- Translate -->
                 <Button x:Name="TranslateBtn"
-                        Content="{DynamicResource S.Toolbar.Translate}"
-                        Style="{StaticResource ToolbarAccentButton}"
-                        Margin="0,0,4,0"
-                        Click="TranslateBtn_Click"/>
+                        Style="{StaticResource ToolbarPrimaryButton}"
+                        Margin="14,0,10,0"
+                        Click="TranslateBtn_Click">
+                    <StackPanel Orientation="Horizontal">
+                        <!-- Drawn rather than typed: there is no sparkle in Segoe MDL2, which is all
+                             Windows 10 has, and a missing glyph on the primary button is the worst
+                             place for one. -->
+                        <Path Width="14" Height="14"
+                              Stretch="None"
+                              VerticalAlignment="Center"
+                              Margin="0,0,7,0"
+                              Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                              Data="M7,0.6 C7.7,4.2 9.8,6.3 13.4,7 C9.8,7.7 7.7,9.8 7,13.4 C6.3,9.8 4.2,7.7 0.6,7 C4.2,6.3 6.3,4.2 7,0.6 Z M12.1,9.6 C12.3,10.8 12.6,11.1 13.8,11.3 C12.6,11.5 12.3,11.8 12.1,13 C11.9,11.8 11.6,11.5 10.4,11.3 C11.6,11.1 11.9,10.8 12.1,9.6 Z"/>
+                        <TextBlock x:Name="TranslateLabel"
+                                   VerticalAlignment="Center"
+                                   Text="{DynamicResource S.Toolbar.Translate}"/>
+                    </StackPanel>
+                </Button>
 
                 <!-- Toggle original / translated bubbles -->
                 <Button x:Name="ToggleBtn"
-                        Content="{DynamicResource S.Toolbar.ShowSource}"
-                        Style="{StaticResource ToolbarFlatButton}"
+                        Style="{StaticResource ToolbarStackButton}"
                         IsEnabled="False"
-                        Margin="0,0,4,0"
-                        Click="ToggleBtn_Click"/>
+                        Click="ToggleBtn_Click">
+                    <StackPanel>
+                        <TextBlock Text="&#xE890;"
+                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="16"
+                                   HorizontalAlignment="Center"
+                                   Foreground="{DynamicResource AppAccent}"/>
+                        <TextBlock x:Name="ToggleLabel"
+                                   Margin="0,3,0,0"
+                                   HorizontalAlignment="Center"
+                                   Text="{DynamicResource S.Toolbar.ShowSource}"/>
+                    </StackPanel>
+                </Button>
 
-                <!-- Copy current selection screenshot to clipboard (subtle accent: tonal, not primary) -->
+                <!-- Reads the recognised source text aloud. The whole text at once, not block by
+                     block: the blocks are how the picture was cut up for recognition, not how the
+                     sentence was written, and read one at a time they come out as fragments. Same
+                     text the translation window is opened with. -->
+                <Button x:Name="TtsBtn"
+                        Style="{StaticResource ToolbarStackButton}"
+                        IsEnabled="False"
+                        Click="TtsBtn_Click">
+                    <StackPanel>
+                        <TextBlock x:Name="TtsGlyph"
+                                   Text="&#xE767;"
+                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="16"
+                                   HorizontalAlignment="Center"
+                                   Foreground="{DynamicResource AppAccent}"/>
+                        <TextBlock x:Name="TtsLabel"
+                                   Margin="0,3,0,0"
+                                   HorizontalAlignment="Center"
+                                   Text="{DynamicResource S.Toolbar.Speak}"/>
+                    </StackPanel>
+                </Button>
+
+                <!-- Copy current selection screenshot to clipboard -->
                 <Button x:Name="CopyShotBtn"
-                        Content="{DynamicResource S.Toolbar.Screenshot}"
-                        Style="{StaticResource ToolbarSubtleAccentButton}"
-                        Margin="0,0,4,0"
-                        Click="CopyShotBtn_Click"/>
+                        Style="{StaticResource ToolbarStackButton}"
+                        Click="CopyShotBtn_Click">
+                    <StackPanel>
+                        <TextBlock Text="&#xE8FF;"
+                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="16"
+                                   HorizontalAlignment="Center"
+                                   Foreground="{DynamicResource AppAccent}"/>
+                        <TextBlock Margin="0,3,0,0"
+                                   HorizontalAlignment="Center"
+                                   Text="{DynamicResource S.Toolbar.Screenshot}"/>
+                    </StackPanel>
+                </Button>
 
                 <!-- Open translation window -->
                 <Button x:Name="OpenWindowBtn"
-                        Content="{DynamicResource S.Toolbar.OpenWindow}"
-                        Style="{StaticResource ToolbarFlatButton}"
-                        Margin="0,0,4,0"
-                        Click="OpenWindowBtn_Click"/>
+                        Style="{StaticResource ToolbarStackRaisedButton}"
+                        Margin="8,0,0,0"
+                        Click="OpenWindowBtn_Click">
+                    <StackPanel>
+                        <TextBlock Text="&#xE8A7;"
+                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="16"
+                                   HorizontalAlignment="Center"
+                                   Foreground="{DynamicResource AppAccent}"/>
+                        <TextBlock Margin="0,3,0,0"
+                                   HorizontalAlignment="Center"
+                                   Text="{DynamicResource S.Toolbar.OpenWindow}"/>
+                    </StackPanel>
+                </Button>
 
-                <Separator Style="{StaticResource VerticalSeparator}"/>
-
-                <!-- Close -->
-                <Button Content="✕"
+                <!-- Close, set apart by the gap: everything left of it acts inside the session. -->
+                <Button Content="&#x2715;"
                         Style="{StaticResource ToolbarIconButton}"
+                        Width="34" Height="34"
+                        Margin="12,0,0,0"
+                        ToolTip="{DynamicResource S.Toolbar.Close}"
+                        AutomationProperties.Name="{DynamicResource S.Toolbar.Close}"
                         Click="CloseBtn_Click"/>
 
             </StackPanel>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
@@ -8,11 +8,24 @@ namespace OverTranslate.Views.Capture;
 
 public partial class ToolbarWindow : Window
 {
+    private const string SpeakGlyph = Controls.TtsGlyphs.Speak;
+    private const string StopGlyph = Controls.TtsGlyphs.Stop;
+
     public event EventHandler<TranslateRequest>? TranslateRequested;
     public event EventHandler? OpenWindowRequested;
     public event EventHandler? CopyScreenshotRequested;
     public event EventHandler? CloseAllRequested;
     public event EventHandler<bool>? BubblesVisibilityChanged;
+
+    /// <summary>The speak button was pressed: start reading, or stop if already reading.</summary>
+    public event EventHandler? SpeakToggleRequested;
+
+    /// <summary>
+    /// Raised when the button that stops playback is about to stop being usable, so whoever owns the
+    /// voice can stop it. Without this, switching the source language to 自動 mid-sentence would
+    /// leave the text playing with no way to stop it — the stop button is the one being disabled.
+    /// </summary>
+    public event EventHandler? SpeakStopRequested;
 
     // Not readonly: the selection can still be moved and resized until translation starts, and this
     // toolbar is anchored to it — see FollowSelection.
@@ -25,6 +38,11 @@ public partial class ToolbarWindow : Window
     private bool _toggleEnabled = false;
     private bool _bubblesVisible = true;
     private bool _hasTranslated;
+
+    // Whether there is recognised text to read, and whether it is being read right now. The voice
+    // itself lives with the capture session, not here: this window only shows its state.
+    private bool _hasSpeakableText;
+    private bool _isSpeaking;
 
     public string CurrentSourceLang => LanguageData.GetValidOcrSourceCode(SrcLangBox.SelectedValue as string);
     public string CurrentTargetLang => LanguageData.GetValidTargetCode(TgtLangBox.SelectedValue as string);
@@ -46,6 +64,8 @@ public partial class ToolbarWindow : Window
         SrcLangBox.SelectionChanged  += SrcLangBox_SelectionChanged;
         TgtLangBox.SelectionChanged  += TgtLangBox_SelectionChanged;
         ProviderBox.SelectionChanged += ProviderBox_SelectionChanged;
+
+        RenderSpeakButton();
     }
 
     protected override void OnSourceInitialized(EventArgs e)
@@ -120,6 +140,10 @@ public partial class ToolbarWindow : Window
     private void SrcLangBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
     {
         SaveCurrentLanguageSelection();
+
+        // The source language is what decides whether there is a voice to read with — see
+        // RenderSpeakButton.
+        RenderSpeakButton();
     }
 
     private void TgtLangBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
@@ -172,6 +196,9 @@ public partial class ToolbarWindow : Window
     private void OpenWindowBtn_Click(object sender, RoutedEventArgs e)
         => OpenWindowRequested?.Invoke(this, EventArgs.Empty);
 
+    private void TtsBtn_Click(object sender, RoutedEventArgs e)
+        => SpeakToggleRequested?.Invoke(this, EventArgs.Empty);
+
     private void CopyShotBtn_Click(object sender, RoutedEventArgs e)
         => CopyScreenshotRequested?.Invoke(this, EventArgs.Empty);
 
@@ -189,18 +216,74 @@ public partial class ToolbarWindow : Window
         _isBusy = busy;
         if (busy) HideEngineBadge(); // stale badge shouldn't linger while the next batch runs
         TranslateBtn.IsEnabled = !busy;
-        TranslateBtn.Content = LocalizationService.Get(
+        TranslateLabel.Text = LocalizationService.Get(
             busy ? "S.Toolbar.Translating"
                  : _hasTranslated ? "S.Toolbar.Retranslate" : "S.Toolbar.Translate");
         ToggleBtn.IsEnabled = !_isBusy && _toggleEnabled;
         OpenWindowBtn.IsEnabled = !_isBusy;
     }
 
+    /// <summary>Whether recognition has produced any text for the speak button to read.</summary>
+    public void SetSpeakableText(bool hasText)
+    {
+        _hasSpeakableText = hasText;
+        RenderSpeakButton();
+    }
+
+    /// <summary>Reflects whether the voice is currently reading, so the button offers to stop it.</summary>
+    public void SetSpeaking(bool speaking)
+    {
+        _isSpeaking = speaking;
+        RenderSpeakButton();
+    }
+
+    /// <summary>
+    /// Settles the speak button against what there is to read and what there is to read it with.
+    /// </summary>
+    /// <remarks>
+    /// <para>Switched off while the source language is 自動, the same way the translation page's
+    /// 原文 speaker is: there is no such thing as an automatic voice. <see cref="TtsService"/> maps
+    /// 自動 onto Chinese, so English or Japanese text would be read aloud in a Chinese voice — which
+    /// used to happen silently, leaving the user to work out from the sound that a picker three
+    /// controls away was the cause. Recognition can run on 自動 because it is choosing between
+    /// three scripts it can see; a voice has nothing to look at.</para>
+    ///
+    /// <para>Also off until recognition has produced something, because until then it is a button
+    /// whose whole action is to do nothing.</para>
+    ///
+    /// <para>Not switched off while a translation is in flight, unlike everything else on this bar:
+    /// the text being read is the one already recognised, the new batch does not touch it, and the
+    /// button is also the only way to stop playback that is already running.</para>
+    /// </remarks>
+    private void RenderSpeakButton()
+    {
+        var automatic = LanguageData.IsAutomaticSource(SrcLangBox.SelectedValue as string);
+
+        // Before the button goes dead: it is the only thing that can stop what it started.
+        if (automatic && _isSpeaking) SpeakStopRequested?.Invoke(this, EventArgs.Empty);
+
+        TtsBtn.IsEnabled = _hasSpeakableText && !automatic;
+
+        // The glyph and the word are what pressing it does, the way the realtime bar's pause
+        // button works. Both, not just the glyph: a stop square under the word 朗讀 says two
+        // different things at once. Two characters either way, so the row does not shift.
+        TtsGlyph.Text = _isSpeaking ? StopGlyph : SpeakGlyph;
+        TtsLabel.Text = LocalizationService.Get(_isSpeaking ? "S.Toolbar.SpeakStopLabel" : "S.Toolbar.Speak");
+
+        // Read through the service rather than bound in XAML, because which of the three applies is
+        // a state and not a constant.
+        TtsBtn.ToolTip = LocalizationService.Get(
+            automatic ? "S.Toolbar.SpeakAutomatic"
+                      : !_hasSpeakableText ? "S.Toolbar.SpeakNoText"
+                      : _isSpeaking ? "S.Toolbar.SpeakStop"
+                      : "S.Toolbar.SpeakHint");
+    }
+
     public void SetTranslationState(bool hasTranslated)
     {
         _hasTranslated = hasTranslated;
         if (!_isBusy)
-            TranslateBtn.Content = LocalizationService.Get(
+            TranslateLabel.Text = LocalizationService.Get(
                 hasTranslated ? "S.Toolbar.Retranslate" : "S.Toolbar.Translate");
     }
 
@@ -233,15 +316,15 @@ public partial class ToolbarWindow : Window
     {
         _toggleEnabled   = enabled;
         _bubblesVisible  = true;
-        ToggleBtn.Content = LocalizationService.Get("S.Toolbar.ShowSource");
+        ToggleLabel.Text = LocalizationService.Get("S.Toolbar.ShowSource");
         ToggleBtn.IsEnabled = !_isBusy && _toggleEnabled;
         BubblesVisibilityChanged?.Invoke(this, _bubblesVisible);
     }
 
     private void ToggleBtn_Click(object sender, RoutedEventArgs e)
     {
-        _bubblesVisible   = !_bubblesVisible;
-        ToggleBtn.Content = LocalizationService.Get(
+        _bubblesVisible  = !_bubblesVisible;
+        ToggleLabel.Text = LocalizationService.Get(
             _bubblesVisible ? "S.Toolbar.ShowSource" : "S.Toolbar.ShowTranslation");
         BubblesVisibilityChanged?.Invoke(this, _bubblesVisible);
     }

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
@@ -11,6 +11,18 @@ public partial class ToolbarWindow : Window
     private const string SpeakGlyph = Controls.TtsGlyphs.Speak;
     private const string StopGlyph = Controls.TtsGlyphs.Stop;
 
+    /// <summary>
+    /// The eye the toggle shows while the translation is on screen, and the struck-through one it
+    /// shows while the original is.
+    /// </summary>
+    /// <remarks>
+    /// Both are the action, like the label beside them: pressing the first reveals the original,
+    /// pressing the second puts it away again. A fixed eye under a label that changed was the icon
+    /// disagreeing with the word next to it every second press.
+    /// </remarks>
+    private const string RevealGlyph = "\uE890";
+    private const string HideGlyph = "\uED1A";
+
     public event EventHandler<TranslateRequest>? TranslateRequested;
     public event EventHandler? OpenWindowRequested;
     public event EventHandler? CopyScreenshotRequested;
@@ -199,6 +211,14 @@ public partial class ToolbarWindow : Window
     private void TtsBtn_Click(object sender, RoutedEventArgs e)
         => SpeakToggleRequested?.Invoke(this, EventArgs.Empty);
 
+    /// <summary>Puts the toggle's icon and label on the same side of what pressing it would do.</summary>
+    private void RenderToggleButton()
+    {
+        ToggleGlyph.Text = _bubblesVisible ? RevealGlyph : HideGlyph;
+        ToggleLabel.Text = LocalizationService.Get(
+            _bubblesVisible ? "S.Toolbar.ShowSource" : "S.Toolbar.ShowTranslation");
+    }
+
     private void CopyShotBtn_Click(object sender, RoutedEventArgs e)
         => CopyScreenshotRequested?.Invoke(this, EventArgs.Empty);
 
@@ -316,16 +336,15 @@ public partial class ToolbarWindow : Window
     {
         _toggleEnabled   = enabled;
         _bubblesVisible  = true;
-        ToggleLabel.Text = LocalizationService.Get("S.Toolbar.ShowSource");
+        RenderToggleButton();
         ToggleBtn.IsEnabled = !_isBusy && _toggleEnabled;
         BubblesVisibilityChanged?.Invoke(this, _bubblesVisible);
     }
 
     private void ToggleBtn_Click(object sender, RoutedEventArgs e)
     {
-        _bubblesVisible  = !_bubblesVisible;
-        ToggleLabel.Text = LocalizationService.Get(
-            _bubblesVisible ? "S.Toolbar.ShowSource" : "S.Toolbar.ShowTranslation");
+        _bubblesVisible = !_bubblesVisible;
+        RenderToggleButton();
         BubblesVisibilityChanged?.Invoke(this, _bubblesVisible);
     }
 

--- a/src/OverTranslate/Views/Controls/TtsGlyphs.cs
+++ b/src/OverTranslate/Views/Controls/TtsGlyphs.cs
@@ -1,0 +1,21 @@
+namespace OverTranslate.Views.Controls;
+
+/// <summary>
+/// The two icon-font glyphs every speak button in the application shares.
+/// </summary>
+/// <remarks>
+/// In one place because there are now two of these buttons - the translation page's pair and the
+/// capture toolbar's - and a user who meets both should not find the same action drawn two ways.
+/// Segoe MDL2 codepoints, so they survive Windows 10, where Segoe Fluent Icons is not installed.
+///
+/// Which of the two shows is the action, not the state: a button reading text aloud offers to stop,
+/// the same way the realtime bar's pause button offers what pressing it would do.
+/// </remarks>
+internal static class TtsGlyphs
+{
+    /// <summary>Speaker - start reading.</summary>
+    public const string Speak = "\uE767";
+
+    /// <summary>Stop - end the reading this button started.</summary>
+    public const string Stop = "\uE71A";
+}

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -35,6 +35,11 @@ public partial class MainWindow : Window
     // callers, not the holder, and the call sites below name AppServices directly so that reading
     // any one of them shows where the engine comes from.
 
+    // The voice for the capture toolbar's speak button. Its own instance rather than the
+    // translation page's: the two are separate places with separate stop buttons, and one shared
+    // player would have the page's speaker silently stop a capture that is still reading.
+    private readonly TtsService _tts = new();
+
     // Kept alive so toolbar translate can re-run OCR/translation on the current selection
     private List<OcrTextBlock> _lastOcrBlocks = [];
     private List<TranslatedBlock> _lastColoredBlocks = [];
@@ -53,6 +58,11 @@ public partial class MainWindow : Window
     {
         var helper = new WindowInteropHelper(this);
         helper.EnsureHandle();
+
+        // The service reports every end of playback — natural, failed, or stopped — and the toolbar
+        // button has to come back from ⏹ to the speaker whichever it was. Start is reflected on the
+        // press instead, so the icon does not wait on the fetch.
+        _tts.StateChanged += (_, _) => _toolbarWindow?.SetSpeaking(_tts.IsActive);
 
         InitNotifyIcon();
         RegisterHotkey();
@@ -556,9 +566,12 @@ public partial class MainWindow : Window
         toolbar.CopyScreenshotRequested += OnCopyScreenshotRequested;
         toolbar.CloseAllRequested       += (_, _) => CloseAll();
         toolbar.BubblesVisibilityChanged += (_, visible) => _overlayWindow?.SetBubblesVisible(visible);
+        toolbar.SpeakToggleRequested    += OnSpeakToggleRequested;
+        toolbar.SpeakStopRequested      += (_, _) => _tts.Stop();
         _toolbarWindow = toolbar;
         toolbar.SetTranslationState(hasTranslated);
         toolbar.SetToggleEnabled(blocks.Count > 0);
+        toolbar.SetSpeakableText(SourceTextForSpeech().Length > 0);
         toolbar.Show();
     }
 
@@ -757,6 +770,7 @@ public partial class MainWindow : Window
             _overlayWindow?.UpdateBlocks(_lastColoredBlocks, _lastSelPhysLeft, _lastSelPhysTop, _lastSelPhysWidth, _lastSelPhysHeight, req.SourceLang, req.TargetLang);
             requestToolbar?.SetTranslationState(_lastColoredBlocks.Count > 0);
             requestToolbar?.SetToggleEnabled(_lastColoredBlocks.Count > 0);
+            requestToolbar?.SetSpeakableText(SourceTextForSpeech().Length > 0);
             ShowBalloon(
                 LocalizationService.Get("S.Main.TranslateFailedTitle"),
                 LocalizationService.Format("S.Main.TranslateFailedBody", ex.Message), selRect);
@@ -855,6 +869,55 @@ public partial class MainWindow : Window
         }
     }
 
+    /// <summary>
+    /// Reads the recognised source text aloud, or stops it if it is already being read.
+    /// </summary>
+    /// <remarks>
+    /// The whole recognised text in one go, joined exactly the way the translation window is opened
+    /// with it. The blocks are how the picture was cut up for recognition — one per line of a
+    /// subtitle, one per label on a form — not how the sentence was written, so reading them one at
+    /// a time would deliver a paragraph as a list of fragments with a pause after each.
+    ///
+    /// The source text rather than the translation: this is for hearing how the thing on screen is
+    /// said, which is also why it needs a real source language and why the button is switched off
+    /// until it has one. See <c>ToolbarWindow.RenderSpeakButton</c>.
+    /// </remarks>
+    private async void OnSpeakToggleRequested(object? sender, EventArgs e)
+    {
+        if (_tts.IsActive) { _tts.Stop(); return; }
+        if (_toolbarWindow is not { } toolbar) return;
+
+        var text = SourceTextForSpeech();
+        if (text.Length == 0) return;
+
+        var lang = toolbar.CurrentSourceLang;
+        // Belt and braces: the button is already disabled on 自動, and a voice picked for a language
+        // nobody chose reads English aloud in Chinese.
+        if (Models.LanguageData.IsAutomaticSource(lang)) return;
+
+        // Shown on the press rather than waited for: fetching the audio takes a moment, and the one
+        // thing the user needs immediately is the way to stop it.
+        toolbar.SetSpeaking(true);
+        try
+        {
+            await _tts.SpeakAsync(text, lang);
+        }
+        catch (Exception ex)
+        {
+            Log.Warn(ex, "Toolbar text-to-speech failed");
+            ShowBalloon(
+                LocalizationService.Get("S.Main.SpeakFailedTitle"),
+                LocalizationService.Format("S.Main.SpeakFailedBody", ex.Message),
+                CurrentSelectionRect());
+        }
+    }
+
+    private string SourceTextForSpeech() =>
+        JoinWithoutLineBreaks(_lastOcrBlocks.Select(b => b.Text)).Trim();
+
+    private System.Windows.Rect CurrentSelectionRect() => new(
+        _lastSelPhysLeft, _lastSelPhysTop, _lastSelPhysWidth, _lastSelPhysHeight);
+
     private void OnOpenWindowRequested(object? sender, EventArgs e)
     {
         var srcText = JoinWithoutLineBreaks(_lastOcrBlocks.Select(b => b.Text));
@@ -880,6 +943,10 @@ public partial class MainWindow : Window
         _selectionSessionId++;
         DisposeEscapeHook();
         CancelSession();
+
+        // A voice reading a selection that is no longer on screen has nothing left to be about, and
+        // nothing would be left to stop it: the button that does is going with the toolbar.
+        _tts.Stop();
 
         // A toast is positioned against the selection it reported on. Once that selection is gone it
         // has nothing left to point at, so it goes with the session rather than lingering on an

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -770,7 +770,6 @@ public partial class MainWindow : Window
             _overlayWindow?.UpdateBlocks(_lastColoredBlocks, _lastSelPhysLeft, _lastSelPhysTop, _lastSelPhysWidth, _lastSelPhysHeight, req.SourceLang, req.TargetLang);
             requestToolbar?.SetTranslationState(_lastColoredBlocks.Count > 0);
             requestToolbar?.SetToggleEnabled(_lastColoredBlocks.Count > 0);
-            requestToolbar?.SetSpeakableText(SourceTextForSpeech().Length > 0);
             ShowBalloon(
                 LocalizationService.Get("S.Main.TranslateFailedTitle"),
                 LocalizationService.Format("S.Main.TranslateFailedBody", ex.Message), selRect);
@@ -780,6 +779,11 @@ public partial class MainWindow : Window
             if (IsCurrentSelectionSession(requestSessionId, requestToolbar, requestCaptureWindow))
             {
                 _overlayWindow?.RestoreIdle(_lastColoredBlocks.Count > 0);
+
+                // Here rather than on the success path: recognition is what produces the text to
+                // read, and it has run by the time translation fails or finds nothing to translate.
+                // A run that failed at the engine still leaves the original on screen and readable.
+                requestToolbar?.SetSpeakableText(SourceTextForSpeech().Length > 0);
                 requestToolbar?.SetBusy(false);
             }
         }

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
@@ -82,7 +82,11 @@
                                    FontSize="12"
                                    Foreground="{DynamicResource AppTextSecondary}"/>
 
-                        <Separator Style="{StaticResource VerticalSeparator}"/>
+                        <!-- Wider than the shared style's own margin, and equal either side: the
+                             count ends at its last glyph and the tray after the rule starts at its
+                             own fill, so both edges are visible ones and the rule belongs midway
+                             between them. -->
+                        <Separator Style="{StaticResource VerticalSeparator}" Margin="11,0"/>
 
                         <!-- The two buttons the user chooses between while framing, in a tray of their
                              own: whether to keep drawing or to start translating is one decision, and

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml
@@ -25,217 +25,236 @@
             MouseLeftButtonDown="Chrome_MouseLeftButtonDown"
             MouseMove="Chrome_MouseMove"
             MouseLeftButtonUp="Chrome_MouseLeftButtonUp">
-        <Border x:Name="Chrome"
-                Background="{DynamicResource ToolbarBg}"
-                BorderBrush="{DynamicResource ToolbarBorder}"
-                BorderThickness="1"
-                CornerRadius="16"
-                Padding="10,6">
-            <Border.Effect>
-                <DropShadowEffect BlurRadius="20" ShadowDepth="3" Opacity="0.22" Color="#000000"/>
-            </Border.Effect>
+        <Grid>
+            <!-- The shadow rides an empty, slightly inset twin of the bar rather than the bar itself.
+                 An Effect makes WPF rasterise the element it is set on into an intermediate surface,
+                 and ClearType sub-pixel antialiasing cannot run over a surface that may be
+                 transparent — so a shadow on the bar quietly dropped every word on it to greyscale
+                 antialiasing, which at this size over moving picture is the difference between text
+                 that reads and text that looks thin and hard. Blurring an empty rectangle costs the
+                 same. Inset by 2, so the twin's own antialiased curve stays underneath the bar in
+                 front of it: two partial-coverage edges of the same colour add up, and the corner
+                 they make together steps instead of easing. The capture toolbar does the same. -->
+            <Border Background="{DynamicResource ToolbarBg}"
+                    Margin="2"
+                    CornerRadius="14">
+                <Border.Effect>
+                    <DropShadowEffect BlurRadius="20" ShadowDepth="3" Opacity="0.22" Color="#000000"/>
+                </Border.Effect>
+            </Border>
 
-            <Grid>
-                <!-- ══════════ Edit mode ══════════ -->
-                <!-- Everything the user needs while framing sits on one line. Refresh is deliberately
-                     absent here: it cannot do anything until translation has started. -->
-                <StackPanel x:Name="EditPanel" Orientation="Horizontal" VerticalAlignment="Center">
-                    <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                               FontSize="14"
-                               Margin="4,0,8,0"
-                               VerticalAlignment="Center"
-                               Foreground="{DynamicResource AppAccent}"
-                               Text="&#xE7A7;"/>
+            <!-- ClearTypeHint over an opaque background: the window itself is layered
+                 (AllowsTransparency), which is the other thing that turns ClearType off. The hint is
+                 how WPF is told this particular surface really is opaque. -->
+            <Border x:Name="Chrome"
+                    Background="{DynamicResource ToolbarBg}"
+                    BorderBrush="{DynamicResource ToolbarBorder}"
+                    BorderThickness="1"
+                    CornerRadius="16"
+                    Padding="10,6"
+                    RenderOptions.ClearTypeHint="Enabled">
+                <Grid>
+                    <!-- ══════════ Edit mode ══════════ -->
+                    <!-- Everything the user needs while framing sits on one line. Refresh is deliberately
+                         absent here: it cannot do anything until translation has started. -->
+                    <StackPanel x:Name="EditPanel" Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="14"
+                                   Margin="4,0,8,0"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource AppAccent}"
+                                   Text="&#xE7A7;"/>
 
-                    <TextBlock x:Name="EditHintText"
-                               VerticalAlignment="Center"
-                               FontFamily="{StaticResource AppFont}"
-                               FontSize="12.5"
-                               Foreground="{DynamicResource AppTextPrimary}"
-                               Text="{DynamicResource S.Realtime.EditHint}"/>
-
-                    <!-- Trailing and a size down: a running count is a reference, not an instruction.
-                         Subordinate by position and size rather than by a dimmer colour — it is the
-                         only place the user is told they have hit the block limit. -->
-                    <TextBlock x:Name="BlockCountText"
-                               VerticalAlignment="Center"
-                               Margin="8,0,0,0"
-                               FontFamily="{StaticResource AppFont}"
-                               FontSize="12"
-                               Foreground="{DynamicResource AppTextSecondary}"/>
-
-                    <Separator Style="{StaticResource VerticalSeparator}"/>
-
-                    <!-- The two buttons the user chooses between while framing, in a tray of their
-                         own: whether to keep drawing or to start translating is one decision, and
-                         set loose on the bar they read as two more pieces of furniture next to ✕.
-                         ✕ stays outside it — ending the session is not part of that decision. -->
-                    <Border Background="{DynamicResource ToolbarGroupBg}"
-                            CornerRadius="10"
-                            Padding="3"
-                            Margin="0,0,6,0">
-                        <StackPanel Orientation="Horizontal">
-                            <!-- Framing on or off, without leaving edit mode. The icon is what
-                                 pressing it does, the same way the pause button works: a plain
-                                 pointer while framing is on — press to hand the mouse back to
-                                 whatever is playing underneath — and the dashed marquee it would
-                                 bring back while it is off. A marquee rather than a crosshair
-                                 because it is the shape the user drags out on screen; a crosshair
-                                 says "precision" without saying what it would do.
-                                 Drawn as a Path because neither shape exists in Segoe MDL2, which is
-                                 all Windows 10 has; a Path also has no font fallback to lose. Its
-                                 stroke follows the button's own foreground so hover and theme
-                                 changes reach it. -->
-                            <Button x:Name="CrosshairBtn"
-                                    Style="{StaticResource ToolbarGroupIconButton}"
-                                    Foreground="{DynamicResource AppTextPrimary}"
-                                    Margin="0,0,2,0"
-                                    Click="CrosshairBtn_Click">
-                                <Path x:Name="CrosshairGlyph"
-                                      Width="16" Height="16"
-                                      Stretch="None"
-                                      Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
-                                      StrokeThickness="1.3"
-                                      StrokeStartLineCap="Round"
-                                      StrokeEndLineCap="Round"
-                                      StrokeLineJoin="Round"/>
-                            </Button>
-
-                            <!-- The accent is carried by the glyph rather than by a filled pill: a
-                                 solid accent square in a row of quiet icons was the one thing on the
-                                 bar shouting, and this bar floats over whatever the user is actually
-                                 watching. Colour alone still makes it the only coloured thing here.
-                                 A solid triangle, not the outline the resume button uses — an
-                                 outline at 16px reads as a hollow shape rather than as play, and the
-                                 two are never on screen together. Drawn rather than typed because
-                                 the solid play glyph (F5B0) is Segoe Fluent Icons only, and on
-                                 Windows 10 it would fall back to MDL2 as a missing-glyph box. The
-                                 nose sits a touch right of centre, where a triangle looks centred
-                                 rather than measures so. -->
-                            <Button x:Name="StartBtn"
-                                    Style="{StaticResource ToolbarGroupIconButton}"
-                                    Foreground="{DynamicResource AppAccent}"
-                                    ToolTip="{DynamicResource S.Realtime.StartTranslating}"
-                                    AutomationProperties.Name="{DynamicResource S.Realtime.StartTranslating}"
-                                    Click="StartBtn_Click">
-                                <Path Width="16" Height="16"
-                                      Stretch="None"
-                                      Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
-                                      Data="M5.8,2.6 L13.4,8 L5.8,13.4 Z"/>
-                            </Button>
-                        </StackPanel>
-                    </Border>
-
-                    <Button Content="✕"
-                            Style="{StaticResource ToolbarIconButton}"
-                            ToolTip="{DynamicResource S.Realtime.StopSession}"
-                            Click="CloseBtn_Click"/>
-                </StackPanel>
-
-                <!-- ══════════ Translating ══════════ -->
-                <!-- Shrunk to a capsule once the work starts: from here on the interface has nothing
-                     to ask, and the user is watching the content, not this. -->
-                <StackPanel x:Name="RunPanel"
-                            Orientation="Horizontal"
-                            VerticalAlignment="Center"
-                            Visibility="Collapsed">
-                    <Ellipse x:Name="StatusDot"
-                             Width="8" Height="8"
-                             Margin="4,0,8,0"
-                             VerticalAlignment="Center"
-                             Fill="{DynamicResource AppAccent}"/>
-
-                    <!-- The language pair, and the transient messages, share this one slot: only one
-                         of the two is ever visible. -->
-                    <TextBlock x:Name="RunStatusText"
-                               VerticalAlignment="Center"
-                               Margin="0,0,8,0"
-                               FontFamily="{StaticResource AppFont}"
-                               FontSize="12.5"
-                               Foreground="{DynamicResource AppTextPrimary}"
-                               Text="{DynamicResource S.Realtime.Running}"/>
-
-                    <!-- Source and target are not two equal labels: the target is the thing on screen
-                         from here on, so it keeps the primary colour and the source steps back one
-                         level to secondary. Not to muted — that brush is #666 on a #2A2A2A bar,
-                         2.4:1, and this is 12.5px CJK floating over whatever the user is watching.
-                         Secondary reaches 5.9:1 dark / 6.4:1 light and still reads as subordinate. The
-                         arrow between them is drawn rather than typed — U+2192 is not in the UI font,
-                         so it used to fall back to a CJK face, which renders it full-width and
-                         centred on the em box: too much air on both sides and sitting visibly high
-                         against 12.5px text. A Path has no fallback to lose and its weight and
-                         height are ours to set. -->
-                    <StackPanel x:Name="LangPairPanel"
-                                Orientation="Horizontal"
-                                VerticalAlignment="Center"
-                                Margin="0,0,8,0"
-                                Visibility="Collapsed">
-                        <TextBlock x:Name="SourceLangText"
+                        <TextBlock x:Name="EditHintText"
                                    VerticalAlignment="Center"
                                    FontFamily="{StaticResource AppFont}"
                                    FontSize="12.5"
+                                   Foreground="{DynamicResource AppTextPrimary}"
+                                   Text="{DynamicResource S.Realtime.EditHint}"/>
+
+                        <!-- Trailing and a size down: a running count is a reference, not an instruction.
+                             Subordinate by position and size rather than by a dimmer colour — it is the
+                             only place the user is told they have hit the block limit. -->
+                        <TextBlock x:Name="BlockCountText"
+                                   VerticalAlignment="Center"
+                                   Margin="8,0,0,0"
+                                   FontFamily="{StaticResource AppFont}"
+                                   FontSize="12"
                                    Foreground="{DynamicResource AppTextSecondary}"/>
 
-                        <!-- Half-pixel coordinates so the 1px stroke lands on a pixel row rather than
-                             straddling two. Bottom margin of 1 lifts it off the text box's centre and
-                             onto the CJK glyphs' optical centre, which sits above it. -->
-                        <!-- Secondary dimmed, rather than the muted brush it wants to be: muted is the
-                             same #666 the source label just left for being unreadable here, and an
-                             arrow nobody can see is not restraint, it is a missing arrow. 0.7 lands
-                             it at 3.7:1 dark / 3.3:1 light — over the 3:1 a 1px non-text stroke
-                             needs, still a step below the label it separates. -->
-                        <Path VerticalAlignment="Center"
-                              Margin="5.5,0,5.5,1"
-                              Width="10.6" Height="9"
-                              Stretch="None"
-                              Stroke="{DynamicResource AppTextSecondary}"
-                              Opacity="0.7"
-                              StrokeThickness="1"
-                              StrokeStartLineCap="Round"
-                              StrokeEndLineCap="Round"
-                              StrokeLineJoin="Round"
-                              Data="M0,4.5 H9.1 M6.8,2.6 L9.6,4.5 L6.8,6.4"/>
+                        <Separator Style="{StaticResource VerticalSeparator}"/>
 
-                        <TextBlock x:Name="TargetLangText"
-                                   VerticalAlignment="Center"
-                                   FontFamily="{StaticResource AppFont}"
-                                   FontSize="12.5"
-                                   Foreground="{DynamicResource AppTextPrimary}"/>
+                        <!-- The two buttons the user chooses between while framing, in a tray of their
+                             own: whether to keep drawing or to start translating is one decision, and
+                             set loose on the bar they read as two more pieces of furniture next to ✕.
+                             ✕ stays outside it — ending the session is not part of that decision. -->
+                        <Border Background="{DynamicResource ToolbarGroupBg}"
+                                CornerRadius="10"
+                                Padding="3"
+                                Margin="0,0,6,0">
+                            <StackPanel Orientation="Horizontal">
+                                <!-- Framing on or off, without leaving edit mode. The icon is what
+                                     pressing it does, the same way the pause button works: a plain
+                                     pointer while framing is on — press to hand the mouse back to
+                                     whatever is playing underneath — and the dashed marquee it would
+                                     bring back while it is off. A marquee rather than a crosshair
+                                     because it is the shape the user drags out on screen; a crosshair
+                                     says "precision" without saying what it would do.
+                                     Drawn as a Path because neither shape exists in Segoe MDL2, which is
+                                     all Windows 10 has; a Path also has no font fallback to lose. Its
+                                     stroke follows the button's own foreground so hover and theme
+                                     changes reach it. -->
+                                <Button x:Name="CrosshairBtn"
+                                        Style="{StaticResource ToolbarGroupIconButton}"
+                                        Foreground="{DynamicResource AppTextPrimary}"
+                                        Margin="0,0,2,0"
+                                        Click="CrosshairBtn_Click">
+                                    <Path x:Name="CrosshairGlyph"
+                                          Width="16" Height="16"
+                                          Stretch="None"
+                                          Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                          StrokeThickness="1.3"
+                                          StrokeStartLineCap="Round"
+                                          StrokeEndLineCap="Round"
+                                          StrokeLineJoin="Round"/>
+                                </Button>
+
+                                <!-- The accent is carried by the glyph rather than by a filled pill: a
+                                     solid accent square in a row of quiet icons was the one thing on the
+                                     bar shouting, and this bar floats over whatever the user is actually
+                                     watching. Colour alone still makes it the only coloured thing here.
+                                     A solid triangle, not the outline the resume button uses — an
+                                     outline at 16px reads as a hollow shape rather than as play, and the
+                                     two are never on screen together. Drawn rather than typed because
+                                     the solid play glyph (F5B0) is Segoe Fluent Icons only, and on
+                                     Windows 10 it would fall back to MDL2 as a missing-glyph box. The
+                                     nose sits a touch right of centre, where a triangle looks centred
+                                     rather than measures so. -->
+                                <Button x:Name="StartBtn"
+                                        Style="{StaticResource ToolbarGroupIconButton}"
+                                        Foreground="{DynamicResource AppAccent}"
+                                        ToolTip="{DynamicResource S.Realtime.StartTranslating}"
+                                        AutomationProperties.Name="{DynamicResource S.Realtime.StartTranslating}"
+                                        Click="StartBtn_Click">
+                                    <Path Width="16" Height="16"
+                                          Stretch="None"
+                                          Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                          Data="M5.8,2.6 L13.4,8 L5.8,13.4 Z"/>
+                                </Button>
+                            </StackPanel>
+                        </Border>
+
+                        <Button Content="✕"
+                                Style="{StaticResource ToolbarIconButton}"
+                                ToolTip="{DynamicResource S.Realtime.StopSession}"
+                                Click="CloseBtn_Click"/>
                     </StackPanel>
 
-                    <!-- Icon-only keeps the running capsule compact. Its tooltip names both the
-                         action and the user's configured keyboard equivalent. The glyph is the
-                         action, not the state: a running session shows ⏸ because that is what
-                         pressing it does — the state is said by the dot and the text beside it. -->
-                    <Button x:Name="PauseBtn"
-                            Style="{StaticResource ToolbarIconButton}"
-                            FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                            FontSize="13"
-                            Content="&#xE769;"
-                            Margin="0,0,4,0"
-                            AutomationProperties.Name="{DynamicResource S.Realtime.Pause}"
-                            Click="PauseBtn_Click"/>
+                    <!-- ══════════ Translating ══════════ -->
+                    <!-- Shrunk to a capsule once the work starts: from here on the interface has nothing
+                         to ask, and the user is watching the content, not this. -->
+                    <StackPanel x:Name="RunPanel"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center"
+                                Visibility="Collapsed">
+                        <Ellipse x:Name="StatusDot"
+                                 Width="8" Height="8"
+                                 Margin="4,0,8,0"
+                                 VerticalAlignment="Center"
+                                 Fill="{DynamicResource AppAccent}"/>
 
-                    <!-- Icon-only, like the two buttons either side of it: the capsule is meant to
-                         be read at a glance and one word set in a flat button among icons was the
-                         only thing on it drawing the eye. The pencil is the same one Windows uses
-                         for edit everywhere else, and the tooltip carries the word it replaced. -->
-                    <Button x:Name="EditBtn"
-                            Style="{StaticResource ToolbarIconButton}"
-                            FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                            FontSize="13"
-                            Content="&#xE70F;"
-                            Margin="0,0,4,0"
-                            ToolTip="{DynamicResource S.Realtime.EditBlocks}"
-                            AutomationProperties.Name="{DynamicResource S.Realtime.EditBlocks}"
-                            Click="EditBtn_Click"/>
+                        <!-- The language pair, and the transient messages, share this one slot: only one
+                             of the two is ever visible. -->
+                        <TextBlock x:Name="RunStatusText"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,0"
+                                   FontFamily="{StaticResource AppFont}"
+                                   FontSize="12.5"
+                                   Foreground="{DynamicResource AppTextPrimary}"
+                                   Text="{DynamicResource S.Realtime.Running}"/>
 
-                    <Button Content="✕"
-                            Style="{StaticResource ToolbarIconButton}"
-                            ToolTip="{DynamicResource S.Realtime.StopSession}"
-                            Click="CloseBtn_Click"/>
-                </StackPanel>
-            </Grid>
-        </Border>
+                        <!-- Source and target are not two equal labels: the target is the thing on screen
+                             from here on, so it keeps the primary colour and the source steps back one
+                             level to secondary. Not to muted — that brush is #666 on a #2A2A2A bar,
+                             2.4:1, and this is 12.5px CJK floating over whatever the user is watching.
+                             Secondary reaches 5.9:1 dark / 6.4:1 light and still reads as subordinate. The
+                             arrow between them is drawn rather than typed — U+2192 is not in the UI font,
+                             so it used to fall back to a CJK face, which renders it full-width and
+                             centred on the em box: too much air on both sides and sitting visibly high
+                             against 12.5px text. A Path has no fallback to lose and its weight and
+                             height are ours to set. -->
+                        <StackPanel x:Name="LangPairPanel"
+                                    Orientation="Horizontal"
+                                    VerticalAlignment="Center"
+                                    Margin="0,0,8,0"
+                                    Visibility="Collapsed">
+                            <TextBlock x:Name="SourceLangText"
+                                       VerticalAlignment="Center"
+                                       FontFamily="{StaticResource AppFont}"
+                                       FontSize="12.5"
+                                       Foreground="{DynamicResource AppTextSecondary}"/>
+
+                            <!-- Half-pixel coordinates so the 1px stroke lands on a pixel row rather than
+                                 straddling two. Bottom margin of 1 lifts it off the text box's centre and
+                                 onto the CJK glyphs' optical centre, which sits above it. -->
+                            <!-- Secondary dimmed, rather than the muted brush it wants to be: muted is the
+                                 same #666 the source label just left for being unreadable here, and an
+                                 arrow nobody can see is not restraint, it is a missing arrow. 0.7 lands
+                                 it at 3.7:1 dark / 3.3:1 light — over the 3:1 a 1px non-text stroke
+                                 needs, still a step below the label it separates. -->
+                            <Path VerticalAlignment="Center"
+                                  Margin="5.5,0,5.5,1"
+                                  Width="10.6" Height="9"
+                                  Stretch="None"
+                                  Stroke="{DynamicResource AppTextSecondary}"
+                                  Opacity="0.7"
+                                  StrokeThickness="1"
+                                  StrokeStartLineCap="Round"
+                                  StrokeEndLineCap="Round"
+                                  StrokeLineJoin="Round"
+                                  Data="M0,4.5 H9.1 M6.8,2.6 L9.6,4.5 L6.8,6.4"/>
+
+                            <TextBlock x:Name="TargetLangText"
+                                       VerticalAlignment="Center"
+                                       FontFamily="{StaticResource AppFont}"
+                                       FontSize="12.5"
+                                       Foreground="{DynamicResource AppTextPrimary}"/>
+                        </StackPanel>
+
+                        <!-- Icon-only keeps the running capsule compact. Its tooltip names both the
+                             action and the user's configured keyboard equivalent. The glyph is the
+                             action, not the state: a running session shows ⏸ because that is what
+                             pressing it does — the state is said by the dot and the text beside it. -->
+                        <Button x:Name="PauseBtn"
+                                Style="{StaticResource ToolbarIconButton}"
+                                FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                FontSize="13"
+                                Content="&#xE769;"
+                                Margin="0,0,4,0"
+                                AutomationProperties.Name="{DynamicResource S.Realtime.Pause}"
+                                Click="PauseBtn_Click"/>
+
+                        <!-- Icon-only, like the two buttons either side of it: the capsule is meant to
+                             be read at a glance and one word set in a flat button among icons was the
+                             only thing on it drawing the eye. The pencil is the same one Windows uses
+                             for edit everywhere else, and the tooltip carries the word it replaced. -->
+                        <Button x:Name="EditBtn"
+                                Style="{StaticResource ToolbarIconButton}"
+                                FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                FontSize="13"
+                                Content="&#xE70F;"
+                                Margin="0,0,4,0"
+                                ToolTip="{DynamicResource S.Realtime.EditBlocks}"
+                                AutomationProperties.Name="{DynamicResource S.Realtime.EditBlocks}"
+                                Click="EditBtn_Click"/>
+
+                        <Button Content="✕"
+                                Style="{StaticResource ToolbarIconButton}"
+                                ToolTip="{DynamicResource S.Realtime.StopSession}"
+                                Click="CloseBtn_Click"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </Grid>
     </Border>
 </Window>

--- a/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeControlWindow.xaml.cs
@@ -306,7 +306,9 @@ public partial class RealtimeControlWindow : Window
         Dispatcher.BeginInvoke(new Action(ClampIntoScreen), DispatcherPriority.Loaded);
     }
 
-    public void SetBlockCount(int count, int max) => BlockCountText.Text = $"· {count}/{max}";
+    // Spaced either side of the slash: at 12px the bare 1/1 reads as one glyph cluster rather than
+    // as a count out of a limit, which is the one thing this line is here to say.
+    public void SetBlockCount(int count, int max) => BlockCountText.Text = $"· {count} / {max}";
 
     /// <summary>Pulses the status dot while a recognition or translation pass is in flight.</summary>
     public void SetBusy(bool busy)

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -343,8 +343,8 @@ public partial class TranslationPage : UserControl
     /// Icon-font glyphs rather than the emoji these used to be, so that they share a vertical axis
     /// with the clear button beside them — see the comment on the 原文 header in the XAML.
     /// </remarks>
-    private const string SpeakerGlyph = "\uE767";
-    private const string StopGlyph = "\uE71A";
+    private const string SpeakerGlyph = Views.Controls.TtsGlyphs.Speak;
+    private const string StopGlyph = Views.Controls.TtsGlyphs.Stop;
 
     private void UpdateTtsIcons()
     {


### PR DESCRIPTION
## 動機

截圖翻譯的工具列沒有朗讀功能，而使用者常常需要聽原文怎麼念。順帶依設計稿重排整個按鈕區。

## 內容

### 1. 朗讀原文

- 位置在工具列**最左邊、來源語言下拉的前面**：那顆下拉正是它用什麼聲音念、以及它會不會被停用的依據，位置本身就說明了「這是給原文的」，標籤不必撐成四個字。
- 讀的是**辨識到的原文全文**，用跟「開啟翻譯視窗」完全相同的方式把所有 block 併成一段。block 是圖片被切開的方式，不是句子被寫出來的方式，逐塊念會變成一串碎片。
- 原文語言為「自動」時停用並在 tooltip 說明原因（`TtsService` 會把「自動」對應到中文，英文原文會用中文聲音念出來）。尚未辨識到文字時也停用。
- 圖示與文字一起切換：朗讀 🔊 ↔ 停止 ⏹。兩者都是兩個字，排版不會跳動。
- 翻譯進行中不停用它：讀的是已經辨識好的文字，而且它同時是唯一能停止播放的按鈕。
- 結束截圖工作階段、或把來源語言切回「自動」時都會停止播放。
- 圖示字符抽到 `Views/Controls/TtsGlyphs.cs` 共用，文字翻譯頁那兩顆也改成引用它。

### 2. 工具列重新設計

- 每個動作變成**圖示＋名稱橫排**，圖示吃強調色、文字維持一般色，一整排讀起來是同一個節奏。
- 「翻譯」改為圓角膠囊＋雙星圖示，並改用專屬色票 `ToolbarPrimaryBg`：深色主題的 `AppAccent` 是淺青色配黑字（頁面上的 Fluent 正解），但在浮於使用者畫面上的深色列上是一塊很亮的補丁。深色主題改用深到足以承載白字的藍，淺色主題的 accent 本來就是這個藍、也已經是白字，所以維持用 accent。
- 「開啟翻譯視窗」保留邊框與抬升底色，因為它是唯一會結束這次工作階段的動作。它有自己的 hover template，否則淺色主題下的層級差幾乎看不出來。
- 「顯示原文／顯示譯文」的圖示跟著標籤切換（👁 ↔ 劃掉的眼睛），原本固定一顆眼睛配會變的文字，每按第二下就自相矛盾。
- 分隔線改用間距；換向鍵與 ✕ 補上 tooltip。

雙星與播放三角形都用 `Path` 繪製而非圖示字型：對應的實心字符只存在於 Segoe Fluent Icons，而本專案 `SupportedOSPlatformVersion` 為 Windows 10 1809，在那裡會 fallback 成 MDL2 的缺字方框。

### 3. 文字與邊緣的渲染品質

兩條懸浮列（截圖工具列、即時翻譯懸浮列）都是 `AllowsTransparency` 的分層視窗，而且外框掛著 `DropShadowEffect`。Effect 會強迫 WPF 把子樹先畫進中介圖層，ClearType 次像素反鋸齒無法在可能透明的表面上運作，於是所有文字掉回灰階反鋸齒——小字級中文會顯得又細又硬。

改法是把陰影搬到一個**空的、內縮 2px 的分身邊框**上，內容邊框本身不掛 Effect 並加上 `RenderOptions.ClearTypeHint="Enabled"`。內縮是必要的：分身若與前方實體同尺寸同圓角，兩條同色的半透明邊緣會相加，圓角會從平滑過渡變成跳階。翻譯膠囊的藍色光暈同理。

`ShellWindow` 的內容區早先就用同一招解過（那邊是被動畫的 bitmap cache 觸發）。

## 驗證

- 建置成功，523 個測試通過。
- 以拋棄式 WPF probe 離線 render 真正的 `ToolbarWindow` 與 `RealtimeControlWindow`，確認深色／淺色主題下的排版、朗讀中狀態、顯示原文狀態，並以 1x 實際像素放大檢查圓角反鋸齒。
- ClearType 本身 probe 驗證不到（`RenderTargetBitmap` 不使用 ClearType），已由實機確認。
- 朗讀的實際播放需連外抓語音，需實機驗收。

## 已知範圍

即時翻譯的區塊視窗（顯示譯文的那些小視窗）沒有套用 ClearTypeHint。它的文字有時疊在半透明遮罩上，宣告表面不透明會在透出的畫面上產生色彩邊紋，需要另外評估。
