### PR TITLE
fix: #116 修正 Windows 10 視窗擷取固定取不到畫面

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -241,7 +241,9 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.ChooseWindowFirst">Choose the window to translate first</sys:String>
     <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">This PC cannot capture a window (Windows 10 1903 or later is required) - use the whole screen instead</sys:String>
     <sys:String x:Key="S.Realtime.WindowCaptureGone">That window has closed or been minimised - refresh the list and pick it again</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFailed">That window cannot be captured, which usually means a game in exclusive fullscreen. Use the whole screen instead</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFailed">That window cannot be captured - pick another window and try again</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">That program is presenting in exclusive fullscreen, which cannot be captured. Set its display mode to windowed or borderless window and try again</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">That window sent no picture at all. A game running fullscreen is the usual cause - set its display mode to windowed or borderless window and try again. If every window behaves this way, please report it with app.log attached</sys:String>
     <sys:String x:Key="S.Realtime.SessionEndedTitle">Realtime translation ended</sys:String>
     <sys:String x:Key="S.Realtime.RemoveBlock">Remove this block</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -239,11 +239,11 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowOnScreen">Blocks will be framed on {0}.</sys:String>
     <sys:String x:Key="S.Realtime.RefreshWindows">Refresh</sys:String>
     <sys:String x:Key="S.Realtime.ChooseWindowFirst">Choose the window to translate first</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">This PC cannot capture a window (Windows 10 1903 or later is required) - use the whole screen instead</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">This PC cannot capture the screen for realtime translation (Windows 10 1903 or later is required)</sys:String>
     <sys:String x:Key="S.Realtime.WindowCaptureGone">That window has closed or been minimised - refresh the list and pick it again</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFailed">That window cannot be captured - pick another window and try again</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">That program is presenting in exclusive fullscreen, which cannot be captured. Set its display mode to windowed or borderless window and try again</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">That window sent no picture at all. A game running fullscreen is the usual cause - set its display mode to windowed or borderless window and try again. If every window behaves this way, please report it with app.log attached</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFailed">That window cannot be captured. If it is a game running fullscreen, set its display mode to borderless window or windowed and try again</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">That program is presenting in exclusive fullscreen, which cannot be captured. Set its display mode to borderless window or windowed and try again</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">That window sent no picture at all. A game running fullscreen is the usual cause - set its display mode to borderless window or windowed and try again. If every window behaves this way, please report it with app.log attached</sys:String>
     <sys:String x:Key="S.Realtime.SessionEndedTitle">Realtime translation ended</sys:String>
     <sys:String x:Key="S.Realtime.RemoveBlock">Remove this block</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -239,11 +239,11 @@ Details: {0}</sys:String>
     <sys:String x:Key="S.Realtime.CaptureWindowOnScreen">Blocks will be framed on {0}.</sys:String>
     <sys:String x:Key="S.Realtime.RefreshWindows">Refresh</sys:String>
     <sys:String x:Key="S.Realtime.ChooseWindowFirst">Choose the window to translate first</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">This PC cannot capture the screen for realtime translation (Windows 10 1903 or later is required)</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureGone">That window has closed or been minimised - refresh the list and pick it again</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFailed">That window cannot be captured. If it is a game running fullscreen, set its display mode to borderless window or windowed and try again</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">That program is presenting in exclusive fullscreen, which cannot be captured. Set its display mode to borderless window or windowed and try again</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">That window sent no picture at all. A game running fullscreen is the usual cause - set its display mode to borderless window or windowed and try again. If every window behaves this way, please report it with app.log attached</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">This version of Windows does not support screen capture.</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureGone">That window has closed or been minimised. Pick a window again.</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFailed">That window cannot be captured. Switch it to borderless window or windowed and try again.</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">That display mode cannot be captured. Switch to borderless window or windowed and try again.</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">No picture could be taken from that window. Switch it to borderless window or windowed and try again.</sys:String>
     <sys:String x:Key="S.Realtime.SessionEndedTitle">Realtime translation ended</sys:String>
     <sys:String x:Key="S.Realtime.RemoveBlock">Remove this block</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -255,11 +255,11 @@
     <sys:String x:Key="S.Realtime.CaptureWindowOnScreen">字幕框選會在{0}上進行。</sys:String>
     <sys:String x:Key="S.Realtime.RefreshWindows">重新整理</sys:String>
     <sys:String x:Key="S.Realtime.ChooseWindowFirst">請先選擇要翻譯的視窗</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">這台電腦不支援「視窗擷取」（需要 Windows 10 1903 以上），請改用「螢幕擷取」</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">這台電腦不支援即時翻譯所需的畫面擷取（需要 Windows 10 1903 以上）</sys:String>
     <sys:String x:Key="S.Realtime.WindowCaptureGone">選定的視窗已經關閉或最小化，請按重新整理後再選一次</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFailed">無法擷取選定的視窗，請改選其他視窗再試一次</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">選定的程式正在以「獨佔全螢幕」呈現畫面，這種畫面擷取不到。請把它的顯示模式改成「視窗化」或「無邊框視窗」後再試一次</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">選定的視窗沒有送出任何畫面，全螢幕執行的遊戲通常是這個原因。請把它的顯示模式改成「視窗化」或「無邊框視窗」後再試一次；若每個視窗都一樣，請附上 app.log 回報</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFailed">無法擷取選定的視窗。若它是全螢幕執行的遊戲，請把顯示模式改成「無邊框視窗」或「視窗化」後再試一次</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">選定的程式正在以「獨佔全螢幕」呈現畫面，這種畫面擷取不到。請把它的顯示模式改成「無邊框視窗」或「視窗化」後再試一次</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">選定的視窗沒有送出任何畫面，全螢幕執行的遊戲通常是這個原因。請把它的顯示模式改成「無邊框視窗」或「視窗化」後再試一次；若每個視窗都一樣，請附上 app.log 回報</sys:String>
     <sys:String x:Key="S.Realtime.SessionEndedTitle">即時翻譯已結束</sys:String>
     <sys:String x:Key="S.Realtime.RemoveBlock">移除此區塊</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -255,11 +255,11 @@
     <sys:String x:Key="S.Realtime.CaptureWindowOnScreen">字幕框選會在{0}上進行。</sys:String>
     <sys:String x:Key="S.Realtime.RefreshWindows">重新整理</sys:String>
     <sys:String x:Key="S.Realtime.ChooseWindowFirst">請先選擇要翻譯的視窗</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">這台電腦不支援即時翻譯所需的畫面擷取（需要 Windows 10 1903 以上）</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureGone">選定的視窗已經關閉或最小化，請按重新整理後再選一次</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFailed">無法擷取選定的視窗。若它是全螢幕執行的遊戲，請把顯示模式改成「無邊框視窗」或「視窗化」後再試一次</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">選定的程式正在以「獨佔全螢幕」呈現畫面，這種畫面擷取不到。請把它的顯示模式改成「無邊框視窗」或「視窗化」後再試一次</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">選定的視窗沒有送出任何畫面，全螢幕執行的遊戲通常是這個原因。請把它的顯示模式改成「無邊框視窗」或「視窗化」後再試一次；若每個視窗都一樣，請附上 app.log 回報</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">目前的 Windows 版本不支援此畫面擷取功能。</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureGone">指定的視窗已關閉或最小化，請重新選擇視窗。</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFailed">無法擷取此視窗，請切換至「無邊框視窗」或「視窗化」後再試一次。</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">目前的顯示模式無法擷取，請切換至「無邊框視窗」或「視窗化」後再試一次。</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">無法取得視窗畫面，請切換至「無邊框視窗」或「視窗化」後再試一次。</sys:String>
     <sys:String x:Key="S.Realtime.SessionEndedTitle">即時翻譯已結束</sys:String>
     <sys:String x:Key="S.Realtime.RemoveBlock">移除此區塊</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -257,7 +257,9 @@
     <sys:String x:Key="S.Realtime.ChooseWindowFirst">請先選擇要翻譯的視窗</sys:String>
     <sys:String x:Key="S.Realtime.WindowCaptureUnsupported">這台電腦不支援「視窗擷取」（需要 Windows 10 1903 以上），請改用「螢幕擷取」</sys:String>
     <sys:String x:Key="S.Realtime.WindowCaptureGone">選定的視窗已經關閉或最小化，請按重新整理後再選一次</sys:String>
-    <sys:String x:Key="S.Realtime.WindowCaptureFailed">無法擷取選定的視窗，獨佔全螢幕的遊戲通常是這個原因。請改用「螢幕擷取」</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFailed">無法擷取選定的視窗，請改選其他視窗再試一次</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureFullscreen">選定的程式正在以「獨佔全螢幕」呈現畫面，這種畫面擷取不到。請把它的顯示模式改成「視窗化」或「無邊框視窗」後再試一次</sys:String>
+    <sys:String x:Key="S.Realtime.WindowCaptureNoFrame">選定的視窗沒有送出任何畫面，全螢幕執行的遊戲通常是這個原因。請把它的顯示模式改成「視窗化」或「無邊框視窗」後再試一次；若每個視窗都一樣，請附上 app.log 回報</sys:String>
     <sys:String x:Key="S.Realtime.SessionEndedTitle">即時翻譯已結束</sys:String>
     <sys:String x:Key="S.Realtime.RemoveBlock">移除此區塊</sys:String>
 

--- a/src/OverTranslate/Services/Realtime/Capture/WgcInterop.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcInterop.cs
@@ -28,6 +28,7 @@ internal static class WgcInterop
     private static readonly Guid IidGraphicsCaptureItem = new("79C3F95B-31F7-4EC2-A464-632EF5D30760");
     private static readonly Guid IidGraphicsCaptureItemInterop = new("3628E81B-3CAC-4C60-B7F4-23CE0E0C3356");
     private static readonly Guid IidDxgiDevice = new("54EC77FA-1377-44E6-8C32-88FD5F44C84C");
+    private static readonly Guid IidDxgiFactory1 = new("770AAE78-F26F-4DBA-A829-253C83D1B387");
 
     private const string GraphicsCaptureItemClassId = "Windows.Graphics.Capture.GraphicsCaptureItem";
 
@@ -99,24 +100,84 @@ internal static class WgcInterop
     /// without a channel shuffle. The device is created without a debug layer and without a swap
     /// chain — nothing here presents anything.
     /// </remarks>
-    public static IDirect3DDevice CreateDirect3DDevice(out IntPtr rawDevice)
+    public static IDirect3DDevice CreateDirect3DDevice(out IntPtr rawDevice) =>
+        CreateDirect3DDevice(IntPtr.Zero, false, out rawDevice, out _);
+
+    /// <inheritdoc cref="CreateDirect3DDevice(out IntPtr)"/>
+    /// <param name="preferredMonitor">
+    /// The monitor the capture source is on, or <see cref="IntPtr.Zero"/> for no preference. Used to
+    /// pick the adapter the device is created on.
+    /// </param>
+    /// <param name="forceWarp">
+    /// Skip the hardware adapters entirely and render on the software one. The retry after a
+    /// hardware device produced no frames at all.
+    /// </param>
+    /// <param name="description">Which adapter was used, for the log.</param>
+    /// <remarks>
+    /// The adapter is not a free choice, and getting it wrong is silent. Windows.Graphics.Capture
+    /// delivers frames onto the device it is given, and on Windows 10 a device on an adapter other
+    /// than the one composing that monitor is not an error — <c>StartCapture</c> succeeds, the item
+    /// reports the right size, and <c>FrameArrived</c> then never fires. That is exactly the shape
+    /// of the report this was written for: capture attached, no frame at all, in every display mode
+    /// the game offered.
+    ///
+    /// So the adapter is chosen rather than defaulted. The one that owns the monitor the source is
+    /// on is asked for by name, which on a hybrid machine — a laptop with two GPUs, a desktop with
+    /// the integrated display output still enabled — is not necessarily adapter zero, which is what
+    /// passing null gets.
+    /// </remarks>
+    public static IDirect3DDevice CreateDirect3DDevice(
+        IntPtr preferredMonitor, bool forceWarp, out IntPtr rawDevice, out string description)
     {
+        const int DriverTypeUnknown = 0;
         const int DriverTypeHardware = 1;
+        const int DriverTypeWarp = 5;
         const uint FlagBgraSupport = 0x20;
         const uint SdkVersion = 7;
 
-        var hr = D3D11CreateDevice(
-            IntPtr.Zero, DriverTypeHardware, IntPtr.Zero, FlagBgraSupport,
-            IntPtr.Zero, 0, SdkVersion, out var device, out _, out var context);
+        var hr = unchecked((int)0x80004005);
+        var device = IntPtr.Zero;
+        var context = IntPtr.Zero;
+        description = "none";
+
+        // The adapter that drives the monitor being captured, when one can be named.
+        var adapter = IntPtr.Zero;
+        if (!forceWarp && preferredMonitor != IntPtr.Zero)
+            adapter = FindAdapterForMonitor(preferredMonitor, out description);
+
+        try
+        {
+            if (adapter != IntPtr.Zero)
+            {
+                // Driver type must be unknown when an adapter is named; anything else is E_INVALIDARG.
+                hr = D3D11CreateDevice(
+                    adapter, DriverTypeUnknown, IntPtr.Zero, FlagBgraSupport,
+                    IntPtr.Zero, 0, SdkVersion, out device, out _, out context);
+
+                if (hr < 0) description = $"{description} (refused a device: 0x{hr:X8})";
+            }
+        }
+        finally
+        {
+            if (adapter != IntPtr.Zero) Marshal.Release(adapter);
+        }
+
+        if (hr < 0 && !forceWarp)
+        {
+            hr = D3D11CreateDevice(
+                IntPtr.Zero, DriverTypeHardware, IntPtr.Zero, FlagBgraSupport,
+                IntPtr.Zero, 0, SdkVersion, out device, out _, out context);
+            if (hr >= 0) description = "default hardware adapter";
+        }
 
         // A machine with no usable hardware device is rare but real — a remote session, a stripped
         // VM. WARP is slower and entirely good enough to read a window at four frames a second.
         if (hr < 0)
         {
-            const int DriverTypeWarp = 5;
             hr = D3D11CreateDevice(
                 IntPtr.Zero, DriverTypeWarp, IntPtr.Zero, FlagBgraSupport,
                 IntPtr.Zero, 0, SdkVersion, out device, out _, out context);
+            if (hr >= 0) description = "WARP (software) adapter";
         }
 
         if (hr < 0) Marshal.ThrowExceptionForHR(hr);
@@ -230,6 +291,82 @@ internal static class WgcInterop
         }
     }
 
+    /// <summary>
+    /// The DXGI adapter driving <paramref name="monitor"/>, as a raw pointer the caller must
+    /// release, or <see cref="IntPtr.Zero"/> when it cannot be named.
+    /// </summary>
+    /// <remarks>
+    /// Asked by walking the adapters and their outputs, because an HMONITOR is the only handle both
+    /// sides of this question speak: capture names its source by monitor or by window, and DXGI
+    /// names its outputs by HMONITOR. Nothing here throws — an unnameable adapter means the caller
+    /// falls back to the default one, which is what it used to do always.
+    /// </remarks>
+    private static IntPtr FindAdapterForMonitor(IntPtr monitor, out string description)
+    {
+        description = "no adapter matched the source monitor";
+
+        var factoryPtr = IntPtr.Zero;
+        try
+        {
+            var iid = IidDxgiFactory1;
+            if (CreateDXGIFactory1(ref iid, out factoryPtr) < 0 || factoryPtr == IntPtr.Zero) return IntPtr.Zero;
+
+            var factory = (IDXGIFactory1)Marshal.GetObjectForIUnknown(factoryPtr);
+
+            for (uint index = 0; ; index++)
+            {
+                if (factory.EnumAdapters1(index, out var adapterPtr) < 0 || adapterPtr == IntPtr.Zero)
+                    return IntPtr.Zero;
+
+                var keep = false;
+                try
+                {
+                    var adapter = (IDXGIAdapter1)Marshal.GetObjectForIUnknown(adapterPtr);
+                    if (!AdapterDrivesMonitor(adapter, monitor)) continue;
+
+                    description = adapter.GetDesc1(out var desc) >= 0
+                        ? $"adapter \"{desc.Description}\" (vendor={desc.VendorId:X4} device={desc.DeviceId:X4}) driving the source monitor"
+                        : "the adapter driving the source monitor";
+
+                    keep = true;
+                    return adapterPtr;
+                }
+                finally
+                {
+                    if (!keep) Marshal.Release(adapterPtr);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Choosing the adapter is an improvement on defaulting to adapter zero, never a
+            // requirement: every failure here simply means the default is used.
+            return IntPtr.Zero;
+        }
+        finally
+        {
+            if (factoryPtr != IntPtr.Zero) Marshal.Release(factoryPtr);
+        }
+    }
+
+    private static bool AdapterDrivesMonitor(IDXGIAdapter1 adapter, IntPtr monitor)
+    {
+        for (uint index = 0; ; index++)
+        {
+            if (adapter.EnumOutputs(index, out var outputPtr) < 0 || outputPtr == IntPtr.Zero) return false;
+
+            try
+            {
+                var output = (IDXGIOutput)Marshal.GetObjectForIUnknown(outputPtr);
+                if (output.GetDesc(out var desc) >= 0 && desc.Monitor == monitor) return true;
+            }
+            finally
+            {
+                Marshal.Release(outputPtr);
+            }
+        }
+    }
+
     private static GraphicsCaptureItem FromAbi(IntPtr abi) =>
         WinRT.MarshalInspectable<GraphicsCaptureItem>.FromAbi(abi);
 
@@ -272,6 +409,104 @@ internal static class WgcInterop
     {
         unsafe void GetBuffer(out byte* buffer, out uint capacity);
     }
+
+    // ── DXGI, only far enough to name the adapter behind a monitor ───────────────────────────────
+    //
+    // Declared by hand and by slot. The methods that are never called are still declared, because a
+    // COM interface is a vtable and leaving one out would shift every method after it onto the wrong
+    // slot; their signatures are deliberately empty, which is safe precisely because they are never
+    // called.
+
+    [ComImport]
+    [Guid("770aae78-f26f-4dba-a829-253c83d1b387")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IDXGIFactory1
+    {
+        void SetPrivateData();
+        void SetPrivateDataInterface();
+        void GetPrivateData();
+        void GetParent();
+        void EnumAdapters();
+        void MakeWindowAssociation();
+        void GetWindowAssociation();
+        void CreateSwapChain();
+        void CreateSoftwareAdapter();
+
+        [PreserveSig]
+        int EnumAdapters1(uint index, out IntPtr adapter);
+    }
+
+    [ComImport]
+    [Guid("29038f61-3839-4626-91fd-086879011a05")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IDXGIAdapter1
+    {
+        void SetPrivateData();
+        void SetPrivateDataInterface();
+        void GetPrivateData();
+        void GetParent();
+
+        [PreserveSig]
+        int EnumOutputs(uint index, out IntPtr output);
+
+        void GetDesc();
+        void CheckInterfaceSupport();
+
+        [PreserveSig]
+        int GetDesc1(out DXGI_ADAPTER_DESC1 desc);
+    }
+
+    [ComImport]
+    [Guid("ae02eedb-c735-4690-8d52-5a8dc20213aa")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IDXGIOutput
+    {
+        void SetPrivateData();
+        void SetPrivateDataInterface();
+        void GetPrivateData();
+        void GetParent();
+
+        [PreserveSig]
+        int GetDesc(out DXGI_OUTPUT_DESC desc);
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct DXGI_ADAPTER_DESC1
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string Description;
+
+        public uint VendorId;
+        public uint DeviceId;
+        public uint SubSysId;
+        public uint Revision;
+        public nuint DedicatedVideoMemory;
+        public nuint DedicatedSystemMemory;
+        public nuint SharedSystemMemory;
+        public long AdapterLuid;
+        public uint Flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct DXGI_OUTPUT_DESC
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string DeviceName;
+
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool AttachedToDesktop;
+
+        public uint Rotation;
+        public IntPtr Monitor;
+    }
+
+    [DllImport("dxgi.dll", ExactSpelling = true)]
+    private static extern int CreateDXGIFactory1(ref Guid iid, out IntPtr factory);
 
     [DllImport("d3d11.dll", ExactSpelling = true)]
     private static extern int D3D11CreateDevice(

--- a/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
@@ -79,6 +79,10 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
     private long _latestAt;
     private long _lastGrabAt;
 
+    // Raised whenever a frame has been read back; only the start-up wait listens. See
+    // WgcWindowCaptureBackend for why that wait must not be a sleep.
+    private readonly ManualResetEventSlim _frameSignal = new(false);
+
     private int _framesReceived;
     private int _framesRead;
     private int _framesBeforeExclusion;
@@ -144,7 +148,11 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
         WgcMonitorCaptureBackend? backend = null;
         try
         {
-            device = WgcInterop.CreateDirect3DDevice(out rawDevice);
+            // On the adapter driving this monitor rather than on whichever one is listed first: a
+            // capture served by another adapter is not refused, it simply never delivers a frame.
+            device = WgcInterop.CreateDirect3DDevice(monitor, false, out rawDevice, out var adapter);
+            Log.Debug("Realtime monitor capture using {Adapter}", adapter);
+
             backend = new WgcMonitorCaptureBackend(resolveMonitor, resolveOverlays, device, rawDevice);
             if (!backend.Attach(monitor)) throw new InvalidOperationException("the monitor refused capture");
             if (!backend.WaitForIsolatedFrame(FirstFrameTimeout))
@@ -395,6 +403,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
     /// </summary>
     private void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
     {
+        SizeInt32? resizeTo = null;
         try
         {
             using var frame = sender.TryGetNextFrame();
@@ -402,9 +411,13 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
 
             Interlocked.Increment(ref _framesReceived);
 
+            // Noted here and done at the end of the handler, once the frame has been released: a
+            // pool asked to recreate itself while one of its own frames is still held waits for a
+            // buffer that only this thread can give back, and this thread is inside the wait. See
+            // the same deferral in WgcWindowCaptureBackend, where the deadlock was found.
             var content = frame.ContentSize;
             if (content.Width != _poolSize.Width || content.Height != _poolSize.Height)
-                Recreate(content);
+                resizeTo = content;
 
             // The one check this whole backend rests on. A frame numbered below the iteration the
             // exclusion was accepted at was composed before it took effect and may still hold the
@@ -437,6 +450,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
                 Volatile.Write(ref _latestAt, Stopwatch.GetTimestamp());
             }
             previous?.Dispose();
+            _frameSignal.Set();
         }
         catch (ObjectDisposedException)
         {
@@ -445,6 +459,11 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
         catch (Exception ex)
         {
             Log.Debug(ex, "Realtime monitor capture dropped a frame");
+        }
+        finally
+        {
+            // Outside the try above, so the frame it was decided for has been disposed by now.
+            if (resizeTo is { } size) Recreate(size);
         }
     }
 
@@ -475,7 +494,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
     {
         var started = Stopwatch.GetTimestamp();
 
-        while (Stopwatch.GetElapsedTime(started) < timeout)
+        while (true)
         {
             // The readback is demand-driven and nothing has polled yet.
             Volatile.Write(ref _lastGrabAt, Stopwatch.GetTimestamp());
@@ -485,7 +504,14 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
                 if (_latest is not null) return true;
             }
 
-            Thread.Sleep(50);
+            var left = timeout - Stopwatch.GetElapsedTime(started);
+            if (left <= TimeSpan.Zero) break;
+
+            // A wait rather than a sleep, for the reason spelled out in
+            // WgcWindowCaptureBackend.WaitForUsableFrame: this runs on the thread that started the
+            // session, and on an STA thread only a wait keeps pumping COM.
+            _frameSignal.Wait(TimeSpan.FromMilliseconds(Math.Min(50, left.TotalMilliseconds)));
+            _frameSignal.Reset();
         }
 
         Log.Warn(
@@ -578,6 +604,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
             _latest = null;
         }
 
+        _frameSignal.Dispose();
         (_device as IDisposable)?.Dispose();
         if (_rawDevice != IntPtr.Zero) Marshal.Release(_rawDevice);
     }

--- a/src/OverTranslate/Services/Realtime/Capture/WgcWindowCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcWindowCaptureBackend.cs
@@ -63,8 +63,9 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
 
     // How long a new backend is given to produce one frame with something in it before it is judged
     // unusable. Generous: this is paid once, on a path whose alternative is a session that appears
-    // to work and never translates anything.
-    private static readonly TimeSpan FirstFrameTimeout = TimeSpan.FromMilliseconds(1500);
+    // to work and never translates anything — and only in full when the capture is genuinely not
+    // producing anything, since the wait now ends on the frame rather than on a timer.
+    private static readonly TimeSpan FirstFrameTimeout = TimeSpan.FromMilliseconds(3000);
 
     private readonly Func<IntPtr> _resolveSource;
     private readonly IDirect3DDevice _device;
@@ -89,11 +90,24 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
     // the window's frame rate, this says whether anyone is still watching.
     private long _lastGrabAt;
 
+    // Raised whenever a frame has been read back. Only the start-up wait listens: it turns waiting
+    // for the first frame from a sleep into a wait the frame itself ends — and, on the UI thread
+    // that starts a session, into a wait that keeps pumping COM while it runs. A thread sleeping in
+    // Thread.Sleep pumps nothing, which is one way a capture that is working fine can look like a
+    // capture that never produced a frame.
+    private readonly ManualResetEventSlim _frameSignal = new(false);
+
     private int _framesReceived;
     private int _framesRead;
     private int _rebuilds;
     private long _readbackTicks;
     private int _outsideReported;
+
+    // Which adapter the frames are being asked for on, and the first thing a frame handler failed
+    // with, if it failed. Both exist for the log line that a capture producing nothing leaves
+    // behind: without them "no frame at all" is the whole of what a report can say.
+    private string _adapter = "unknown";
+    private string? _firstFault;
 
     private WgcWindowCaptureBackend(Func<IntPtr> resolveSource, IDirect3DDevice device, IntPtr rawDevice)
     {
@@ -120,8 +134,20 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
     /// Asked again whenever the source has to be found afresh — the window was closed and reopened,
     /// or a game replaced its window on a mode change. Returns <see cref="IntPtr.Zero"/> for none.
     /// </param>
-    public static WgcWindowCaptureBackend? TryCreate(Func<IntPtr> resolveSource)
+    public static WgcWindowCaptureBackend? TryCreate(Func<IntPtr> resolveSource) =>
+        TryCreate(resolveSource, out _);
+
+    /// <inheritdoc cref="TryCreate(Func{IntPtr})"/>
+    /// <param name="outcome">
+    /// Why there is no backend, when this returns null. The interface says something different for
+    /// each: a window presenting past the compositor is a setting in that application the user can
+    /// change, while a capture chain that produced nothing is not.
+    /// </param>
+    public static WgcWindowCaptureBackend? TryCreate(
+        Func<IntPtr> resolveSource, out WindowCaptureOutcome outcome)
     {
+        outcome = WindowCaptureOutcome.Refused;
+
         if (!WgcInterop.IsCaptureSupported())
         {
             Log.Info(
@@ -134,19 +160,53 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
         var hwnd = resolveSource();
         if (hwnd == IntPtr.Zero) return null;
 
+        WgcWindowCaptureBackend? backend;
+        (backend, outcome) = TryStart(resolveSource, hwnd, forceWarp: false);
+        if (backend is not null) return backend;
+
+        // No frame at all is the one failure a different graphics device can answer. It is what a
+        // capture on the wrong adapter looks like — nothing arrives, nothing is refused — so the
+        // software adapter, which every machine has and which no display arrangement can put on the
+        // wrong side of, is given one try before the mode is declared unavailable.
+        //
+        // Blank frames are not retried: those say the window is being presented past the compositor,
+        // and no device this program creates changes that.
+        if (outcome is not WindowCaptureOutcome.NoFrame) return null;
+
+        // Half the wait for the retry. A capture that works at all hands over its first frame at
+        // once, and this one is on top of a wait the user has already spent.
+        Log.Info("Retrying window capture for hwnd={Hwnd:X} on the software adapter", hwnd);
+        (backend, outcome) = TryStart(resolveSource, hwnd, forceWarp: true);
+        return backend;
+    }
+
+    private static (WgcWindowCaptureBackend? Backend, WindowCaptureOutcome Outcome) TryStart(
+        Func<IntPtr> resolveSource, IntPtr hwnd, bool forceWarp)
+    {
+        var timeout = forceWarp ? FirstFrameTimeout / 2 : FirstFrameTimeout;
+
         IDirect3DDevice? device = null;
         var rawDevice = IntPtr.Zero;
         WgcWindowCaptureBackend? backend = null;
+        var outcome = WindowCaptureOutcome.Refused;
         try
         {
-            device = WgcInterop.CreateDirect3DDevice(out rawDevice);
-            backend = new WgcWindowCaptureBackend(resolveSource, device, rawDevice);
-            if (!backend.Attach(hwnd)) throw new InvalidOperationException("the window refused capture");
-            if (!backend.WaitForUsableFrame(FirstFrameTimeout))
-                throw new InvalidOperationException(
-                    "the window produced no usable frame — a game in exclusive fullscreen is the usual cause");
+            device = WgcInterop.CreateDirect3DDevice(
+                MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST), forceWarp,
+                out rawDevice, out var adapter);
 
-            return backend;
+            backend = new WgcWindowCaptureBackend(resolveSource, device, rawDevice) { _adapter = adapter };
+            if (!backend.Attach(hwnd)) throw new InvalidOperationException("the window refused capture");
+
+            outcome = backend.WaitForUsableFrame(timeout);
+            if (outcome is not WindowCaptureOutcome.Started)
+                throw new InvalidOperationException(
+                    outcome is WindowCaptureOutcome.NoFrame
+                        ? "the window produced no frame at all — see the counters logged above"
+                        : "the window produced only blank frames — a game in exclusive fullscreen is " +
+                          "the usual cause");
+
+            return (backend, outcome);
         }
         catch (Exception ex)
         {
@@ -160,9 +220,10 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
                 (device as IDisposable)?.Dispose();
                 if (rawDevice != IntPtr.Zero) Marshal.Release(rawDevice);
             }
-            return null;
+            return (null, outcome);
         }
     }
+
 
     public Bitmap? GrabRegion(Rectangle screenBounds)
     {
@@ -304,8 +365,9 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
             _session.StartCapture();
 
             Log.Info(
-                "Realtime capture backend WgcWindow attached: hwnd={Hwnd:X} itemSize={Width}x{Height}",
-                hwnd, item.Size.Width, item.Size.Height);
+                "Realtime capture backend WgcWindow attached: hwnd={Hwnd:X} itemSize={Width}x{Height} " +
+                "on {Adapter}",
+                hwnd, item.Size.Width, item.Size.Height, _adapter);
             return true;
         }
     }
@@ -317,6 +379,7 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
     /// </summary>
     private void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
     {
+        SizeInt32? resizeTo = null;
         try
         {
             using var frame = sender.TryGetNextFrame();
@@ -334,9 +397,16 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
             // harmless and was not: capture only produces frames when the window's content changes,
             // so on a still window the frame dropped this way was the only one that would ever
             // arrive, and the capture appeared to produce nothing at all.
+            //
+            // The resize itself is deferred to the end of this handler, after the frame has been
+            // read and released. Recreating a pool while still holding one of its frames is asking
+            // it to reclaim a buffer this thread has not given back, and the wait for that can only
+            // end on this thread — which is inside the wait. That deadlock takes the capture with
+            // it, silently and on the very first frame, since a window's content size and its item
+            // size routinely differ by the invisible resize border.
             var content = frame.ContentSize;
             if (content.Width != _poolSize.Width || content.Height != _poolSize.Height)
-                Recreate(content);
+                resizeTo = content;
 
             // The first frame is always read, and that is not an optimisation detail: capture emits
             // one frame when the session starts and one whenever the content changes, so over a
@@ -361,6 +431,7 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
                 Volatile.Write(ref _latestAt, Stopwatch.GetTimestamp());
             }
             previous?.Dispose();
+            _frameSignal.Set();
         }
         catch (ObjectDisposedException)
         {
@@ -370,7 +441,17 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
         {
             // One bad frame must not take the capture down — the next one is milliseconds away, and
             // a poll that finds no fresh frame simply reads the one before it.
+            //
+            // The first one is kept, though. A capture that produces nothing because every frame
+            // throws is indistinguishable, from the outside, from one where no frame ever arrives,
+            // and the difference is the whole of what a report about it would need to say.
+            Interlocked.CompareExchange(ref _firstFault, $"{ex.GetType().Name}: {ex.Message.Trim()}", null);
             Log.Debug(ex, "Realtime capture dropped a frame");
+        }
+        finally
+        {
+            // Outside the try above, so the frame it was decided for has been disposed by now.
+            if (resizeTo is { } size) Recreate(size);
         }
     }
 
@@ -440,12 +521,12 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
     /// refused here. That is a frame with nothing to translate in it either, and the user is told
     /// which mode to try instead rather than left watching a session produce nothing.
     /// </remarks>
-    private bool WaitForUsableFrame(TimeSpan timeout)
+    private WindowCaptureOutcome WaitForUsableFrame(TimeSpan timeout)
     {
         var started = Stopwatch.GetTimestamp();
         var sawFrame = false;
 
-        while (Stopwatch.GetElapsedTime(started) < timeout)
+        while (true)
         {
             // The readback is demand-driven, and nothing has asked yet.
             Volatile.Write(ref _lastGrabAt, Stopwatch.GetTimestamp());
@@ -455,20 +536,35 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
                 if (_latest is { } latest)
                 {
                     sawFrame = true;
-                    if (!IsBlank(latest)) return true;
+                    if (!IsBlank(latest)) return WindowCaptureOutcome.Started;
                 }
             }
 
-            Thread.Sleep(50);
+            var left = timeout - Stopwatch.GetElapsedTime(started);
+            if (left <= TimeSpan.Zero) break;
+
+            // On the handle rather than through ManualResetEventSlim.Wait, and not Thread.Sleep.
+            // This is called from the thread that starts a session, which on a WPF application is
+            // the UI thread — an STA thread, whose blocking waits must keep pumping COM for anything
+            // marshalled through it to arrive. A sleep here would be a capture stack held shut for
+            // the whole of its own start-up timeout.
+            _frameSignal.Wait(TimeSpan.FromMilliseconds(Math.Min(50, left.TotalMilliseconds)));
+            _frameSignal.Reset();
         }
 
         Log.Warn(
             sawFrame
                 ? "Realtime window capture of hwnd={Hwnd:X} produced only blank frames; the window is " +
-                  "not being composited — a game in exclusive fullscreen is the usual cause"
-                : "Realtime window capture of hwnd={Hwnd:X} produced no frame at all",
-            _hwnd);
-        return false;
+                  "not being composited — a game in exclusive fullscreen is the usual cause " +
+                  "({Activity}, adapter: {Adapter})"
+                : "Realtime window capture of hwnd={Hwnd:X} produced no frame at all " +
+                  "({Activity}, adapter: {Adapter})",
+            _hwnd, DescribeActivity(), _adapter);
+
+        if (_firstFault is { } fault)
+            Log.Warn("Realtime window capture of hwnd={Hwnd:X} first failed with {Fault}", _hwnd, fault);
+
+        return sawFrame ? WindowCaptureOutcome.Blank : WindowCaptureOutcome.NoFrame;
     }
 
     /// <summary>
@@ -571,6 +667,7 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
             _latest = null;
         }
 
+        _frameSignal.Dispose();
         (_device as IDisposable)?.Dispose();
         if (_rawDevice != IntPtr.Zero) Marshal.Release(_rawDevice);
     }
@@ -586,9 +683,14 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
         public int Bottom;
     }
 
+    private const uint MONITOR_DEFAULTTONEAREST = 2;
+
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint flags);
 
     [DllImport("dwmapi.dll")]
     private static extern int DwmGetWindowAttribute(IntPtr hwnd, uint attribute, out RECT value, int size);

--- a/src/OverTranslate/Services/Realtime/Capture/WindowCaptureOutcome.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WindowCaptureOutcome.cs
@@ -1,0 +1,30 @@
+namespace OverTranslate.Services.Realtime.Capture;
+
+/// <summary>
+/// How an attempt to start capturing one window ended.
+/// </summary>
+/// <remarks>
+/// Three failures rather than one, because they are three different things to tell the user. A
+/// window that hands over only flat frames is presenting past the compositor — a game in exclusive
+/// fullscreen — and the answer is a setting inside that game. A window that hands over nothing at
+/// all has a capture chain that never ran, which the user cannot act on and a log can. Anything
+/// else was refused outright, before any frame was waited for.
+///
+/// The distinction is new because the old message covered all of them with the fullscreen
+/// explanation, which sent a user whose game was already windowed looking for a setting that was
+/// not the problem.
+/// </remarks>
+public enum WindowCaptureOutcome
+{
+    /// <summary>The capture never got as far as waiting for a frame.</summary>
+    Refused,
+
+    /// <summary>No frame arrived at all within the start-up window.</summary>
+    NoFrame,
+
+    /// <summary>Frames arrived and every one of them was a single flat colour.</summary>
+    Blank,
+
+    /// <summary>A frame with something in it; the backend is running.</summary>
+    Started
+}

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -601,12 +601,18 @@ internal sealed class RealtimeSessionController
     /// </summary>
     /// <remarks>
     /// A refusal per reason, because each has a different answer. A system without window capture
-    /// can only ever use 螢幕擷取, and should be told that once. A window that closed between the
-    /// picker and this call needs the list refreshed. A window presenting past the compositor — a
+    /// has no realtime capture at all — 螢幕擷取 is built on the same API and needs more of it, not
+    /// less — so that one states the fact and stops. A window that closed between the picker and
+    /// this call needs the list refreshed. A window presenting past the compositor — a
     /// game in exclusive fullscreen, see <c>WgcWindowCaptureBackend.WaitForUsableFrame</c> — has a
     /// display setting the user can change. And a capture that produced nothing at all is none of
     /// those: it is this machine's capture chain, which the user cannot act on, so that one names
     /// the log instead of an action.
+    ///
+    /// None of them sends the user to 螢幕擷取. Someone who chose 視窗擷取 either has a reason to
+    /// avoid the other mode or is on a machine that does not offer it — this report came from the
+    /// second kind — so the way forward that is always theirs to take is the display mode of the
+    /// application they are translating, and that is what every one of these says.
     ///
     /// The last two used to share the fullscreen message, which is how a report of it arrived —
     /// a Windows 10 user told to leave exclusive fullscreen by a game that was already windowed.

--- a/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeSessionController.cs
@@ -600,12 +600,16 @@ internal sealed class RealtimeSessionController
     /// Window capture over the handle the user picked, or the reason it is not available.
     /// </summary>
     /// <remarks>
-    /// Three separate refusals rather than one, because the three have different answers. A system
-    /// without window capture can only ever use 螢幕擷取, and should be told that once. A window that
-    /// closed between the picker and this call needs the list refreshed. A window that refuses
-    /// capture — a game in exclusive fullscreen is the usual cause, see
-    /// <c>WgcWindowCaptureBackend.WaitForUsableFrame</c> — is a real property of that application,
-    /// and 螢幕擷取 does read it.
+    /// A refusal per reason, because each has a different answer. A system without window capture
+    /// can only ever use 螢幕擷取, and should be told that once. A window that closed between the
+    /// picker and this call needs the list refreshed. A window presenting past the compositor — a
+    /// game in exclusive fullscreen, see <c>WgcWindowCaptureBackend.WaitForUsableFrame</c> — has a
+    /// display setting the user can change. And a capture that produced nothing at all is none of
+    /// those: it is this machine's capture chain, which the user cannot act on, so that one names
+    /// the log instead of an action.
+    ///
+    /// The last two used to share the fullscreen message, which is how a report of it arrived —
+    /// a Windows 10 user told to leave exclusive fullscreen by a game that was already windowed.
     /// </remarks>
     private WgcWindowCaptureBackend? CreateWindowCapture(IntPtr hwnd, out string refusal)
     {
@@ -625,18 +629,27 @@ internal sealed class RealtimeSessionController
             return null;
         }
 
-        return CreateWindowBackend(hwnd);
+        return CreateWindowBackend(hwnd, ref refusal);
     }
 
     [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.18362.0")]
-    private WgcWindowCaptureBackend? CreateWindowBackend(IntPtr hwnd)
+    private WgcWindowCaptureBackend? CreateWindowBackend(IntPtr hwnd, ref string refusal)
     {
         // The same handle every time it is asked, which is what turns the backend's re-attach into a
         // no-op and lets the closing of that window end the session. Searching for a replacement is
         // the alternative, and it would have to guess which new window is the same application —
         // guessing is what this mode exists to stop doing.
-        var backend = WgcWindowCaptureBackend.TryCreate(() => hwnd);
-        if (backend is null) return null;
+        var backend = WgcWindowCaptureBackend.TryCreate(() => hwnd, out var outcome);
+        if (backend is null)
+        {
+            refusal = outcome switch
+            {
+                WindowCaptureOutcome.Blank => "S.Realtime.WindowCaptureFullscreen",
+                WindowCaptureOutcome.NoFrame => "S.Realtime.WindowCaptureNoFrame",
+                _ => "S.Realtime.WindowCaptureFailed"
+            };
+            return null;
+        }
 
         backend.SourceLost += OnCaptureSourceLost;
         return backend;


### PR DESCRIPTION
Refs #116（**先不要合併關閉 issue**：修正尚未由原回報的 Windows 10 使用者實測）

## 主因

`itemSize=1936x1056`（1920 + 16 隱形邊框）說明 Windows 10 的 `GraphicsCaptureItem.Size` 是含邊框的 window rect，而 Windows 11 給的是 extended frame bounds。於是 Windows 10 上**第一張 frame 的 ContentSize 必定和 pool size 不一致**，一定會走 `Recreate`——而原本的 `OnFrameArrived` 是在還握著那張 frame 的情況下呼叫 `_pool.Recreate()`，pool 等的 buffer 只有這條被卡住的執行緒能還，第一張 frame 就死鎖，對外表現為 `produced no frame at all`。

## 改動

- `WgcWindowCaptureBackend` / `WgcMonitorCaptureBackend`：把 pool 重建延後到 frame 釋放之後（`finally`）。
- `WgcInterop`：新增 DXGI adapter 列舉，依來源 HMONITOR 建立 D3D device；用錯 adapter 的 WGC 不會報錯，只是永遠不送 frame。
- 等待第一張 frame 由 `Thread.Sleep` 改為等事件——這段跑在 STA 的 UI 執行緒上，sleep 不泵送 COM，且改完後 frame 一到就返回。
- 完全沒 frame 時，自動以 WARP 軟體 adapter 重試一次（半個 timeout）。
- 失敗診斷：記錄 received/read 計數、實際使用的顯示卡、frame handler 第一個例外；attach 那行也帶上 adapter 名稱。
- 新增 `WindowCaptureOutcome`，讓失敗原因能傳到介面層。

## 文案

視窗擷取的每一種失敗都不再指向「螢幕擷取」（選視窗擷取的人不是刻意避開它，就是機器上根本沒有——這次的回報者屬於後者），一律指向來源程式的顯示模式：

| 情境 | 文案 |
|---|---|
| 完全沒有畫面 | 無法取得視窗畫面，請切換至「無邊框視窗」或「視窗化」後再試一次。 |
| 黑畫面／純色 | 目前的顯示模式無法擷取，請切換至「無邊框視窗」或「視窗化」後再試一次。 |
| 擷取失敗 | 無法擷取此視窗，請切換至「無邊框視窗」或「視窗化」後再試一次。 |
| 視窗不見 | 指定的視窗已關閉或最小化，請重新選擇視窗。 |
| 系統太舊 | 目前的 Windows 版本不支援此畫面擷取功能。 |

## 驗證

- `dotnet test`：523 通過 / 0 失敗。
- WgcProbe 在本機（Windows 11 + RTX 3070）對三個實際視窗擷取正常，adapter 選擇會寫出 `adapter "NVIDIA GeForce RTX 3070" … driving the source monitor`，讀回時間與改動前相當。
- **尚未在 Windows 10 上實測**——主因無法在本機重現，需要原回報者協助。
