### PR TITLE
fix: 即時翻譯進階選項的說明改為適用情境

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -179,7 +179,7 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.NaturalBackgroundHint">Tries to remove the original text and rebuild the background from the surrounding picture, so the translation sits in the scene.</sys:String>
     <sys:String x:Key="S.Realtime.SampleTextColor">Keep the original text colour</sys:String>
     <sys:String x:Key="S.Realtime.SampleTextColorHint">Samples the original text's colour first, and uses the colour you set when recognition is unreliable.</sys:String>
-    <sys:String x:Key="S.Realtime.AdvancedOptionsCost">Advanced options need extra processing, so enabling them may affect performance.</sys:String>
+    <sys:String x:Key="S.Realtime.AdvancedOptionsBestFor">Advanced options suit steadier scenes — a dialogue box, a menu, a static picture. When the picture changes quickly, the background and the text colour may not keep up with it.</sys:String>
 
     <sys:String x:Key="S.Realtime.HowItWorks">How it works</sys:String>
     <sys:String x:Key="S.Realtime.Step1">1. Click "Select blocks" and drag over the areas you want translated.</sys:String>
@@ -233,7 +233,7 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.ScreenPrompt">Choose the screen to read.</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowPromptLine">Choose the window to read.</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowPrompt">Choose a window</sys:String>
-    <sys:String x:Key="S.Realtime.CaptureWindowHint">The list is what was open when you last refreshed - press refresh after opening the app.</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureWindowHint">The window list updates when you press Refresh. If you have just opened another app, refresh before choosing.</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowNone">No window can be captured. Open the app first, then refresh.</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowDetail">from {0}</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowOnScreen">Blocks will be framed on {0}.</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -188,7 +188,9 @@
     <sys:String x:Key="S.Realtime.NaturalBackgroundHint">嘗試移除原文並以周圍畫面補背景，讓譯文更自然融入畫面。</sys:String>
     <sys:String x:Key="S.Realtime.SampleTextColor">沿用原文字顏色</sys:String>
     <sys:String x:Key="S.Realtime.SampleTextColorHint">優先取樣原文字顏色，若辨識不穩定則改用你設定的文字顏色。</sys:String>
-    <sys:String x:Key="S.Realtime.AdvancedOptionsCost">進階選項需要額外處理資源，啟用後可能影響效能。</sys:String>
+    <!-- 不是效能警語。這兩個選項都靠讀取畫面上原本的像素來運作，畫面靜止時讀到的就是對的，
+         畫面快速變動時讀到的是上一瞬間的樣子——這是合不合適的問題，不是快不快的問題。 -->
+    <sys:String x:Key="S.Realtime.AdvancedOptionsBestFor">進階選項適合較為穩定的情境，例如對話框、選單或靜態畫面等。畫面快速變動時，背景與文字顏色可能無法即時貼合。</sys:String>
 
     <sys:String x:Key="S.Realtime.HowItWorks">運作方式</sys:String>
     <sys:String x:Key="S.Realtime.Step1">1. 點擊「選取翻譯區塊」，在畫面上框選要翻譯的區域。</sys:String>
@@ -247,7 +249,7 @@
     <sys:String x:Key="S.Realtime.ScreenPrompt">選擇要擷取的螢幕。</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowPromptLine">選擇要擷取的視窗。</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowPrompt">請選擇視窗</sys:String>
-    <sys:String x:Key="S.Realtime.CaptureWindowHint">清單是按下重新整理當下開著的視窗，剛開好的程式請再按一次重新整理。</sys:String>
+    <sys:String x:Key="S.Realtime.CaptureWindowHint">視窗清單會在按下「重新整理」時更新；若剛開啟新的程式，請重新整理後再選擇。</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowNone">找不到可以擷取的視窗，請先開啟要翻譯的程式，再按重新整理。</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowDetail">來自 {0}</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowOnScreen">字幕框選會在{0}上進行。</sys:String>

--- a/src/OverTranslate/Views/Realtime/RealtimePage.xaml
+++ b/src/OverTranslate/Views/Realtime/RealtimePage.xaml
@@ -639,8 +639,17 @@
                             </StackPanel>
                         </Border>
 
-                        <!-- Outside the group rather than inside it: it is not a third option, it is
-                             what both of the two above cost. -->
+                        <!-- Outside the group rather than inside it: it is not a third option, it
+                             is when both of the two above are worth having.
+
+                             It used to warn about performance, which was not true and pointed the
+                             reader at the wrong question. Both options work by reading the pixels
+                             already on screen: the colour sampler reads once, when a line is rebuilt
+                             after the text changed, and the background repair runs on its own thread
+                             at 4Hz over the block's own strip and stops at a fingerprint when the
+                             picture has not moved. What actually decides whether to turn them on is
+                             the content: a picture that holds still is one they can read correctly,
+                             and a picture that does not is one they are always a moment behind. -->
                         <Grid Margin="4,0,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
@@ -654,7 +663,7 @@
                                        Margin="0,3,7,0"
                                        VerticalAlignment="Top"/>
                             <TextBlock Grid.Column="1"
-                                       Text="{DynamicResource S.Realtime.AdvancedOptionsCost}"
+                                       Text="{DynamicResource S.Realtime.AdvancedOptionsBestFor}"
                                        Style="{StaticResource FieldHint}"
                                        Margin="0"/>
                         </Grid>

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -19,7 +19,7 @@
                  MinWidth still fits an icon and a short label; MaxWidth stops the rail from
                  eating the page beside it. -->
             <ColumnDefinition x:Name="SidebarColumn"
-                              Width="220" MinWidth="180" MaxWidth="300"/>
+                              Width="230" MinWidth="180" MaxWidth="300"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 


### PR DESCRIPTION
## 動機

即時翻譯「顯示外觀 → 進階選項」下方的小字寫的是「進階選項需要額外處理資源，啟用後可能影響效能」。這句話不準確，而且把讀者指向錯誤的問題。

讀過實作後確認兩個選項的實際成本：

| | 何時執行 | 成本 |
|---|---|---|
| 兩個都關 | — | `RealtimeBlockWindow` 完全不讀螢幕 |
| 沿用原文字顏色 | 只在譯文回來、重建行時讀一次 | 對一行的範圍掃像素 |
| 更符合原背景 | 250ms 週期，跑在 dispatcher 之外 | 只抓區塊自己那條、指紋隔像素取樣、畫面沒動就在比對處停住 |

背景修補早先已從 `DispatcherTimer` 改為 `Task.Run` + `PeriodicTimer`，不佔 UI 執行緒；每次 tick 先做 `FrameFingerprint` 比對，畫面沒動就直接跳過修補。靜止畫面下等於一秒 4 次對字幕大小的長條做 BitBlt 加抽樣比對。

真正決定要不要開這兩個選項的是**內容**：兩者都靠讀取畫面上原本的像素運作，畫面靜止時讀到的就是對的，畫面快速變動時讀到的是上一瞬間的樣子。

## 內容

- 進階選項下方的小字改為適用情境說明，資源鍵從 `S.Realtime.AdvancedOptionsCost` 改名為 `S.Realtime.AdvancedOptionsBestFor`（舊鍵名會讓下一個讀到的人以為它在講成本）。XAML 註解一併改寫，記下為什麼原本那句是錯的。

  > 進階選項適合較為穩定的情境，例如對話框、選單或靜態畫面等。畫面快速變動時，背景與文字顏色可能無法即時貼合。

- 選擇「視窗擷取」後出現的下拉選單，其提示文字改寫得更明確。

  > 視窗清單會在按下「重新整理」時更新；若剛開啟新的程式，請重新整理後再選擇。

英文字串同步調整。

## 驗證

建置成功，523 個測試通過（含 `StringsParityTests` 的鍵值對照與引用檢查）。

純文案與資源鍵變更，沒有行為改動。
