### PR TITLE
feat: 主視窗改版與更新視窗自繪標題列

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -23,6 +23,8 @@
     <sys:String x:Key="S.Shell.TextTranslate">Text</sys:String>
     <sys:String x:Key="S.Shell.RealtimeTranslate">Realtime</sys:String>
     <sys:String x:Key="S.Shell.Settings">Settings</sys:String>
+    <sys:String x:Key="S.Shell.HideSidebar">Hide sidebar</sys:String>
+    <sys:String x:Key="S.Shell.ShowSidebar">Show sidebar</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">Realtime translation is running — stop it before using screen capture</sys:String>
     <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">Realtime translation is running — stop it before using quick lookup</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">Update to v{0}</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -17,11 +17,14 @@
 
     <!-- ── Shell window ── -->
     <sys:String x:Key="S.Shell.About">About</sys:String>
+    <sys:String x:Key="S.Shell.QuickTools">Quick tools</sys:String>
     <sys:String x:Key="S.Shell.CaptureTranslate">Screen capture</sys:String>
+    <sys:String x:Key="S.Shell.QuickLookup">Quick lookup</sys:String>
     <sys:String x:Key="S.Shell.TextTranslate">Text</sys:String>
     <sys:String x:Key="S.Shell.RealtimeTranslate">Realtime</sys:String>
     <sys:String x:Key="S.Shell.Settings">Settings</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">Realtime translation is running — stop it before using screen capture</sys:String>
+    <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">Realtime translation is running — stop it before using quick lookup</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">Update to v{0}</sys:String>
 
     <!-- ── Tray menu ── -->

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -49,18 +49,17 @@
     <!-- ── Update ── -->
     <sys:String x:Key="S.Update.WindowTitle">Update available</sys:String>
     <sys:String x:Key="S.Update.Heading">Update available</sys:String>
-    <sys:String x:Key="S.Update.CurrentVersion">Current</sys:String>
-    <sys:String x:Key="S.Update.LatestVersion">Latest</sys:String>
     <sys:String x:Key="S.Update.Explanation">"Update now" downloads and applies the update, then restarts the app.</sys:String>
     <sys:String x:Key="S.Update.NotesBefore" xml:space="preserve">Curious what changed? </sys:String>
     <sys:String x:Key="S.Update.NotesLink">See the release notes</sys:String>
     <sys:String x:Key="S.Update.Later">Later</sys:String>
     <sys:String x:Key="S.Update.Now">Update now</sys:String>
     <sys:String x:Key="S.Update.Skip">Skip this version and stop reminding me</sys:String>
-    <sys:String x:Key="S.Update.Downloading">Downloading {0}%</sys:String>
+    <sys:String x:Key="S.Update.Downloading">Downloading {0}</sys:String>
     <sys:String x:Key="S.Update.Applying">Applying...</sys:String>
     <sys:String x:Key="S.Update.Retry">Retry</sys:String>
     <sys:String x:Key="S.Update.Failed">Could not download the update: {0}</sys:String>
+    <sys:String x:Key="S.Update.CloseBlocked">The update is running — the app restarts itself when it finishes</sys:String>
 
     <!-- ── Service errors ── -->
     <sys:String x:Key="S.Error.OpenAiHttp">The OpenAI-compatible API returned {0}: {1}</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -49,18 +49,17 @@
     <!-- ── Update ── -->
     <sys:String x:Key="S.Update.WindowTitle">發現新版本</sys:String>
     <sys:String x:Key="S.Update.Heading">發現新版本！</sys:String>
-    <sys:String x:Key="S.Update.CurrentVersion">目前版本</sys:String>
-    <sys:String x:Key="S.Update.LatestVersion">最新版本</sys:String>
     <sys:String x:Key="S.Update.Explanation">點擊「立即更新」後將自動下載並套用，完成後自動重新啟動。</sys:String>
     <sys:String x:Key="S.Update.NotesBefore" xml:space="preserve">想了解這次更新了什麼？</sys:String>
     <sys:String x:Key="S.Update.NotesLink">查看更新內容</sys:String>
     <sys:String x:Key="S.Update.Later">稍後再說</sys:String>
     <sys:String x:Key="S.Update.Now">立即更新</sys:String>
     <sys:String x:Key="S.Update.Skip">跳過此版本，不要再提醒我</sys:String>
-    <sys:String x:Key="S.Update.Downloading">下載中 {0}%</sys:String>
+    <sys:String x:Key="S.Update.Downloading">下載中 {0}</sys:String>
     <sys:String x:Key="S.Update.Applying">套用中…</sys:String>
     <sys:String x:Key="S.Update.Retry">重試</sys:String>
     <sys:String x:Key="S.Update.Failed">下載更新失敗：{0}</sys:String>
+    <sys:String x:Key="S.Update.CloseBlocked">更新進行中，完成後會自動重新啟動</sys:String>
 
     <!-- ── Service errors ──
          These reach the user through an exception message shown in a balloon or status line, so

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -20,6 +20,8 @@
     <sys:String x:Key="S.Shell.TextTranslate">文字翻譯</sys:String>
     <sys:String x:Key="S.Shell.RealtimeTranslate">即時翻譯</sys:String>
     <sys:String x:Key="S.Shell.Settings">設定</sys:String>
+    <sys:String x:Key="S.Shell.HideSidebar">收起側邊欄</sys:String>
+    <sys:String x:Key="S.Shell.ShowSidebar">展開側邊欄</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">即時翻譯進行中，請先結束後再使用截圖翻譯</sys:String>
     <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">即時翻譯進行中，請先結束後再使用取詞翻譯</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">可更新至 v{0}</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -14,11 +14,14 @@
 
     <!-- ── Shell window ── -->
     <sys:String x:Key="S.Shell.About">關於</sys:String>
+    <sys:String x:Key="S.Shell.QuickTools">快速工具</sys:String>
     <sys:String x:Key="S.Shell.CaptureTranslate">截圖翻譯</sys:String>
+    <sys:String x:Key="S.Shell.QuickLookup">取詞翻譯</sys:String>
     <sys:String x:Key="S.Shell.TextTranslate">文字翻譯</sys:String>
     <sys:String x:Key="S.Shell.RealtimeTranslate">即時翻譯</sys:String>
     <sys:String x:Key="S.Shell.Settings">設定</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">即時翻譯進行中，請先結束後再使用截圖翻譯</sys:String>
+    <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">即時翻譯進行中，請先結束後再使用取詞翻譯</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">可更新至 v{0}</sys:String>
 
     <!-- ── Tray menu ── -->

--- a/src/OverTranslate/Services/ThemeService.cs
+++ b/src/OverTranslate/Services/ThemeService.cs
@@ -12,6 +12,15 @@ public static class ThemeService
 
     public static string Current => SettingsService.Instance.Current.Theme;
 
+    /// <summary>
+    /// Raised once the new dictionary is in place.
+    /// </summary>
+    /// <remarks>
+    /// For the colours a DynamicResource cannot reach — the shell window's outer edge is drawn by
+    /// the desktop compositor from a value handed over once, so nothing repaints it on its own.
+    /// </remarks>
+    public static event EventHandler? Changed;
+
     public static void Apply(string theme)
     {
         var dicts = System.Windows.Application.Current.Resources.MergedDictionaries;
@@ -24,5 +33,7 @@ public static class ThemeService
         {
             Source = theme == Dark ? DarkUri : LightUri
         });
+
+        Changed?.Invoke(null, EventArgs.Empty);
     }
 }

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1620,6 +1620,50 @@
         </Setter>
     </Style>
 
+    <!-- The rail's show/hide switch, at the caption strip's leading edge. Deliberately not one of
+         the caption buttons opposite it: those are the system's strip, square and flush to the
+         window's corner because that is what every window does with that corner. This one belongs
+         to the application, so it takes the application's shape — a 6-radius tile, inset from the
+         edge, sized to the 40 strip with room left around it.
+
+         Quieter than the caption glyphs until it is pointed at: it is a preference about the
+         window's layout, and one that sits beside the app's own name and icon. Hover brings it to
+         full strength, so the strip does not carry a control at full contrast that most sessions
+         never touch. -->
+    <Style x:Key="WindowSidebarToggle" TargetType="Button">
+        <Setter Property="FontFamily" Value="Segoe Fluent Icons, Segoe MDL2 Assets"/>
+        <Setter Property="FontSize"   Value="14"/>
+        <Setter Property="Foreground" Value="{DynamicResource AppTextSecondary}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Cursor"     Value="Hand"/>
+        <Setter Property="Width"      Value="32"/>
+        <Setter Property="Height"     Value="32"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="6">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppButtonHoverBg}"/>
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource AppTextPrimary}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppButtonPressedBg}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Close is the one caption button with a colour of its own, and it is the system's red rather
          than the application's accent: it means "this is the destructive one" in every window the
          user has ever closed, and the accent means "this is the one we would like you to press". -->

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1565,6 +1565,88 @@
     </Style>
 
     <!-- ═══════════════════════════════════════════ -->
+    <!--  SHELL SURFACES                             -->
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- The two panels the shell window is built from: the nav rail and the page. Both are cards
+         floating on the window's own surface with a gap between them, rather than two regions
+         meeting at a seam — so no edge here is ever drawn on the side that faces the other panel,
+         and the boundary the user sees is the gap itself.
+
+         Opaque, not tinted: the page card is what the content transition's bitmap cache renders
+         into, and ClearType cannot run over a surface WPF believes may be transparent. -->
+    <Style x:Key="ShellCard" TargetType="Border">
+        <Setter Property="Background"      Value="{DynamicResource AppCardBg}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource AppBorder}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius"    Value="10"/>
+    </Style>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!--  WINDOW CAPTION BUTTONS                     -->
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- Windows' own geometry — 46x32, glyph-only, square, flush to the window's top-right corner —
+         because this strip is the one part of an application nobody wants redesigned. Only the
+         colours are the application's.
+
+         Square, unlike every other control here: these run to the window's edges, and a rounded
+         corner would leave a wedge of window background outside a button that the user still
+         expects to hit. -->
+    <Style x:Key="WindowCaptionButton" TargetType="Button">
+        <Setter Property="FontFamily"  Value="Segoe Fluent Icons, Segoe MDL2 Assets"/>
+        <Setter Property="FontSize"    Value="10"/>
+        <Setter Property="Foreground"  Value="{DynamicResource AppTextPrimary}"/>
+        <Setter Property="Background"  Value="Transparent"/>
+        <Setter Property="Width"       Value="46"/>
+        <Setter Property="Height"      Value="40"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root" Background="{TemplateBinding Background}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppButtonHoverBg}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppButtonPressedBg}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Close is the one caption button with a colour of its own, and it is the system's red rather
+         than the application's accent: it means "this is the destructive one" in every window the
+         user has ever closed, and the accent means "this is the one we would like you to press". -->
+    <Style x:Key="WindowCloseButton" TargetType="Button" BasedOn="{StaticResource WindowCaptionButton}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Root" Background="{TemplateBinding Background}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#E81123"/>
+                            <Setter Property="Foreground" Value="#FFFFFF"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Root" Property="Background" Value="#F1707A"/>
+                            <Setter Property="Foreground" Value="#FFFFFF"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ═══════════════════════════════════════════ -->
     <!--  SIDEBAR NAV                                -->
     <!--  Selected state lives on RadioButton's      -->
     <!--  IsChecked, so grouping is free. Icon and   -->
@@ -1613,10 +1695,10 @@
          true. Sizing follows the version label it hangs off (11px) rather than the nav items, so it
          reads as an annotation on the brand block instead of a fourth destination.
 
-         Tonal fill with no accent outline. NavPrimaryAction's outlined treatment is what 截圖翻譯
-         uses to claim the rail's primary action, and repeating it here would have news out-shouting
-         the button the user actually came for. The border is one step up the same tonal ramp — just
-         enough to give the fill an edge on the sidebar's own background.
+         Tonal fill with no accent outline. RailQuickTool's accent-tinted icon tile is what the
+         快速工具 rows use to claim the rail's actions, and competing with it here would have news
+         out-shouting the buttons the user actually came for. The border is one step up the same
+         tonal ramp — just enough to give the fill an edge on the sidebar's own background.
 
          Fully rounded, unlike every other surface in the app at 6. That is the point: a pill is the
          shape of a label, a 6px rectangle is the shape of a button, and this is a statement about
@@ -1695,74 +1777,100 @@
         </Setter>
     </Style>
 
-    <!-- The nav rail's one primary action (截圖翻譯). Borrows the app's existing tonal-accent
-         surface — 1px AppAccent border over an AppAccentSubtle fill, the same pair
-         ToolbarSubtleAccentButton and the theme picker already use — rather than inventing a
-         material for one control. The accent outline is what separates it from NavItem's selected
-         state, which shares the tint but is never bordered, and the drop shadow is what keeps it
-         reading as a raised, pressable object instead of a highlighted row.
-         The shadow is allowed to spill past the 8,2 margin: nothing in the rail's DockPanel or
-         StackPanel clips its children, so it renders in full without extra reserved space. -->
-    <Style x:Key="NavPrimaryAction" TargetType="Button">
-        <Setter Property="FontFamily"   Value="{StaticResource AppFont}"/>
-        <Setter Property="FontSize"     Value="{StaticResource AppFontSize}"/>
-        <Setter Property="Foreground"   Value="{DynamicResource AppTextPrimary}"/>
-        <Setter Property="Background"   Value="{DynamicResource AppAccentSubtle}"/>
-        <Setter Property="Cursor"       Value="Hand"/>
+    <!-- The 快速工具 rows (截圖翻譯, 取詞翻譯) — the rail's actions, as opposed to the destinations
+         NavItem carries below them. A card rather than a bare row is what says so: a neutral
+         surface lifted one step off the rail's own background, with the accent living only in the
+         icon tile, so two of these side by side stay a group instead of two walls of colour.
+
+         Both rows carry the identical treatment on purpose. Neither one is the primary — the shell
+         is the only place either shortcut is named, and ranking them here would leave the loser
+         looking like a lesser copy of the winner.
+
+         Deliberately NOT ToolbarSubtleAccentButton's flip to a solid accent fill on hover: at
+         full-rail width that is a wall of colour. Hover walks the accent's own tonal ramp and
+         brings the border with it, so the card lights up without changing material.
+
+         No drop shadow, and no effect anywhere in the template: any element carrying an Effect
+         pushes its whole subtree through an intermediate render surface, where ClearType sub-pixel
+         antialiasing cannot run — text inside a shadowed Border came out visibly soft next to the
+         nav items. Same trap ShellWindow's page transition documents for BitmapCache. -->
+    <Style x:Key="RailQuickTool" TargetType="Button">
+        <Setter Property="FontFamily"      Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"        Value="{StaticResource AppFontSize}"/>
+        <Setter Property="Foreground"      Value="{DynamicResource AppTextPrimary}"/>
+        <Setter Property="Background"      Value="{DynamicResource AppCardBg}"/>
+        <Setter Property="BorderBrush"     Value="{DynamicResource AppSubtleBorder}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Cursor"          Value="Hand"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <!-- The content is a SIBLING of the material, never its child. Any element
-                         carrying an Effect pushes its whole subtree through an intermediate render
-                         surface, and ClearType sub-pixel antialiasing cannot run there — text
-                         nested inside this Border came out visibly soft next to the nav items.
-                         Same trap ShellWindow's page transition documents for BitmapCache. -->
-                    <Grid Margin="8,2" Height="44">
-                        <Border x:Name="Root"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{DynamicResource AppAccent}"
-                                BorderThickness="1"
-                                CornerRadius="8">
-                            <!-- Effects are Freezables, so they have no template namescope entry
-                                 and cannot be reached by TargetName. Each state swaps the whole
-                                 effect rather than one of its properties. -->
-                            <Border.Effect>
-                                <DropShadowEffect BlurRadius="8" ShadowDepth="2" Direction="270"
-                                                  Opacity="0.14" Color="#000000"/>
-                            </Border.Effect>
-                        </Border>
-                        <ContentPresenter Margin="12,0" VerticalAlignment="Center"/>
-                    </Grid>
+                    <!-- 8 margin + 1 border + 11 of padding = 20, which is where NavItem's own
+                         12 puts its glyph: one left edge down the whole rail. -->
+                    <Border x:Name="Root"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="8"
+                            Margin="8,3"
+                            Padding="11,0"
+                            Height="46">
+                        <ContentPresenter VerticalAlignment="Center"/>
+                    </Border>
                     <ControlTemplate.Triggers>
-                        <!-- Rises toward the pointer: one step deeper tint, one step more shadow.
-                             Deliberately NOT ToolbarSubtleAccentButton's flip to a solid accent
-                             fill — at 44px full-rail width that is a wall of colour, which is the
-                             very thing the tonal treatment exists to avoid. -->
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Root" Property="Background"
+                                    Value="{DynamicResource AppAccentSubtle}"/>
+                            <Setter TargetName="Root" Property="BorderBrush"
                                     Value="{DynamicResource AppAccentSubtleHover}"/>
-                            <Setter TargetName="Root" Property="Effect">
-                                <Setter.Value>
-                                    <DropShadowEffect BlurRadius="12" ShadowDepth="3" Direction="270"
-                                                      Opacity="0.20" Color="#000000"/>
-                                </Setter.Value>
-                            </Setter>
                         </Trigger>
-                        <!-- and settles back down when pressed, rather than only changing colour -->
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="Root" Property="Background"
                                     Value="{DynamicResource AppAccentSubtlePressed}"/>
-                            <Setter TargetName="Root" Property="Effect">
-                                <Setter.Value>
-                                    <DropShadowEffect BlurRadius="4" ShadowDepth="1" Direction="270"
-                                                      Opacity="0.10" Color="#000000"/>
-                                </Setter.Value>
-                            </Setter>
+                        </Trigger>
+                        <!-- 截圖翻譯 is switched off for the length of a realtime session, and its
+                             tooltip is then the only place that reason exists — so the card has to
+                             read as unavailable rather than as missing. -->
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="Root" Property="Opacity" Value="0.4"/>
+                            <Setter Property="Cursor" Value="Arrow"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <!-- The accent-tinted square behind a 快速工具 row's glyph. A tile here and a bare glyph on the
+         nav items below is what separates the rail's two halves at a glance, without a second
+         divider or a second type size. -->
+    <Style x:Key="RailQuickToolIcon" TargetType="Border">
+        <Setter Property="Width"               Value="30"/>
+        <Setter Property="Height"              Value="30"/>
+        <Setter Property="CornerRadius"        Value="7"/>
+        <Setter Property="Background"          Value="{DynamicResource AppAccentSubtle}"/>
+        <Setter Property="BorderBrush"         Value="{DynamicResource AppAccentSubtleHover}"/>
+        <Setter Property="BorderThickness"     Value="1"/>
+        <Setter Property="VerticalAlignment"   Value="Center"/>
+        <Setter Property="Margin"              Value="0,0,10,0"/>
+    </Style>
+
+    <Style x:Key="RailQuickToolGlyph" TargetType="TextBlock">
+        <Setter Property="FontFamily"          Value="Segoe Fluent Icons, Segoe MDL2 Assets"/>
+        <Setter Property="FontSize"            Value="15"/>
+        <Setter Property="Foreground"          Value="{DynamicResource AppAccent}"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment"   Value="Center"/>
+    </Style>
+
+    <!-- The shortcut trailing a 快速工具 row: a reference the user reads once, not a second label
+         competing with the row's name. -->
+    <Style x:Key="RailQuickToolHotkey" TargetType="TextBlock">
+        <Setter Property="FontFamily"        Value="{StaticResource AppFont}"/>
+        <Setter Property="FontSize"          Value="11"/>
+        <Setter Property="Foreground"        Value="{DynamicResource AppTextSecondary}"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Margin"            Value="8,0,0,0"/>
     </Style>
 
     <!-- Circular close button for the modal overlay -->

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -330,6 +330,21 @@ public partial class MainWindow : Window
         });
 
     /// <summary>
+    /// Opens 取詞翻譯 from the shell window's nav rail.
+    /// </summary>
+    /// <remarks>
+    /// Straight through <see cref="OnQuickLookupHotkeyPressed"/> rather than calling
+    /// <c>SummonAsync</c> itself: the two states a popup must not appear in are about the screen,
+    /// not about which control asked, and a second entry point with its own guards is one that can
+    /// fall out of step with them. The rail's own button being disabled during a realtime session
+    /// is a presentation detail on top of this, not a replacement for it.
+    ///
+    /// The shell stays where it is. Unlike a capture, this puts a popup over the screen rather than
+    /// photographing it, so there is nothing to get out of the way of.
+    /// </remarks>
+    public void StartQuickLookupFromShell() => OnQuickLookupHotkeyPressed(this, EventArgs.Empty);
+
+    /// <summary>
     /// Opens the translation window, and during a realtime session brings its layers to the front
     /// instead — the same two answers the tray icon gives, for the same reasons.
     /// </summary>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -41,9 +41,9 @@ public partial class SettingsPage : UserControl
     /// — the one place that decides which of two shortcuts sharing a combination stays on.
     /// </param>
     /// <param name="AdvertisedInShell">
-    /// Whether the shell's nav rail prints this combination beside a button, and so has to be told
-    /// when it changes. True for the capture shortcut, which the interface names in three places;
-    /// false for the other shortcuts, which it names nowhere.
+    /// Whether the shell's nav rail prints this combination beside a 快速工具 row, and so has to be
+    /// told when it changes. True for the two shortcuts those rows name; false for the rest, which
+    /// the interface names nowhere.
     /// </param>
     /// <remarks>
     /// There is no record button in the record because there is none on the page: the box is
@@ -110,7 +110,7 @@ public partial class SettingsPage : UserControl
                 s => s.QuickLookupHotkeyDisplay,
                 s => HotkeyBindings.TriggerFor(s, HotkeyAction.QuickLookup),
                 ApplyQuickLookupTrigger,
-                AdvertisedInShell: false,
+                AdvertisedInShell: true,
                 QuickLookupHotkeyEnabledCheckBox,
                 (s, on) => s.QuickLookupHotkeyEnabled = on,
                 QuickLookupHotkeyEnabledLabel),
@@ -500,6 +500,11 @@ public partial class SettingsPage : UserControl
         // a switch that takes effect later is worse than no switch.
         if (System.Windows.Application.Current.MainWindow is MainWindow main)
             main.ReRegisterHotkey();
+
+        // A row the rail advertises drops its combination when it is switched off, so the rail is
+        // as wrong after a tick as it is after a re-record.
+        if (field.AdvertisedInShell && Window.GetWindow(this) is Shell.ShellWindow shell)
+            shell.RefreshHotkeyHints();
     }
 
     private static void ApplyCaptureTrigger(AppSettings s, ShortcutTrigger trigger, string display)
@@ -772,10 +777,10 @@ public partial class SettingsPage : UserControl
         if (System.Windows.Application.Current.MainWindow is MainWindow main)
             main.ReRegisterHotkey();
 
-        // The nav rail advertises the capture shortcut beside 截圖翻譯 and is on screen right now, so
-        // it has to be told; nothing else re-reads it until the shell is next shown or activated. The
+        // The nav rail advertises these beside 截圖翻譯 and 取詞翻譯 and is on screen right now, so it
+        // has to be told; nothing else re-reads them until the shell is next shown or activated. The
         // other shortcuts are advertised nowhere, so there is nothing to refresh.
         if (recording.AdvertisedInShell && Window.GetWindow(this) is Shell.ShellWindow shell)
-            shell.RefreshHotkeyHint();
+            shell.RefreshHotkeyHints();
     }
 }

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -1,3 +1,12 @@
+<!-- MinWidth is the 文字翻譯 toolbar's floor. Its four pickers are fixed widths and cannot give:
+     162 + 32 + 162 + 180 with their gaps is 554, and the rail, the two card margins and the
+     page's own take 354 more before the page sees any of the window at all. 960 clears that
+     with room left for a different DPI or a wider system font, and it is close enough to the
+     1200 this window opens at that shrinking it never passes through a range where the page is
+     merely bad rather than either right or refused.
+
+     MinHeight is the rail's: the brand block, both 快速工具 rows, three nav rows and 關於 need
+     about 480 between them, and 640 leaves the page a card rather than a strip. -->
 <Window x:Class="OverTranslate.Views.Shell.ShellWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -5,7 +14,7 @@
         xmlns:settings="clr-namespace:OverTranslate.Views.Settings"
         Title="OverTranslate"
         Width="1200" Height="720"
-        MinWidth="840" MinHeight="520"
+        MinWidth="960" MinHeight="640"
         WindowStartupLocation="CenterScreen"
         ShowInTaskbar="True"
         WindowStyle="None"
@@ -41,9 +50,31 @@
         <Grid Grid.Row="0">
             <StackPanel Orientation="Horizontal"
                         VerticalAlignment="Center"
-                        Margin="12,0,0,0">
+                        Margin="6,0,0,0">
+                <!-- The rail's own switch, at the leading edge of the caption strip because that is
+                     where every pane the user has met keeps it — Finder's, Mail's, and Windows'
+                     own navigation view. Here specifically it has to be somewhere outside the rail:
+                     a switch that lived on the rail would go away with it and leave a collapsed
+                     rail with no way back.
+
+                     Hit-test-visible on the button alone rather than on the row: the icon and the
+                     title beside it are drag surface, and the whole point of this strip is that it
+                     still moves the window.
+
+                     One glyph for both states. The hamburger names the pane, not the direction —
+                     what it will do is in the tooltip, which is rewritten with the state.
+
+                     Since 快速工具 has to be reachable, this cannot be the app's only nav: the
+                     rail's rows are the destinations and the hotkeys are the actions, and putting
+                     the rail away is a choice about width, not about features. -->
+                <Button x:Name="SidebarToggleBtn"
+                        Style="{StaticResource WindowSidebarToggle}"
+                        Content="&#xE700;"
+                        WindowChrome.IsHitTestVisibleInChrome="True"
+                        Click="SidebarToggleBtn_Click"/>
                 <Image x:Name="TitleIcon"
                        Width="16" Height="16"
+                       Margin="6,0,0,0"
                        VerticalAlignment="Center"
                        RenderOptions.BitmapScalingMode="HighQuality"/>
                 <TextBlock Text="OverTranslate"
@@ -79,18 +110,17 @@
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <!-- 248 was sized to the Chinese labels, which fit a 快速工具 row and its shortcut on
-                     one line with room to spare. English does not — "Screen capture" and
-                     "Ctrl+Alt+A" share that line, and the shortcut is docked first — so the default
-                     is wider and the user can settle it themselves with the splitter.
+                <!-- 248 is sized to the 快速工具 rows, which are the widest thing the rail holds: a
+                     label and its shortcut on one line. The width is fixed and the user's only
+                     choice about it is whether the rail is there at all — a rail that can be any
+                     width is a rail whose contents have to survive every one of them, and what the
+                     user actually wants from dragging it narrow is the width back for the page.
 
-                     MaxWidth is the rail's ceiling and is enforced here; its floor is not, and is 0
-                     on purpose. The rail has to be able to reach nothing at all — that is the only
-                     way this window has of giving the page the whole width — and a column with a
-                     MinWidth can never be taken there, not even from code. RailMinWidth is what
-                     holds the floor instead, on the drag itself. -->
+                     No MinWidth, on purpose: 0 is a width this column is asked for every time the
+                     rail is put away, and a column with a MinWidth can never be taken there, not
+                     even from code. The animation writes it; nothing else does. -->
                 <ColumnDefinition x:Name="SidebarColumn"
-                                  Width="248" MinWidth="0" MaxWidth="340"/>
+                                  Width="248" MinWidth="0"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
@@ -271,7 +301,7 @@
 
                                 <!-- Filled in on every ShowOrActivate so a shortcut changed in 設定
                                      is never stale. Docked before the label so the label is the
-                                     part that trims when the rail is dragged narrow — a
+                                     part that gives way when the two do not both fit — a
                                      half-written shortcut is worse than none. -->
                                 <TextBlock x:Name="CaptureHotkeyText"
                                            DockPanel.Dock="Right"
@@ -387,35 +417,6 @@
                     <TranslateTransform x:Name="ContentTransform"/>
                 </Border.RenderTransform>
             </Border>
-
-            <!-- ══════════ Rail splitter ══════════ -->
-            <!-- Invisible, and in the gap between the two cards rather than on either card's edge:
-                 there is no seam here to put a handle on, and a drawn one would be the only line in
-                 a window built out of gaps. The hit area is what the user finds, and the cursor is
-                 what tells them it is there.
-
-                 In the page's column rather than the rail's, filling the gap from edge to edge.
-                 That is what keeps it reachable when the rail is collapsed to nothing: on the
-                 rail's own trailing edge it would sit at x=0 and extend off the window, leaving a
-                 collapsed rail with no way back short of restarting. It is wider than the gap looks
-                 for the same reason — collapsed, its first few pixels are underneath the window's
-                 own resize border, and what is left has to stay big enough to hit.
-
-                 Declared after both panels so it takes the mouse ahead of them, and before the
-                 modals so an overlay still covers it. -->
-            <GridSplitter Grid.Column="1"
-                          x:Name="SidebarSplitter"
-                          Width="16"
-                          Margin="0,4,0,16"
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Stretch"
-                          Background="Transparent"
-                          Focusable="False"
-                          ResizeDirection="Columns"
-                          ResizeBehavior="PreviousAndCurrent"
-                          DragDelta="Splitter_DragDelta"
-                          DragCompleted="Splitter_DragCompleted"
-                          Cursor="SizeWE"/>
 
             <!-- ══════════ Modals ══════════ -->
             <!-- Declared last and spanning both columns so a modal covers the nav rail as well as

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -8,29 +8,104 @@
         MinWidth="840" MinHeight="520"
         WindowStartupLocation="CenterScreen"
         ShowInTaskbar="True"
+        WindowStyle="None"
         Background="{DynamicResource AppWindowBg}">
 
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <!-- 208 was sized to the Chinese labels, which fit the rail's primary action and its
-                 shortcut on one line with room to spare. English does not — "Screen capture" and
-                 "Ctrl+Alt+A" share that line, and the shortcut is docked first — so the default
-                 is wider and the user can settle it themselves with the splitter below.
-                 MinWidth still fits an icon and a short label; MaxWidth stops the rail from
-                 eating the page beside it. -->
-            <ColumnDefinition x:Name="SidebarColumn"
-                              Width="230" MinWidth="180" MaxWidth="300"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
+    <!-- The system title bar is replaced rather than hidden. WindowChrome keeps everything the
+         non-client area does — drag, double-click to maximise, Aero Snap, the resize borders and
+         the taskbar preview — and hands the strip itself over to be drawn in the application's own
+         theme, which the system one cannot follow.
 
-        <!-- ══════════ Sidebar ══════════ -->
-        <Border Grid.Column="0"
-                Background="{DynamicResource AppHeaderBg}"
-                BorderBrush="{DynamicResource AppBorder}"
-                BorderThickness="0,0,1,0">
-            <DockPanel>
+         CaptionHeight matches the title row below exactly: it is what makes that strip draggable,
+         and anything in it that must stay clickable says so with IsHitTestVisibleInChrome.
+         GlassFrameThickness 0 drops the system's own frame drawing; UseAeroCaptionButtons 0 stops
+         it from drawing its buttons over the ones this window paints. -->
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="40"
+                      ResizeBorderThickness="6"
+                      CornerRadius="0"
+                      GlassFrameThickness="0"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <!-- Maximised, a WindowChrome window is sized to the monitor plus its own resize border, so the
+         edges fall off the screen. WindowRoot carries the inset that pulls them back; it is applied
+         from code (ApplyMaximizedInset) because the amount is the system's, not a number to guess. -->
+    <Grid x:Name="WindowRoot">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- ══════════ Title bar ══════════ -->
+        <Grid Grid.Row="0">
+            <StackPanel Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Margin="12,0,0,0">
+                <Image x:Name="TitleIcon"
+                       Width="16" Height="16"
+                       VerticalAlignment="Center"
+                       RenderOptions.BitmapScalingMode="HighQuality"/>
+                <TextBlock Text="OverTranslate"
+                           FontFamily="{StaticResource AppFont}"
+                           FontSize="12"
+                           Margin="8,0,0,0"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource AppTextSecondary}"/>
+            </StackPanel>
+
+            <!-- Windows' own order, left to right, because muscle memory for this strip is older
+                 than any application: minimise, restore/maximise, close. -->
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        WindowChrome.IsHitTestVisibleInChrome="True">
+                <Button x:Name="MinimizeBtn"
+                        Style="{StaticResource WindowCaptionButton}"
+                        Content="&#xE921;"
+                        Click="MinimizeBtn_Click"/>
+                <!-- One button, two meanings, so its glyph is set from the window state rather than
+                     fixed here: a maximised window offering "maximise" is a control that lies. -->
+                <Button x:Name="MaximizeBtn"
+                        Style="{StaticResource WindowCaptionButton}"
+                        Content="&#xE922;"
+                        Click="MaximizeBtn_Click"/>
+                <Button x:Name="CloseBtn"
+                        Style="{StaticResource WindowCloseButton}"
+                        Content="&#xE8BB;"
+                        Click="CloseBtn_Click"/>
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <!-- 248 was sized to the Chinese labels, which fit a 快速工具 row and its shortcut on
+                     one line with room to spare. English does not — "Screen capture" and
+                     "Ctrl+Alt+A" share that line, and the shortcut is docked first — so the default
+                     is wider and the user can settle it themselves with the splitter.
+
+                     MaxWidth is the rail's ceiling and is enforced here; its floor is not, and is 0
+                     on purpose. The rail has to be able to reach nothing at all — that is the only
+                     way this window has of giving the page the whole width — and a column with a
+                     MinWidth can never be taken there, not even from code. RailMinWidth is what
+                     holds the floor instead, on the drag itself. -->
+                <ColumnDefinition x:Name="SidebarColumn"
+                                  Width="248" MinWidth="0" MaxWidth="340"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- ══════════ Rail ══════════ -->
+            <!-- Clipped, because the column is allowed down to zero: without this the rail's
+                 contents would keep their measured width and spill across the page beside them. -->
+            <DockPanel Grid.Column="0"
+                       x:Name="RailPanel"
+                       ClipToBounds="True"
+                       Margin="16,4,0,16">
 
                 <!-- Brand.
+                     On the window's own surface rather than on the card below it, so the card
+                     starts at the first thing the user can act on. Same reason the page's title is
+                     inside its card and this is not: this names the application, not the panel.
 
                      A two-row grid rather than nested stacks, so both of the alignments here hold
                      themselves together instead of being maintained by hand.
@@ -46,7 +121,7 @@
                      width. It is deliberately outside the height binding: the mark answers to the
                      name and version, which are always there, and not to a badge that comes and
                      goes — otherwise the mark would resize itself every time a release appeared. -->
-                <Grid DockPanel.Dock="Top" Margin="18,18,16,20">
+                <Grid DockPanel.Dock="Top" Margin="8,10,8,16">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
@@ -63,16 +138,16 @@
                          would report the source bitmap's and take the whole rail. -->
                     <Image x:Name="BrandIcon"
                            Grid.Row="0" Grid.Column="0"
-                           Width="34" Height="34"
+                           Width="38" Height="38"
                            VerticalAlignment="Top"
                            RenderOptions.BitmapScalingMode="HighQuality"/>
 
                     <StackPanel x:Name="BrandText"
                                 Grid.Row="0" Grid.Column="1"
-                                Margin="10,0,0,0">
+                                Margin="12,0,0,0">
                         <TextBlock Text="OverTranslate"
                                    FontFamily="{StaticResource AppFont}"
-                                   FontSize="14"
+                                   FontSize="15"
                                    FontWeight="SemiBold"
                                    Foreground="{DynamicResource AppTextPrimary}"/>
                         <TextBlock x:Name="VersionText"
@@ -102,7 +177,7 @@
                             Grid.Row="1" Grid.Column="1"
                             Style="{StaticResource RailUpdateChip}"
                             HorizontalAlignment="Left"
-                            Margin="10,5,0,0"
+                            Margin="12,6,0,0"
                             Visibility="Collapsed"
                             Click="UpdateBtn_Click">
                         <DockPanel>
@@ -138,166 +213,217 @@
                     </Button>
                 </Grid>
 
-                <!-- 關於 opens a modal overlay rather than switching pages, so it sits
-                     apart from the nav list and never takes the selected state -->
-                <Button x:Name="AboutBtn"
-                        DockPanel.Dock="Bottom"
-                        Style="{StaticResource NavActionItem}"
-                        Margin="8,0,8,12"
-                        Click="AboutBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="14" Text="&#xE946;"
-                                   Width="24" VerticalAlignment="Center"/>
-                        <TextBlock Text="{DynamicResource S.Shell.About}" VerticalAlignment="Center"/>
-                    </StackPanel>
-                </Button>
-
-                <!-- Docked after 關於 so it lands above it. 關於 is the one item down here and the
-                     nav list ends a long way above it, so without a line the two read as one list
-                     with a large accidental gap in it. Inset to 16 so it starts and ends on the
-                     same vertical as the nav rows' own edges, which is what makes it read as
-                     dividing them rather than as a stray rule. -->
-                <Border DockPanel.Dock="Bottom"
-                        Height="1"
-                        Margin="16,0,16,10"
-                        Background="{DynamicResource AppBorder}"/>
-
-                <!-- 截圖翻譯 — the app's primary action, and since the tray menu no longer
-                     offers it, the only place other than the shortcut itself. It sits above the
-                     nav list rather than inside it because it performs an action instead of
-                     choosing a destination, and it lives on the shell rather than on a page so
-                     it stays reachable from 設定 too. Whitespace, not a rule, separates it: a
-                     divider would imply these are sections of one list. -->
-                <Button x:Name="CaptureBtn"
-                        DockPanel.Dock="Top"
-                        Style="{StaticResource NavPrimaryAction}"
-                        Margin="0,0,0,12"
-                        ToolTipService.ShowOnDisabled="True"
-                        Click="CaptureBtn_Click">
+                <!-- The rail's card. Nothing draws the boundary between this and the page: the gap
+                     between the two cards is the boundary, which is why neither of them carries an
+                     edge on the side that faces the other. -->
+                <Border Style="{StaticResource ShellCard}">
                     <DockPanel>
-                        <!-- Bare 24px glyph, identical geometry to the nav items below, so icons
-                             and labels share one column down the whole rail. A filled tile would
-                             need a gap a glyph gets for free and would knock this label out of
-                             that column. -->
-                        <TextBlock DockPanel.Dock="Left"
-                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="15" Text="&#xE123;"
-                                   Width="24" VerticalAlignment="Center"
-                                   Foreground="{DynamicResource AppAccent}"/>
 
-                        <!-- Trailing, muted, and on the same line: the shortcut is a reference the
-                             user reads once, not a second label competing with 截圖翻譯. Filled in
-                             on every ShowOrActivate so a shortcut changed in 設定 is never stale. -->
-                        <TextBlock x:Name="CaptureHotkeyText"
-                                   DockPanel.Dock="Right"
-                                   FontSize="11"
-                                   Margin="8,0,0,0"
-                                   VerticalAlignment="Center"
-                                   Foreground="{DynamicResource AppTextSecondary}"/>
+                        <!-- 關於 opens a modal overlay rather than switching pages, so it sits
+                             apart from the nav list and never takes the selected state -->
+                        <Button x:Name="AboutBtn"
+                                DockPanel.Dock="Bottom"
+                                Style="{StaticResource NavActionItem}"
+                                Margin="8,0,8,12"
+                                Click="AboutBtn_Click">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                           FontSize="14" Text="&#xE946;"
+                                           Width="24" VerticalAlignment="Center"/>
+                                <TextBlock Text="{DynamicResource S.Shell.About}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
 
-                        <TextBlock Text="{DynamicResource S.Shell.CaptureTranslate}"
-                                   FontWeight="SemiBold"
-                                   VerticalAlignment="Center"/>
+                        <!-- Docked after 關於 so it lands above it. 關於 is the one item down here
+                             and the nav list ends a long way above it, so without a line the two
+                             read as one list with a large accidental gap in it. Inset to 16 so it
+                             starts and ends on the same vertical as the nav rows' own edges, which
+                             is what makes it read as dividing them rather than as a stray rule. -->
+                        <Border DockPanel.Dock="Bottom"
+                                Height="1"
+                                Margin="16,0,16,10"
+                                Background="{DynamicResource AppSeparator}"/>
+
+                        <!-- 快速工具 — the two shortcut-driven actions, above the nav list rather
+                             than inside it because they perform an action instead of choosing a
+                             destination, and on the shell rather than on a page so they stay
+                             reachable from 設定 too. Since the tray menu no longer offers either,
+                             this is the only place other than the shortcuts themselves.
+
+                             A heading here and a rule below: two cards with no caption read as a
+                             list whose first two rows are inexplicably taller than the rest, and
+                             naming the group is what says these do something rather than go
+                             somewhere. -->
+                        <TextBlock DockPanel.Dock="Top"
+                                   Text="{DynamicResource S.Shell.QuickTools}"
+                                   Style="{StaticResource SectionHeader}"
+                                   Margin="20,16,16,8"/>
+
+                        <Button x:Name="CaptureBtn"
+                                DockPanel.Dock="Top"
+                                Style="{StaticResource RailQuickTool}"
+                                ToolTipService.ShowOnDisabled="True"
+                                Click="CaptureBtn_Click">
+                            <DockPanel>
+                                <Border DockPanel.Dock="Left" Style="{StaticResource RailQuickToolIcon}">
+                                    <TextBlock Text="&#xE123;" Style="{StaticResource RailQuickToolGlyph}"/>
+                                </Border>
+
+                                <!-- Filled in on every ShowOrActivate so a shortcut changed in 設定
+                                     is never stale. Docked before the label so the label is the
+                                     part that trims when the rail is dragged narrow — a
+                                     half-written shortcut is worse than none. -->
+                                <TextBlock x:Name="CaptureHotkeyText"
+                                           DockPanel.Dock="Right"
+                                           Style="{StaticResource RailQuickToolHotkey}"/>
+
+                                <TextBlock Text="{DynamicResource S.Shell.CaptureTranslate}"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </DockPanel>
+                        </Button>
+
+                        <!-- Same glyph 設定 gives this shortcut, so the row and the row that
+                             configures it are recognisably the same feature. -->
+                        <Button x:Name="QuickLookupBtn"
+                                DockPanel.Dock="Top"
+                                Style="{StaticResource RailQuickTool}"
+                                ToolTipService.ShowOnDisabled="True"
+                                Click="QuickLookupBtn_Click">
+                            <DockPanel>
+                                <Border DockPanel.Dock="Left" Style="{StaticResource RailQuickToolIcon}">
+                                    <TextBlock Text="&#xE721;" Style="{StaticResource RailQuickToolGlyph}"/>
+                                </Border>
+
+                                <TextBlock x:Name="QuickLookupHotkeyText"
+                                           DockPanel.Dock="Right"
+                                           Style="{StaticResource RailQuickToolHotkey}"/>
+
+                                <TextBlock Text="{DynamicResource S.Shell.QuickLookup}"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </DockPanel>
+                        </Button>
+
+                        <Border DockPanel.Dock="Top"
+                                Height="1"
+                                Margin="16,14,16,10"
+                                Background="{DynamicResource AppSeparator}"/>
+
+                        <!-- Nav list + sliding selection indicator -->
+                        <Grid VerticalAlignment="Top">
+                            <Border x:Name="NavIndicator"
+                                    Width="3" Height="18"
+                                    CornerRadius="1.5"
+                                    Background="{DynamicResource AppAccent}"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Top"
+                                    Margin="4,0,0,0">
+                                <Border.RenderTransform>
+                                    <TranslateTransform x:Name="NavIndicatorTransform"/>
+                                </Border.RenderTransform>
+                            </Border>
+
+                            <StackPanel x:Name="NavPanel">
+                                <RadioButton x:Name="TranslationNav"
+                                             Style="{StaticResource NavItem}"
+                                             GroupName="ShellNav"
+                                             Checked="Nav_Checked">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="15" Text="&#xE8C1;"
+                                                   Width="24" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{DynamicResource S.Shell.TextTranslate}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </RadioButton>
+
+                                <!-- Its own destination rather than a mode of 文字翻譯: nothing on
+                                     that page applies here, and a session started from it keeps
+                                     running long after the user has navigated away. -->
+                                <RadioButton x:Name="RealtimeNav"
+                                             Style="{StaticResource NavItem}"
+                                             GroupName="ShellNav"
+                                             Checked="Nav_Checked">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="15" Text="&#xE9D9;"
+                                                   Width="24" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{DynamicResource S.Shell.RealtimeTranslate}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </RadioButton>
+
+                                <RadioButton x:Name="SettingsNav"
+                                             Style="{StaticResource NavItem}"
+                                             GroupName="ShellNav"
+                                             Checked="Nav_Checked">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="15" Text="&#xE713;"
+                                                   Width="24" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{DynamicResource S.Shell.Settings}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </RadioButton>
+                            </StackPanel>
+                        </Grid>
                     </DockPanel>
-                </Button>
-
-                <!-- Nav list + sliding selection indicator -->
-                <Grid VerticalAlignment="Top">
-                    <Border x:Name="NavIndicator"
-                            Width="3" Height="18"
-                            CornerRadius="1.5"
-                            Background="{DynamicResource AppAccent}"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Top"
-                            Margin="4,0,0,0">
-                        <Border.RenderTransform>
-                            <TranslateTransform x:Name="NavIndicatorTransform"/>
-                        </Border.RenderTransform>
-                    </Border>
-
-                    <StackPanel x:Name="NavPanel">
-                        <RadioButton x:Name="TranslationNav"
-                                     Style="{StaticResource NavItem}"
-                                     GroupName="ShellNav"
-                                     Checked="Nav_Checked">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                           FontSize="15" Text="&#xE8C1;"
-                                           Width="24" VerticalAlignment="Center"/>
-                                <TextBlock Text="{DynamicResource S.Shell.TextTranslate}" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </RadioButton>
-
-                        <!-- Its own destination rather than a mode of 文字翻譯: nothing on that page
-                             applies here, and a session started from it keeps running long after
-                             the user has navigated away. -->
-                        <RadioButton x:Name="RealtimeNav"
-                                     Style="{StaticResource NavItem}"
-                                     GroupName="ShellNav"
-                                     Checked="Nav_Checked">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                           FontSize="15" Text="&#xE9D9;"
-                                           Width="24" VerticalAlignment="Center"/>
-                                <TextBlock Text="{DynamicResource S.Shell.RealtimeTranslate}" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </RadioButton>
-
-                        <RadioButton x:Name="SettingsNav"
-                                     Style="{StaticResource NavItem}"
-                                     GroupName="ShellNav"
-                                     Checked="Nav_Checked">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                           FontSize="15" Text="&#xE713;"
-                                           Width="24" VerticalAlignment="Center"/>
-                                <TextBlock Text="{DynamicResource S.Shell.Settings}" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </RadioButton>
-                    </StackPanel>
-                </Grid>
+                </Border>
             </DockPanel>
-        </Border>
 
-        <!-- ══════════ Content ══════════ -->
-        <!-- A Border rather than a ContentControl so the animated layer has an opaque background of
-             its own: the slide runs this subtree through a bitmap cache (see AnimateContentIn) and
-             through an opacity animation, both of which are intermediate surfaces that WPF assumes
-             may be transparent, and ClearType sub-pixel antialiasing cannot run over transparent
-             pixels. An opaque backing plus ClearTypeHint tells WPF the surface really is opaque, so
-             ClearType stays on for the whole transition. -->
-        <Border Grid.Column="1"
-                x:Name="ContentHost"
-                Background="{DynamicResource AppWindowBg}"
-                RenderOptions.ClearTypeHint="Enabled">
-            <Border.RenderTransform>
-                <TranslateTransform x:Name="ContentTransform"/>
-            </Border.RenderTransform>
-        </Border>
+            <!-- ══════════ Content ══════════ -->
+            <!-- A Border rather than a ContentControl so the animated layer has an opaque background
+                 of its own: the slide runs this subtree through a bitmap cache (see
+                 AnimateContentIn) and through an opacity animation, both of which are intermediate
+                 surfaces that WPF assumes may be transparent, and ClearType sub-pixel antialiasing
+                 cannot run over transparent pixels. An opaque backing plus ClearTypeHint tells WPF
+                 the surface really is opaque, so ClearType stays on for the whole transition. -->
+            <Border Grid.Column="1"
+                    x:Name="ContentHost"
+                    Style="{StaticResource ShellCard}"
+                    Margin="16,4,16,16"
+                    RenderOptions.ClearTypeHint="Enabled">
+                <Border.RenderTransform>
+                    <TranslateTransform x:Name="ContentTransform"/>
+                </Border.RenderTransform>
+            </Border>
 
-        <!-- ══════════ Sidebar splitter ══════════ -->
-        <!-- Sits on the rail's trailing edge rather than in a column of its own, so it costs no
-             layout width and the seam stays exactly where the two backgrounds meet. Transparent
-             with a wider hit area than it looks: the visible boundary is the Border's edge, and a
-             drawn handle would be a permanent line across a window that otherwise has none.
-             Declared after both panels so it takes the mouse ahead of them, and before the About
-             overlay so a modal still covers it. -->
-        <GridSplitter Grid.Column="0"
-                      x:Name="SidebarSplitter"
-                      Width="6"
-                      HorizontalAlignment="Right"
-                      VerticalAlignment="Stretch"
-                      Background="Transparent"
-                      Focusable="False"
-                      ResizeDirection="Columns"
-                      ResizeBehavior="CurrentAndNext"
-                      Cursor="SizeWE"/>
+            <!-- ══════════ Rail splitter ══════════ -->
+            <!-- Invisible, and in the gap between the two cards rather than on either card's edge:
+                 there is no seam here to put a handle on, and a drawn one would be the only line in
+                 a window built out of gaps. The hit area is what the user finds, and the cursor is
+                 what tells them it is there.
 
-        <!-- ══════════ Modals ══════════ -->
-        <!-- Declared last and spanning both columns so a modal covers the nav rail as well as the
-             page: one the user can navigate out from behind is not modal. -->
-        <shell:AboutOverlay Grid.ColumnSpan="2" x:Name="About"/>
-        <settings:ServiceSettingsOverlay Grid.ColumnSpan="2" x:Name="ServiceSettings"/>
+                 In the page's column rather than the rail's, filling the gap from edge to edge.
+                 That is what keeps it reachable when the rail is collapsed to nothing: on the
+                 rail's own trailing edge it would sit at x=0 and extend off the window, leaving a
+                 collapsed rail with no way back short of restarting. It is wider than the gap looks
+                 for the same reason — collapsed, its first few pixels are underneath the window's
+                 own resize border, and what is left has to stay big enough to hit.
+
+                 Declared after both panels so it takes the mouse ahead of them, and before the
+                 modals so an overlay still covers it. -->
+            <GridSplitter Grid.Column="1"
+                          x:Name="SidebarSplitter"
+                          Width="16"
+                          Margin="0,4,0,16"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Stretch"
+                          Background="Transparent"
+                          Focusable="False"
+                          ResizeDirection="Columns"
+                          ResizeBehavior="PreviousAndCurrent"
+                          DragDelta="Splitter_DragDelta"
+                          DragCompleted="Splitter_DragCompleted"
+                          Cursor="SizeWE"/>
+
+            <!-- ══════════ Modals ══════════ -->
+            <!-- Declared last and spanning both columns so a modal covers the nav rail as well as
+                 the page: one the user can navigate out from behind is not modal. Inside the body
+                 row, so the window's own buttons stay reachable — a modal that could close the
+                 window is not what the scrim is protecting. -->
+            <shell:AboutOverlay Grid.ColumnSpan="2" x:Name="About"/>
+            <settings:ServiceSettingsOverlay Grid.ColumnSpan="2" x:Name="ServiceSettings"/>
+        </Grid>
     </Grid>
 </Window>

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
-using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
@@ -58,7 +58,7 @@ public partial class ShellWindow : Window
     private static WindowState _lastWindowState = WindowState.Normal;
 
     /// <inheritdoc cref="_lastSize"/>
-    private static double? _lastSidebarWidth;
+    private static bool _lastRailCollapsed;
 
     /// <summary>
     /// The page the shell was last showing, so opening it again lands where the user left off
@@ -177,13 +177,9 @@ public partial class ShellWindow : Window
 
         if (_lastWindowState == WindowState.Maximized) WindowState = WindowState.Maximized;
 
-        if (_lastSidebarWidth is { } railWidth)
-        {
-            // Either put away or inside its bounds — the same two states a drag can leave it in.
-            SetRailWidth(railWidth < RailMinWidth
-                ? 0
-                : Math.Clamp(railWidth, RailMinWidth, SidebarColumn.MaxWidth));
-        }
+        _railCollapsed = _lastRailCollapsed;
+        SetRailWidth(_railCollapsed ? 0 : RailWidth);
+        RefreshSidebarToggle();
     }
 
     // The window's outer edge is the compositor's, not this window's, so it is the one colour in
@@ -194,6 +190,7 @@ public partial class ShellWindow : Window
     {
         RefreshQuickToolAvailability();
         RefreshUpdateAvailability();
+        RefreshSidebarToggle();
     }
 
     /// <summary>
@@ -333,18 +330,15 @@ public partial class ShellWindow : Window
     private void RefreshMaximizeButton() =>
         MaximizeBtn.Content = WindowState == WindowState.Maximized ? "" : "";
 
-    /// <summary>
-    /// How far past its minimum the pointer has to be dragged before letting go puts the rail away.
-    /// </summary>
+    /// <summary>The rail's width whenever it is showing.</summary>
     /// <remarks>
-    /// A width the rail is never actually shown at — it stops at <see cref="RailMinWidth"/> and
-    /// stays there while the pointer keeps going. That overshoot is the whole gesture: putting the
-    /// rail away has to be something the user asks for, not somewhere a drag can accidentally stop.
+    /// One width rather than a range. The rail holds a fixed set of rows whose widest line is a
+    /// 快速工具 label and its shortcut, so there is one width that fits them — every other width is
+    /// either wasting the page's or trimming the rail's own labels. What a user dragging the rail
+    /// narrow actually wants is the width back, and the toggle in the title bar gives them all of
+    /// it in one press.
     /// </remarks>
-    private const double RailCollapseThreshold = 120;
-
-    /// <summary>The narrowest the rail is ever shown at — enough for an icon and a short label.</summary>
-    private const double RailMinWidth = 200;
+    private const double RailWidth = 248;
 
     private static readonly Duration RailDuration = new(TimeSpan.FromMilliseconds(320));
 
@@ -361,12 +355,12 @@ public partial class ShellWindow : Window
         new PropertyMetadata(0.0, (d, e) => ((ShellWindow)d).ApplyRailWidth((double)e.NewValue)));
 
     /// <summary>
-    /// The rail's width as the splitter has just set it.
+    /// The rail's width as it has just been written, animation included.
     /// </summary>
     /// <remarks>
-    /// Not ActualWidth: the splitter writes the column's own Width, and a drag that has just ended
-    /// is read before the layout pass that would make ActualWidth agree — so the snap would decide
-    /// on the width the rail had one drag ago.
+    /// Not ActualWidth: the column's own Width is what the animation writes, and it is read here
+    /// before the layout pass that would make ActualWidth agree — so a toggle pressed mid-slide
+    /// would otherwise carry on from the width the rail had a frame ago and jump.
     /// </remarks>
     private double CurrentRailWidth => SidebarColumn.Width.IsAbsolute
         ? SidebarColumn.Width.Value
@@ -400,8 +394,10 @@ public partial class ShellWindow : Window
             return;
         }
 
+        // From wherever the rail is on screen right now, not from where the animation in flight was
+        // headed: pressing the button again mid-slide reverses it instead of finishing first.
         // Critically damped — eased out with no overshoot. The rail is a panel being put somewhere,
-        // not something thrown, and a bounce here would read as the drag having missed.
+        // not something thrown, and a bounce here would read as it having missed.
         BeginAnimation(RailWidthProperty, new DoubleAnimation
         {
             From = from,
@@ -411,44 +407,41 @@ public partial class ShellWindow : Window
         });
     }
 
-    /// <summary>Set while a drag is being held past the point where letting go collapses the rail.</summary>
-    private bool _railDraggedPastCollapse;
-
-    /// <summary>
-    /// Holds the rail between its own bounds for the length of the drag, and dims it once the
-    /// pointer has gone far enough that letting go would put it away.
-    /// </summary>
+    /// <summary>Whether the rail is currently put away.</summary>
     /// <remarks>
-    /// The splitter writes whatever width the pointer asks for, including none at all — the column
-    /// has no MinWidth of its own because the rail has to be able to reach zero. Clamping here is
-    /// what makes the floor and the ceiling real, and the dimming is the only warning the user gets
-    /// before the rail goes.
+    /// Held here rather than read back off the column, so a press that lands while the slide is
+    /// still running toggles what the rail is going to be rather than whatever width it happens to
+    /// be passing through at that instant.
     /// </remarks>
-    private void Splitter_DragDelta(object sender, DragDeltaEventArgs e)
+    private bool _railCollapsed;
+
+    private void SidebarToggleBtn_Click(object sender, RoutedEventArgs e)
     {
-        var wanted = CurrentRailWidth;
-
-        _railDraggedPastCollapse = wanted < RailCollapseThreshold;
-        RailPanel.Opacity = _railDraggedPastCollapse ? 0.45 : 1;
-
-        ApplyRailWidth(Math.Clamp(wanted, RailMinWidth, SidebarColumn.MaxWidth));
+        _railCollapsed = !_railCollapsed;
+        AnimateRailTo(_railCollapsed ? 0 : RailWidth);
+        // Now, rather than when the slide lands: the button already offers the opposite of what it
+        // just did, and a tooltip that only caught up 320ms later would be wrong for the whole of
+        // the one moment the pointer is still sitting on it.
+        RefreshSidebarToggle();
     }
 
     /// <summary>
-    /// Settles the rail where the drag left it: away entirely, or no narrower than its labels need.
+    /// Says what pressing the toggle would do next, in the language the window is currently in.
     /// </summary>
     /// <remarks>
-    /// A rail dragged to nothing is the only way this window has of giving the page its whole
-    /// width, so the splitter is left reachable at the page's edge — see the markup — and dragging
-    /// it back out is what brings the rail back.
+    /// The glyph does not change with the state — it names the rail rather than a direction, the
+    /// way Windows' own pane toggle does — so this text is the only place that direction is stated.
+    /// It is the accessible name as well as the tooltip: a glyph-only button has nothing else for a
+    /// screen reader to read out.
     /// </remarks>
-    private void Splitter_DragCompleted(object sender, DragCompletedEventArgs e)
+    private void RefreshSidebarToggle()
     {
-        RailPanel.Opacity = 1;
-        AnimateRailTo(_railDraggedPastCollapse
-            ? 0
-            : Math.Clamp(CurrentRailWidth, RailMinWidth, SidebarColumn.MaxWidth));
-        _railDraggedPastCollapse = false;
+        var label = LocalizationService.Get(_railCollapsed
+            ? "S.Shell.ShowSidebar"
+            : "S.Shell.HideSidebar");
+
+        SidebarToggleBtn.ToolTip = label;
+        AutomationProperties.SetName(SidebarToggleBtn, label);
     }
 
     private void CaptureBtn_Click(object sender, RoutedEventArgs e)
@@ -625,7 +618,7 @@ public partial class ShellWindow : Window
         _lastSize = new Size(bounds.Width, bounds.Height);
         // Minimised is a state to reopen out of, not into.
         _lastWindowState = WindowState == WindowState.Minimized ? WindowState.Normal : WindowState;
-        _lastSidebarWidth = SidebarColumn.ActualWidth;
+        _lastRailCollapsed = _railCollapsed;
 
         base.OnClosing(e);
     }

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
@@ -106,8 +107,8 @@ public partial class ShellWindow : Window
         }
 
         _instance.Navigate(target);
-        _instance.RefreshHotkeyHint();
-        _instance.RefreshCaptureAvailability();
+        _instance.RefreshHotkeyHints();
+        _instance.RefreshQuickToolAvailability();
 
         var shell = _instance;
         shell.Dispatcher.BeginInvoke(shell.Activate, DispatcherPriority.ApplicationIdle);
@@ -121,11 +122,12 @@ public partial class ShellWindow : Window
         var icon = AppIconService.CreateWindowIcon();
         Icon = icon;
         BrandIcon.Source = icon;
+        TitleIcon.Source = icon;
         VersionText.Text = $"v{Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0"}";
 
         _instance = this;
         MatchBrandIconToText();
-        RefreshHotkeyHint();
+        RefreshHotkeyHints();
 
         // Subscribed once here rather than per open, so the handler is not stacked up by a user who
         // opens the service panel more than once.
@@ -135,19 +137,28 @@ public partial class ShellWindow : Window
         // Show(), not through ShowOrActivate, so nothing else would clear the disabled state and
         // the button would stay greyed out for as long as the shell stayed open.
         Realtime.RealtimeSessionController.Instance.StateChanged += OnRealtimeStateChanged;
-        RefreshCaptureAvailability();
+        RefreshQuickToolAvailability();
 
         // Same reasoning, and one more: the periodic check runs whether or not this window exists,
         // so the rail has to be able to gain the row while the user is sitting in front of it.
         UpdateNotifier.AvailabilityChanged += OnUpdateAvailabilityChanged;
         RefreshUpdateAvailability();
 
-        // The rail's two composed strings — the update row's version and the capture button's
-        // blocked-by-realtime tooltip — are set from code, so DynamicResource does not reach them
+        // The rail's composed strings — the update row's version and the 快速工具 rows'
+        // blocked-by-realtime tooltips — are set from code, so DynamicResource does not reach them
         // and they would keep the language they were built in. The settings page that changes the
         // language lives inside this window, so they are always on screen when it happens.
         LocalizationService.LanguageChanged += OnLanguageChanged;
         Closed += (_, _) => LocalizationService.LanguageChanged -= OnLanguageChanged;
+
+        // The system title bar is gone, so what it used to do for itself is done here: maximising
+        // to the work area rather than over it, rounding the window and colouring its outer edge,
+        // and saying which of maximise or restore this window is currently offering.
+        WindowFrame.Attach(this);
+        ThemeService.Changed += OnThemeChanged;
+        Closed += (_, _) => ThemeService.Changed -= OnThemeChanged;
+        StateChanged += (_, _) => RefreshMaximizeButton();
+        RefreshMaximizeButton();
 
         RestoreSessionLayout();
 
@@ -168,14 +179,20 @@ public partial class ShellWindow : Window
 
         if (_lastSidebarWidth is { } railWidth)
         {
-            SidebarColumn.Width = new GridLength(
-                Math.Clamp(railWidth, SidebarColumn.MinWidth, SidebarColumn.MaxWidth));
+            // Either put away or inside its bounds — the same two states a drag can leave it in.
+            SetRailWidth(railWidth < RailMinWidth
+                ? 0
+                : Math.Clamp(railWidth, RailMinWidth, SidebarColumn.MaxWidth));
         }
     }
 
+    // The window's outer edge is the compositor's, not this window's, so it is the one colour in
+    // the application that has to be handed over again rather than re-resolved.
+    private void OnThemeChanged(object? sender, EventArgs e) => WindowFrame.ApplyAppearance(this);
+
     private void OnLanguageChanged(object? sender, EventArgs e)
     {
-        RefreshCaptureAvailability();
+        RefreshQuickToolAvailability();
         RefreshUpdateAvailability();
     }
 
@@ -204,41 +221,60 @@ public partial class ShellWindow : Window
     }
 
     /// <summary>
-    /// Re-reads the shortcut into the capture button's trailing hint. Called on construction and on
+    /// Re-reads the shortcuts into the 快速工具 rows' trailing hints. Called on construction and on
     /// every ShowOrActivate, and directly by <see cref="Settings.SettingsPage"/> the moment a new
     /// shortcut is recorded — the rail is visible the whole time the user is on 設定, so waiting
     /// for the next navigation would leave the wrong shortcut on screen next to the button.
     /// </summary>
-    public void RefreshHotkeyHint()
+    public void RefreshHotkeyHints()
     {
-        var hotkey = SettingsService.Instance.Current.HotkeyDisplay;
+        var settings = SettingsService.Instance.Current;
+
         // Blank rather than a "未設定" placeholder: the label already says what the button does,
         // and a slot that only ever holds a shortcut should be empty when there is none.
-        CaptureHotkeyText.Text = string.IsNullOrWhiteSpace(hotkey) ? "" : hotkey;
+        CaptureHotkeyText.Text = string.IsNullOrWhiteSpace(settings.HotkeyDisplay)
+            ? ""
+            : settings.HotkeyDisplay;
+
+        // Also blank when the shortcut is switched off in 設定: this row is not registered then, so
+        // printing the combination would advertise a key press that does nothing. The button
+        // itself stays — it is a way in of its own, not a reminder of the shortcut.
+        QuickLookupHotkeyText.Text =
+            settings.QuickLookupHotkeyEnabled && !string.IsNullOrWhiteSpace(settings.QuickLookupHotkeyDisplay)
+                ? settings.QuickLookupHotkeyDisplay
+                : "";
     }
 
     /// <summary>
-    /// Greys out the rail's capture button while a realtime session is running, and says why.
+    /// Greys out the rail's 快速工具 rows while a realtime session is running, and says why.
     /// </summary>
     /// <remarks>
-    /// The two features share one OCR engine and one pool of inference slots, so they are exclusive
-    /// — see MainWindow.RefuseWhileRealtimeRuns, which is what actually enforces it. This is the
-    /// half the user sees: a button that refuses when pressed teaches nothing, while a disabled one
-    /// carrying its reason answers the question before it is asked.
+    /// All three features share one OCR engine and one pool of inference slots, so they are
+    /// exclusive — see MainWindow.RefuseWhileRealtimeRuns, which is what actually enforces it. This
+    /// is the half the user sees: a button that refuses when pressed teaches nothing, while a
+    /// disabled one carrying its reason answers the question before it is asked.
     ///
     /// The shell is hidden for the duration of a session, so this matters in one specific way in: a
-    /// user who opens 設定 from the tray mid-session gets the rail, and its primary action with it.
+    /// user who opens 設定 from the tray mid-session gets the rail, and its actions with it.
     /// </remarks>
     private void OnRealtimeStateChanged(object? sender, EventArgs e) =>
-        Dispatcher.BeginInvoke(RefreshCaptureAvailability);
+        Dispatcher.BeginInvoke(RefreshQuickToolAvailability);
 
-    public void RefreshCaptureAvailability()
+    public void RefreshQuickToolAvailability()
     {
         var running = Realtime.RealtimeSessionController.Instance.IsActive;
 
         CaptureBtn.IsEnabled = !running;
         CaptureBtn.ToolTip = running
             ? LocalizationService.Get("S.Shell.CaptureBlockedByRealtime")
+            : null;
+
+        // 取詞翻譯 is not merely refused during a session — a session already dismisses the popup
+        // when it starts (MainWindow.OnRealtimeStateChanged), so a row that still looked available
+        // would open a window that closes itself.
+        QuickLookupBtn.IsEnabled = !running;
+        QuickLookupBtn.ToolTip = running
+            ? LocalizationService.Get("S.Shell.QuickLookupBlockedByRealtime")
             : null;
     }
 
@@ -277,12 +313,158 @@ public partial class ShellWindow : Window
         UpdateWindow.ShowOrActivate(update);
     }
 
+    private void MinimizeBtn_Click(object sender, RoutedEventArgs e) =>
+        WindowState = WindowState.Minimized;
+
+    private void MaximizeBtn_Click(object sender, RoutedEventArgs e) =>
+        WindowState = WindowState == WindowState.Maximized
+            ? WindowState.Normal
+            : WindowState.Maximized;
+
+    private void CloseBtn_Click(object sender, RoutedEventArgs e) => Close();
+
+    /// <summary>
+    /// Puts the right one of maximise and restore on the middle caption button.
+    /// </summary>
+    /// <remarks>
+    /// Driven from StateChanged rather than only from the button's own click: double-clicking the
+    /// title bar and Aero Snap both maximise this window without going anywhere near it.
+    /// </remarks>
+    private void RefreshMaximizeButton() =>
+        MaximizeBtn.Content = WindowState == WindowState.Maximized ? "" : "";
+
+    /// <summary>
+    /// How far past its minimum the pointer has to be dragged before letting go puts the rail away.
+    /// </summary>
+    /// <remarks>
+    /// A width the rail is never actually shown at — it stops at <see cref="RailMinWidth"/> and
+    /// stays there while the pointer keeps going. That overshoot is the whole gesture: putting the
+    /// rail away has to be something the user asks for, not somewhere a drag can accidentally stop.
+    /// </remarks>
+    private const double RailCollapseThreshold = 120;
+
+    /// <summary>The narrowest the rail is ever shown at — enough for an icon and a short label.</summary>
+    private const double RailMinWidth = 200;
+
+    private static readonly Duration RailDuration = new(TimeSpan.FromMilliseconds(320));
+
+    /// <summary>
+    /// The rail column's width, as something that can be animated.
+    /// </summary>
+    /// <remarks>
+    /// GridLength is not a double and WPF ships no animation for it, so a column driven directly
+    /// can only jump. Animating a plain double here and writing the column from it is what lets the
+    /// rail settle into place instead.
+    /// </remarks>
+    private static readonly DependencyProperty RailWidthProperty = DependencyProperty.Register(
+        "RailWidth", typeof(double), typeof(ShellWindow),
+        new PropertyMetadata(0.0, (d, e) => ((ShellWindow)d).ApplyRailWidth((double)e.NewValue)));
+
+    /// <summary>
+    /// The rail's width as the splitter has just set it.
+    /// </summary>
+    /// <remarks>
+    /// Not ActualWidth: the splitter writes the column's own Width, and a drag that has just ended
+    /// is read before the layout pass that would make ActualWidth agree — so the snap would decide
+    /// on the width the rail had one drag ago.
+    /// </remarks>
+    private double CurrentRailWidth => SidebarColumn.Width.IsAbsolute
+        ? SidebarColumn.Width.Value
+        : SidebarColumn.ActualWidth;
+
+    private void ApplyRailWidth(double width)
+    {
+        SidebarColumn.Width = new GridLength(Math.Max(0, width));
+
+        // Only once there is nothing left to draw. The rail is clipped to its column, so the
+        // collapse reads as the card being wiped off the edge rather than as it shrinking — and a
+        // panel left visible at zero width would still take a hit test in the page's first pixel.
+        RailPanel.Visibility = width < 1
+            ? Visibility.Collapsed
+            : Visibility.Visible;
+    }
+
+    /// <summary>Puts the rail at <paramref name="width"/> at once, for a layout being restored.</summary>
+    private void SetRailWidth(double width)
+    {
+        BeginAnimation(RailWidthProperty, null);
+        ApplyRailWidth(width);
+    }
+
+    private void AnimateRailTo(double width)
+    {
+        var from = CurrentRailWidth;
+        if (Math.Abs(from - width) < 0.5)
+        {
+            SetRailWidth(width);
+            return;
+        }
+
+        // Critically damped — eased out with no overshoot. The rail is a panel being put somewhere,
+        // not something thrown, and a bounce here would read as the drag having missed.
+        BeginAnimation(RailWidthProperty, new DoubleAnimation
+        {
+            From = from,
+            To = width,
+            Duration = RailDuration,
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+        });
+    }
+
+    /// <summary>Set while a drag is being held past the point where letting go collapses the rail.</summary>
+    private bool _railDraggedPastCollapse;
+
+    /// <summary>
+    /// Holds the rail between its own bounds for the length of the drag, and dims it once the
+    /// pointer has gone far enough that letting go would put it away.
+    /// </summary>
+    /// <remarks>
+    /// The splitter writes whatever width the pointer asks for, including none at all — the column
+    /// has no MinWidth of its own because the rail has to be able to reach zero. Clamping here is
+    /// what makes the floor and the ceiling real, and the dimming is the only warning the user gets
+    /// before the rail goes.
+    /// </remarks>
+    private void Splitter_DragDelta(object sender, DragDeltaEventArgs e)
+    {
+        var wanted = CurrentRailWidth;
+
+        _railDraggedPastCollapse = wanted < RailCollapseThreshold;
+        RailPanel.Opacity = _railDraggedPastCollapse ? 0.45 : 1;
+
+        ApplyRailWidth(Math.Clamp(wanted, RailMinWidth, SidebarColumn.MaxWidth));
+    }
+
+    /// <summary>
+    /// Settles the rail where the drag left it: away entirely, or no narrower than its labels need.
+    /// </summary>
+    /// <remarks>
+    /// A rail dragged to nothing is the only way this window has of giving the page its whole
+    /// width, so the splitter is left reachable at the page's edge — see the markup — and dragging
+    /// it back out is what brings the rail back.
+    /// </remarks>
+    private void Splitter_DragCompleted(object sender, DragCompletedEventArgs e)
+    {
+        RailPanel.Opacity = 1;
+        AnimateRailTo(_railDraggedPastCollapse
+            ? 0
+            : Math.Clamp(CurrentRailWidth, RailMinWidth, SidebarColumn.MaxWidth));
+        _railDraggedPastCollapse = false;
+    }
+
     private void CaptureBtn_Click(object sender, RoutedEventArgs e)
     {
         // MainWindow owns the whole capture session (hotkey, screenshot, overlay, teardown), so
         // the shell only asks for one and hands itself over to be hidden and brought back.
         if (System.Windows.Application.Current.MainWindow is MainWindow main)
             main.StartCaptureFromShell(this);
+    }
+
+    private void QuickLookupBtn_Click(object sender, RoutedEventArgs e)
+    {
+        // MainWindow owns 取詞翻譯's guards the same way it owns the capture session's, so the shell
+        // asks for the popup rather than summoning one behind them.
+        if (System.Windows.Application.Current.MainWindow is MainWindow main)
+            main.StartQuickLookupFromShell();
     }
 
     public void Navigate(ShellPage page)

--- a/src/OverTranslate/Views/Shell/UpdateWindow.xaml
+++ b/src/OverTranslate/Views/Shell/UpdateWindow.xaml
@@ -7,138 +7,229 @@
         ResizeMode="CanMinimize"
         WindowStartupLocation="CenterScreen"
         ShowInTaskbar="True"
+        WindowStyle="None"
         Closing="Window_Closing"
         Background="{DynamicResource AppWindowBg}">
 
-    <Grid Margin="24,20,24,24">
+    <!-- The same strip the shell draws, for the same reason: this was the last window in the
+         application still wearing the system title bar, which follows the system's theme rather
+         than the application's and so read as a different program's dialog in dark mode.
+
+         ResizeBorderThickness is 0 where the shell has 6 — this window is sized to its own content
+         and has nothing to resize. CaptionHeight still matches the title row below exactly, so the
+         strip drags the window and the buttons on it say they are buttons. -->
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="40"
+                      ResizeBorderThickness="0"
+                      CornerRadius="0"
+                      GlassFrameThickness="0"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
+
+    <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="40"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- 標題區 -->
-        <StackPanel Grid.Row="0" HorizontalAlignment="Center" Margin="0,0,0,16">
-            <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                       FontSize="36" Text="&#xE895;"
-                       HorizontalAlignment="Center"
-                       Foreground="{DynamicResource AppAccent}"/>
-            <TextBlock Text="{DynamicResource S.Update.Heading}"
-                       FontFamily="{StaticResource AppFont}"
-                       FontSize="18"
-                       FontWeight="SemiBold"
-                       Foreground="{DynamicResource AppTextPrimary}"
-                       HorizontalAlignment="Center"
-                       Margin="0,8,0,0"/>
-        </StackPanel>
+        <!-- ══════════ Title bar ══════════ -->
+        <!-- Carries the application's name, not this window's, exactly as the shell's does: the
+             window's own title is already the heading below it, and a strip repeating it would say
+             the same three words twice. Title is still set on the window itself, where the taskbar
+             and Alt+Tab read it from. -->
+        <Grid Grid.Row="0">
+            <StackPanel Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Margin="12,0,0,0">
+                <Image x:Name="TitleIcon"
+                       Width="16" Height="16"
+                       VerticalAlignment="Center"
+                       RenderOptions.BitmapScalingMode="HighQuality"/>
+                <TextBlock Text="OverTranslate"
+                           FontFamily="{StaticResource AppFont}"
+                           FontSize="12"
+                           Margin="8,0,0,0"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource AppTextSecondary}"/>
+            </StackPanel>
 
-        <!-- 版本資訊 -->
-        <Border Grid.Row="1" Style="{StaticResource CardBorder}">
-            <StackPanel>
-                <Grid Margin="0,0,0,4">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="70"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" Text="{DynamicResource S.Update.CurrentVersion}" Style="{StaticResource FieldLabel}"/>
-                    <TextBlock Grid.Column="1" x:Name="CurrentVersionText"
+            <!-- No maximise: this window is sized to its content and there is nothing to fill a
+                 screen with. Close is disabled rather than hidden while the update runs — it says
+                 why in a tooltip, which a missing button could not. The Closing handler still
+                 refuses as well, because Alt+F4 and the taskbar never touch this button. -->
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        WindowChrome.IsHitTestVisibleInChrome="True">
+                <Button x:Name="MinimizeBtn"
+                        Style="{StaticResource WindowCaptionButton}"
+                        Content="&#xE921;"
+                        Click="MinimizeBtn_Click"/>
+                <Button x:Name="CloseBtn"
+                        Style="{StaticResource WindowCloseButton}"
+                        Content="&#xE8BB;"
+                        ToolTipService.ShowOnDisabled="True"
+                        Click="CloseBtn_Click"/>
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="1" Margin="24,4,24,24">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- ══════════ Heading ══════════ -->
+            <StackPanel Grid.Row="0" HorizontalAlignment="Center" Margin="0,0,0,16">
+                <!-- The glyph on a tinted disc rather than loose on the window: at 36pt it was the
+                     largest thing here and the only element with no surface of its own, which read
+                     as decoration that had drifted in. The disc is the rail's update chip's tint,
+                     so the badge that brought the user here and the window it opens are visibly
+                     the same piece of news. -->
+                <Border Width="52" Height="52"
+                        CornerRadius="26"
+                        HorizontalAlignment="Center"
+                        Background="{DynamicResource AppAccentSubtle}">
+                    <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                               FontSize="24" Text="&#xE895;"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource AppAccent}"/>
+                </Border>
+
+                <TextBlock Text="{DynamicResource S.Update.Heading}"
+                           FontFamily="{StaticResource AppFont}"
+                           FontSize="18"
+                           FontWeight="SemiBold"
+                           Foreground="{DynamicResource AppTextPrimary}"
+                           HorizontalAlignment="Center"
+                           Margin="0,10,0,0"/>
+
+                <!-- Both versions on one line, with the arrow doing what two labels used to. The
+                     pair is the whole point — a version number alone answers neither "which one am
+                     I on" nor "is this worth taking" — and reading it as one movement is faster
+                     than reading it as a two-row table. The one the user is being offered carries
+                     the accent; the one they have is secondary text, because it is context. -->
+                <StackPanel Orientation="Horizontal"
+                            HorizontalAlignment="Center"
+                            Margin="0,6,0,0">
+                    <TextBlock x:Name="CurrentVersionText"
                                FontFamily="{StaticResource AppFont}"
                                FontSize="13"
                                Foreground="{DynamicResource AppTextSecondary}"
                                VerticalAlignment="Center"/>
-                </Grid>
-                <Grid Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="70"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Grid.Column="0" Text="{DynamicResource S.Update.LatestVersion}" Style="{StaticResource FieldLabel}"/>
-                    <TextBlock Grid.Column="1" x:Name="LatestVersionText"
+                    <TextBlock Text="→"
+                               FontFamily="{StaticResource AppFont}"
+                               FontSize="13"
+                               Margin="8,0"
+                               Foreground="{DynamicResource AppTextSecondary}"
+                               VerticalAlignment="Center"/>
+                    <TextBlock x:Name="LatestVersionText"
                                FontFamily="{StaticResource AppFont}"
                                FontSize="13"
                                FontWeight="SemiBold"
                                Foreground="{DynamicResource AppAccent}"
                                VerticalAlignment="Center"/>
-                </Grid>
-                <TextBlock Text="{DynamicResource S.Update.Explanation}"
-                           FontFamily="{StaticResource AppFont}"
-                           FontSize="12"
-                           Foreground="{DynamicResource AppTextSecondary}"
-                           TextWrapping="Wrap"/>
-                <ProgressBar x:Name="DownloadProgress"
-                             Style="{StaticResource SlimProgressBar}"
-                             Minimum="0"
-                             Maximum="100"
-                             Value="0"
-                             Margin="0,14,0,0"
-                             Visibility="Collapsed"/>
+                </StackPanel>
+            </StackPanel>
 
-                <!-- Failures are reported here rather than through a system MessageBox, which was
-                     the only OS-styled dialog left in the app and matched nothing around it. -->
-                <TextBlock x:Name="ErrorText"
+            <!-- ══════════ What pressing update does ══════════ -->
+            <Border Grid.Row="1" Style="{StaticResource CardBorder}">
+                <StackPanel>
+                    <TextBlock Text="{DynamicResource S.Update.Explanation}"
+                               FontFamily="{StaticResource AppFont}"
+                               FontSize="12"
+                               Foreground="{DynamicResource AppTextSecondary}"
+                               TextWrapping="Wrap"/>
+
+                    <ProgressBar x:Name="DownloadProgress"
+                                 Style="{StaticResource SlimProgressBar}"
+                                 Minimum="0"
+                                 Maximum="100"
+                                 Value="0"
+                                 Margin="0,14,0,0"
+                                 Visibility="Collapsed"/>
+
+                    <!-- The live readout sits under the bar it belongs to, not on the button. The
+                         button is disabled for the whole download, and disabled text is the lowest
+                         contrast in the window — the one line that changes every few hundred
+                         milliseconds is the last thing to put there. -->
+                    <TextBlock x:Name="StatusText"
+                               FontFamily="{StaticResource AppFont}"
+                               FontSize="12"
+                               Foreground="{DynamicResource AppTextSecondary}"
+                               Margin="0,8,0,0"
+                               Visibility="Collapsed"/>
+
+                    <!-- Failures are reported here rather than through a system MessageBox, which was
+                         the only OS-styled dialog left in the app and matched nothing around it. -->
+                    <TextBlock x:Name="ErrorText"
+                               FontFamily="{StaticResource AppFont}"
+                               FontSize="12"
+                               Foreground="{DynamicResource AppError}"
+                               TextWrapping="Wrap"
+                               Visibility="Collapsed"
+                               Margin="0,12,0,0"/>
+
+                    <TextBlock FontFamily="{StaticResource AppFont}"
+                               FontSize="12"
+                               Margin="0,8,0,0"
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource AppTextSecondary}">
+                        <Run Text="{DynamicResource S.Update.NotesBefore}"/><Hyperlink x:Name="ReleaseNotesLink"
+                                  Foreground="{DynamicResource AppAccent}"
+                                  TextDecorations="None"
+                                  RequestNavigate="ReleaseNotesLink_RequestNavigate"
+                                  NavigateUri="https://github.com/asd880921/OverTranslate/releases/latest"><Run Text="{DynamicResource S.Update.NotesLink}"/></Hyperlink>
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+
+            <!-- ══════════ Answers ══════════ -->
+            <StackPanel Grid.Row="2" Margin="0,12,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="8"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="DismissBtn" Grid.Column="0" Content="{DynamicResource S.Update.Later}"
+                            Style="{StaticResource FlatButton}"
+                            Height="36"
+                            Click="DismissBtn_Click"/>
+                    <Button x:Name="DownloadBtn" Grid.Column="2"
+                            Style="{StaticResource AccentButton}"
+                            Height="36"
+                            Click="DownloadBtn_Click">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                       FontSize="13" Text="&#xE896;"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,6,0"/>
+                            <TextBlock x:Name="DownloadBtnText" Text="{DynamicResource S.Update.Now}"
+                                       FontFamily="{StaticResource AppFont}"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                </Grid>
+
+                <!-- Below the pair rather than beside it, and unstyled as a link rather than a third
+                     button: Later and Update now are the two answers to the question being asked, while
+                     this one changes what the application does in future. Giving it equal weight in the
+                     row would put a lasting choice one mis-click away from the dismiss button it would
+                     sit next to. -->
+                <TextBlock HorizontalAlignment="Center"
+                           Margin="0,10,0,0"
                            FontFamily="{StaticResource AppFont}"
                            FontSize="12"
-                           Foreground="{DynamicResource AppError}"
-                           TextWrapping="Wrap"
-                           Visibility="Collapsed"
-                           Margin="0,12,0,0"/>
-                <TextBlock FontFamily="{StaticResource AppFont}"
-                           FontSize="12"
-                           Margin="0,8,0,0"
-                           TextWrapping="Wrap"
                            Foreground="{DynamicResource AppTextSecondary}">
-                    <Run Text="{DynamicResource S.Update.NotesBefore}"/><Hyperlink x:Name="ReleaseNotesLink"
-                              Foreground="{DynamicResource AppAccent}"
-                              TextDecorations="None"
-                              RequestNavigate="ReleaseNotesLink_RequestNavigate"
-                              NavigateUri="https://github.com/asd880921/OverTranslate/releases/latest"><Run Text="{DynamicResource S.Update.NotesLink}"/></Hyperlink>
+                    <Hyperlink x:Name="SkipVersionLink"
+                               Foreground="{DynamicResource AppTextSecondary}"
+                               TextDecorations="None"
+                               Click="SkipVersionLink_Click"><Run Text="{DynamicResource S.Update.Skip}"/></Hyperlink>
                 </TextBlock>
             </StackPanel>
-        </Border>
-
-        <!-- 按鈕列 -->
-        <StackPanel Grid.Row="2" Margin="0,12,0,0">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="8"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <Button x:Name="DismissBtn" Grid.Column="0" Content="{DynamicResource S.Update.Later}"
-                        Style="{StaticResource FlatButton}"
-                        Height="36"
-                        Click="DismissBtn_Click"/>
-                <Button x:Name="DownloadBtn" Grid.Column="2"
-                        Style="{StaticResource AccentButton}"
-                        Height="36"
-                        Click="DownloadBtn_Click">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                   FontSize="13" Text="&#xE896;"
-                                   VerticalAlignment="Center"
-                                   Margin="0,0,6,0"/>
-                        <TextBlock x:Name="DownloadBtnText" Text="{DynamicResource S.Update.Now}"
-                                   FontFamily="{StaticResource AppFont}"
-                                   VerticalAlignment="Center"/>
-                    </StackPanel>
-                </Button>
-            </Grid>
-
-            <!-- Below the pair rather than beside it, and unstyled as a link rather than a third
-                 button: Later and Update now are the two answers to the question being asked, while
-                 this one changes what the application does in future. Giving it equal weight in the
-                 row would put a lasting choice one mis-click away from the dismiss button it would
-                 sit next to. -->
-            <TextBlock HorizontalAlignment="Center"
-                       Margin="0,10,0,0"
-                       FontFamily="{StaticResource AppFont}"
-                       FontSize="12"
-                       Foreground="{DynamicResource AppTextSecondary}">
-                <Hyperlink x:Name="SkipVersionLink"
-                           Foreground="{DynamicResource AppTextSecondary}"
-                           TextDecorations="None"
-                           Click="SkipVersionLink_Click"><Run Text="{DynamicResource S.Update.Skip}"/></Hyperlink>
-            </TextBlock>
-        </StackPanel>
+        </Grid>
     </Grid>
 </Window>

--- a/src/OverTranslate/Views/Shell/UpdateWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/UpdateWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Documents;
 using System.Windows.Media.Animation;
 using System.Windows.Navigation;
 using System.Windows.Threading;
@@ -42,40 +43,127 @@ public partial class UpdateWindow : Window
         InitializeComponent();
         _updateInfo = info;
 
+        var icon = AppIconService.CreateWindowIcon();
+        Icon = icon;
+        TitleIcon.Source = icon;
+
+        // "v" on both, matching the rail's version line and its update chip — the number is the
+        // same number, and dropping the prefix here would make it look like a different notation.
         var current = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
-        CurrentVersionText.Text = current;
-        LatestVersionText.Text  = info.LatestVersion;
+        CurrentVersionText.Text = $"v{current}";
+        LatestVersionText.Text  = $"v{info.LatestVersion}";
+
+        // The system title bar is gone, so what it used to do for itself is done here: the rounded
+        // corner and the outer edge, in the application's own border colour rather than the
+        // system's. The edge is the compositor's, so it has to be handed over again on a theme
+        // change — a DynamicResource never reaches it.
+        WindowFrame.Attach(this);
+        ThemeService.Changed += OnThemeChanged;
+        Closed += (_, _) => ThemeService.Changed -= OnThemeChanged;
     }
+
+    private void OnThemeChanged(object? sender, EventArgs e) => WindowFrame.ApplyAppearance(this);
 
     private async void DownloadBtn_Click(object sender, RoutedEventArgs e)
     {
         try
         {
-            _isUpdating = true;
-            DismissBtn.IsEnabled = false;
-            DownloadBtn.IsEnabled = false;
-            SkipVersionLink.IsEnabled = false;
+            SetUpdating(true);
             ErrorText.Visibility = Visibility.Collapsed;
-            DownloadBtnText.Text = LocalizationService.Format("S.Update.Downloading", 0);
             DownloadProgress.IsIndeterminate = false;
             DownloadProgress.Value = 0;
             DownloadProgress.Visibility = Visibility.Visible;
+            SetDownloadStatus(0);
 
             await UpdateService.DownloadAndApplyAsync(_updateInfo, OnDownloadProgress, OnApplyingAsync);
         }
         catch (Exception ex)
         {
-            _isUpdating = false;
-            DismissBtn.IsEnabled = true;
-            DownloadBtn.IsEnabled = true;
-            SkipVersionLink.IsEnabled = true;
+            SetUpdating(false);
+            // The button is the way to try again, so it says so — this is the one thing about it
+            // that changes, now that the progress no longer lives on its label.
             DownloadBtnText.Text = LocalizationService.Get("S.Update.Retry");
             DownloadProgress.BeginAnimation(System.Windows.Controls.ProgressBar.ValueProperty, null);
             DownloadProgress.IsIndeterminate = false;
             DownloadProgress.Visibility = Visibility.Collapsed;
+            SetStatus(null);
             ErrorText.Text = LocalizationService.Format("S.Update.Failed", ex.Message);
             ErrorText.Visibility = Visibility.Visible;
         }
+    }
+
+    /// <summary>
+    /// Switches the window between offering the update and running it.
+    /// </summary>
+    /// <remarks>
+    /// Every way out of this window goes dead together, the title bar's close included: Velopack
+    /// replaces the application's own files and then restarts the process, and a download abandoned
+    /// half way through is the one state this has no way to clean up after. The close button says
+    /// why rather than simply refusing — SetResourceReference rather than a fetched string, so the
+    /// reason follows a language changed in 設定 while this window is still on screen.
+    /// </remarks>
+    private void SetUpdating(bool updating)
+    {
+        _isUpdating = updating;
+
+        DismissBtn.IsEnabled = !updating;
+        DownloadBtn.IsEnabled = !updating;
+        SkipVersionLink.IsEnabled = !updating;
+        CloseBtn.IsEnabled = !updating;
+
+        if (updating) CloseBtn.SetResourceReference(ToolTipProperty, "S.Update.CloseBlocked");
+        else CloseBtn.ToolTip = null;
+    }
+
+    /// <summary>Puts a line under the progress bar, or takes it away.</summary>
+    private void SetStatus(string? text)
+    {
+        StatusText.Inlines.Clear();
+        if (text is not null) StatusText.Inlines.Add(new Run(text));
+        StatusText.Visibility = text is null ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    /// <summary>
+    /// The download's own line: the same sentence, with the figure in the accent colour.
+    /// </summary>
+    /// <remarks>
+    /// The number is the only part of this line that carries information — the words around it say
+    /// the same thing for the whole download — so it is the part that is coloured, and it is
+    /// coloured in the same accent as the progress bar directly above it, which is what it is a
+    /// readout of. The unit travels with the figure: "45" and "%" are one number, and splitting
+    /// them across two colours would read as two.
+    ///
+    /// Built out of runs rather than formatted into one string, so the placeholder can be found and
+    /// what surrounds it left in whatever order the language puts it. The percent sign is inside
+    /// the placeholder rather than in the resource for the same reason — a language that writes
+    /// "%45" keeps it attached to the figure without the resource having to say so twice.
+    ///
+    /// SetResourceReference rather than a resolved brush: this line is on screen for the whole
+    /// download, which is long enough for the theme to be switched underneath it.
+    /// </remarks>
+    private void SetDownloadStatus(int percent)
+    {
+        var template = LocalizationService.Get("S.Update.Downloading");
+        var at = template.IndexOf("{0}", StringComparison.Ordinal);
+
+        StatusText.Inlines.Clear();
+
+        if (at < 0)
+        {
+            // A translation that dropped the placeholder still has to show the number.
+            StatusText.Inlines.Add(new Run(LocalizationService.Format("S.Update.Downloading", percent)));
+        }
+        else
+        {
+            var figure = new Run($"{percent}%") { FontWeight = FontWeights.SemiBold };
+            figure.SetResourceReference(TextElement.ForegroundProperty, "AppAccent");
+
+            if (at > 0) StatusText.Inlines.Add(new Run(template[..at]));
+            StatusText.Inlines.Add(figure);
+            if (at + 3 < template.Length) StatusText.Inlines.Add(new Run(template[(at + 3)..]));
+        }
+
+        StatusText.Visibility = Visibility.Visible;
     }
 
     private void OnDownloadProgress(int percent)
@@ -83,7 +171,7 @@ public partial class UpdateWindow : Window
         Dispatcher.Invoke(() =>
         {
             DownloadProgress.Value = percent;
-            DownloadBtnText.Text = LocalizationService.Format("S.Update.Downloading", percent);
+            SetDownloadStatus(percent);
         });
     }
 
@@ -98,7 +186,7 @@ public partial class UpdateWindow : Window
         // The apply step exposes no progress at all, so an indeterminate bar is the honest signal:
         // still working, duration unknown. It keeps moving, which a bar frozen at 100% would not.
         DownloadProgress.IsIndeterminate = true;
-        DownloadBtnText.Text = LocalizationService.Get("S.Update.Applying");
+        SetStatus(LocalizationService.Get("S.Update.Applying"));
 
         // Let those two land on screen: ApplyUpdatesAndRestart blocks this thread and then kills the
         // process, so anything not painted by now is never painted at all.
@@ -109,7 +197,7 @@ public partial class UpdateWindow : Window
     {
         var completed = new TaskCompletionSource();
 
-        DownloadBtnText.Text = LocalizationService.Format("S.Update.Downloading", 100);
+        SetDownloadStatus(100);
         var toFull = new DoubleAnimation(100, TimeSpan.FromMilliseconds(280))
         {
             EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
@@ -126,12 +214,23 @@ public partial class UpdateWindow : Window
         return completed.Task;
     }
 
+    /// <summary>
+    /// Refuses to close while the update is running.
+    /// </summary>
+    /// <remarks>
+    /// The title bar's own close button is disabled for the same stretch, so this is what catches
+    /// Alt+F4, the taskbar's close and anything else that never goes near a button of ours.
+    /// </remarks>
     private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
     {
-        // 更新進行中禁止關閉視窗（含標題列的 X），避免中斷下載或對已關閉視窗更新進度。
         if (_isUpdating)
             e.Cancel = true;
     }
+
+    private void MinimizeBtn_Click(object sender, RoutedEventArgs e) =>
+        WindowState = WindowState.Minimized;
+
+    private void CloseBtn_Click(object sender, RoutedEventArgs e) => Close();
 
     private void DismissBtn_Click(object sender, RoutedEventArgs e) => Close();
 

--- a/src/OverTranslate/Views/Shell/WindowFrame.cs
+++ b/src/OverTranslate/Views/Shell/WindowFrame.cs
@@ -26,6 +26,9 @@ internal static class WindowFrame
     private const int WM_GETMINMAXINFO = 0x0024;
     private const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
 
+    private const int GWL_STYLE = -16;
+    private const int WS_CAPTION = 0x00C00000;
+
     private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
     private const int DWMWA_BORDER_COLOR = 34;
     private const int DWMWCP_ROUND = 2;
@@ -39,6 +42,7 @@ internal static class WindowFrame
         if (PresentationSource.FromVisual(window) is HwndSource existing)
         {
             existing.AddHook(HookFor(window));
+            RestoreSystemAnimations(existing.Handle);
             ApplyAppearance(window);
             return;
         }
@@ -48,7 +52,11 @@ internal static class WindowFrame
         void OnSourceInitialized(object? sender, EventArgs e)
         {
             window.SourceInitialized -= OnSourceInitialized;
-            if (PresentationSource.FromVisual(window) is HwndSource source) source.AddHook(HookFor(window));
+            if (PresentationSource.FromVisual(window) is HwndSource source)
+            {
+                source.AddHook(HookFor(window));
+                RestoreSystemAnimations(source.Handle);
+            }
             ApplyAppearance(window);
         }
     }
@@ -80,6 +88,35 @@ internal static class WindowFrame
         // system default colour instead of the one named here.
         var colorRef = border.Color.R | (border.Color.G << 8) | (border.Color.B << 16);
         DwmSetWindowAttribute(hwnd, DWMWA_BORDER_COLOR, ref colorRef, sizeof(int));
+    }
+
+    /// <summary>
+    /// Gives the window back the maximise, restore and minimise animations the system plays for
+    /// every other window.
+    /// </summary>
+    /// <remarks>
+    /// Those animations are DWM's, and DWM plays them only for a window whose style says it has a
+    /// caption. WindowStyle="None" takes WS_CAPTION off, which is why this window used to snap
+    /// between normal and maximised in a single frame while every other window on the desktop
+    /// eased — the application looked like it had drawn the new size rather than moved to it.
+    ///
+    /// Putting the bit back does not put a caption back: WindowChrome answers WM_NCCALCSIZE by
+    /// giving the client area the whole window, so there is no non-client strip left for the system
+    /// to draw one in. The bit is read by DWM for the animation and by the shell for Snap Layouts;
+    /// nothing draws from it.
+    ///
+    /// WS_CAPTION only, and never WS_THICKFRAME: that one is what makes a window resizable, and
+    /// 更新視窗 is deliberately not. Whether a window can be resized stays WPF's decision, taken
+    /// from ResizeMode.
+    /// </remarks>
+    private static void RestoreSystemAnimations(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero) return;
+
+        var style = GetWindowLong(hwnd, GWL_STYLE);
+        if (style == 0 || (style & WS_CAPTION) == WS_CAPTION) return;
+
+        SetWindowLong(hwnd, GWL_STYLE, style | WS_CAPTION);
     }
 
     private static HwndSourceHook HookFor(Window window) =>
@@ -161,6 +198,12 @@ internal static class WindowFrame
 
     [DllImport("user32.dll")]
     private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint flags);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW")]
+    private static extern int GetWindowLong(IntPtr hwnd, int index);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongW")]
+    private static extern int SetWindowLong(IntPtr hwnd, int index, int value);
 
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/OverTranslate/Views/Shell/WindowFrame.cs
+++ b/src/OverTranslate/Views/Shell/WindowFrame.cs
@@ -1,0 +1,171 @@
+﻿using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+
+namespace OverTranslate.Views.Shell;
+
+/// <summary>
+/// The parts of the system window frame a shell window still needs once it draws its own title bar:
+/// the maximised size, and the outer edge the desktop compositor draws around it.
+/// </summary>
+/// <remarks>
+/// Windows maximises such a window to the monitor's full size plus its own resize border, on the
+/// assumption that the border is non-client and therefore off-screen. Under WindowChrome it is not
+/// — it is the application's own content — so the window's edges, and part of the caption buttons
+/// with them, end up past the screen, and the taskbar is covered.
+///
+/// WM_GETMINMAXINFO is where that size is decided, so it is the one place to answer it: the work
+/// area of the monitor the window is on, in physical pixels, which is exactly what the message asks
+/// for. Insetting the content by a guessed number of device-independent units instead would be
+/// wrong at every scale factor other than 100%, and wrong again on a second monitor whose taskbar
+/// is somewhere else.
+/// </remarks>
+internal static class WindowFrame
+{
+    private const int WM_GETMINMAXINFO = 0x0024;
+    private const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
+
+    private const int DWMWA_WINDOW_CORNER_PREFERENCE = 33;
+    private const int DWMWA_BORDER_COLOR = 34;
+    private const int DWMWCP_ROUND = 2;
+
+    /// <summary>
+    /// Takes the frame over for as long as <paramref name="window"/> lives. Safe to call before the
+    /// window has a handle — everything that needs one waits for it.
+    /// </summary>
+    public static void Attach(Window window)
+    {
+        if (PresentationSource.FromVisual(window) is HwndSource existing)
+        {
+            existing.AddHook(HookFor(window));
+            ApplyAppearance(window);
+            return;
+        }
+
+        window.SourceInitialized += OnSourceInitialized;
+
+        void OnSourceInitialized(object? sender, EventArgs e)
+        {
+            window.SourceInitialized -= OnSourceInitialized;
+            if (PresentationSource.FromVisual(window) is HwndSource source) source.AddHook(HookFor(window));
+            ApplyAppearance(window);
+        }
+    }
+
+    /// <summary>
+    /// Rounds the window's corners and paints its outer edge in the application's own border
+    /// colour. Call again when the theme changes — the edge is drawn by the compositor, so a
+    /// DynamicResource never reaches it.
+    /// </summary>
+    /// <remarks>
+    /// The compositor draws this frame, rather than the window drawing a rounded border of its own
+    /// the way 取詞翻譯 does. That popup can afford AllowsTransparency because it is a small,
+    /// fixed-size card; here it would make the whole window a layered surface, which costs
+    /// ClearType on every glyph in the application and hardware acceleration with it — a bad trade
+    /// for a window that is mostly text. Asking DWM for the same shape keeps the text sharp, and
+    /// keeps the corners the ones the rest of Windows 11 draws.
+    /// </remarks>
+    public static void ApplyAppearance(Window window)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero) return;
+
+        var round = DWMWCP_ROUND;
+        DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref round, sizeof(int));
+
+        if (window.TryFindResource("AppBorder") is not SolidColorBrush border) return;
+
+        // COLORREF: 0x00BBGGRR, and the alpha byte is not an alpha — a non-zero one asks for the
+        // system default colour instead of the one named here.
+        var colorRef = border.Color.R | (border.Color.G << 8) | (border.Color.B << 16);
+        DwmSetWindowAttribute(hwnd, DWMWA_BORDER_COLOR, ref colorRef, sizeof(int));
+    }
+
+    private static HwndSourceHook HookFor(Window window) =>
+        (IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled) =>
+            Hook(window, hwnd, msg, lParam, ref handled);
+
+    private static IntPtr Hook(Window window, IntPtr hwnd, int msg, IntPtr lParam, ref bool handled)
+    {
+        if (msg != WM_GETMINMAXINFO) return IntPtr.Zero;
+
+        var monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        if (monitor == IntPtr.Zero) return IntPtr.Zero;
+
+        var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+        if (!GetMonitorInfo(monitor, ref info)) return IntPtr.Zero;
+
+        var mmi = Marshal.PtrToStructure<MINMAXINFO>(lParam);
+
+        // Relative to the monitor's own origin, which is what the message is expressed in — the
+        // work area's absolute coordinates would place the window off a secondary monitor.
+        mmi.ptMaxPosition.x = info.rcWork.left - info.rcMonitor.left;
+        mmi.ptMaxPosition.y = info.rcWork.top - info.rcMonitor.top;
+        mmi.ptMaxSize.x = info.rcWork.right - info.rcWork.left;
+        mmi.ptMaxSize.y = info.rcWork.bottom - info.rcWork.top;
+
+        // Without this a maximised window cannot be dragged wider than the monitor it started on,
+        // which is what the tracking size, not the maximised size, is for.
+        mmi.ptMaxTrackSize.x = Math.Max(mmi.ptMaxTrackSize.x, mmi.ptMaxSize.x);
+        mmi.ptMaxTrackSize.y = Math.Max(mmi.ptMaxTrackSize.y, mmi.ptMaxSize.y);
+
+        // This message is also where WPF enforces MinWidth and MinHeight, and answering it takes
+        // that away — a window with no floor can be dragged down to a title bar with nothing under
+        // it. Same numbers, in the physical pixels this message is expressed in.
+        var dpi = VisualTreeHelper.GetDpi(window);
+        if (window.MinWidth > 0 && !double.IsInfinity(window.MinWidth))
+            mmi.ptMinTrackSize.x = (int)Math.Ceiling(window.MinWidth * dpi.DpiScaleX);
+        if (window.MinHeight > 0 && !double.IsInfinity(window.MinHeight))
+            mmi.ptMinTrackSize.y = (int)Math.Ceiling(window.MinHeight * dpi.DpiScaleY);
+
+        Marshal.StructureToPtr(mmi, lParam, true);
+        handled = true;
+        return IntPtr.Zero;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int x;
+        public int y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MINMAXINFO
+    {
+        public POINT ptReserved;
+        public POINT ptMaxSize;
+        public POINT ptMaxPosition;
+        public POINT ptMinTrackSize;
+        public POINT ptMaxTrackSize;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int left;
+        public int top;
+        public int right;
+        public int bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MONITORINFO
+    {
+        public int cbSize;
+        public RECT rcMonitor;
+        public RECT rcWork;
+        public uint dwFlags;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint flags);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetMonitorInfo(IntPtr monitor, ref MONITORINFO info);
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+}

--- a/tests/OverTranslate.Tests/ShellWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/ShellWindowMarkupTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Xml.Linq;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The facts about the shell's nav rail markup that read like decoration and are not.
+/// </summary>
+/// <inheritdoc cref="TranslationPageMarkupTests"/>
+public class ShellWindowMarkupTests
+{
+    private static readonly XNamespace X = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    private static XDocument Window() => XDocument.Load(Path.Combine(
+        StringsParityTests.ProjectDirectory(), "Views", "Shell", "ShellWindow.xaml"));
+
+    private static XElement Row(string name) => Window()
+        .Descendants()
+        .Single(e => (string?)e.Attribute(X + "Name") == name);
+
+    /// <summary>
+    /// Both 快速工具 rows are switched off for the length of a realtime session, and their tooltips
+    /// are then the only place that reason exists — the rail has no room for a note beside them.
+    /// WPF withholds tooltips from disabled controls unless asked.
+    /// </summary>
+    [Theory]
+    [InlineData("CaptureBtn")]
+    [InlineData("QuickLookupBtn")]
+    public void A_quick_tool_still_explains_itself_while_disabled(string name)
+    {
+        Assert.Equal("True", (string?)Row(name).Attribute("ToolTipService.ShowOnDisabled"));
+    }
+
+    /// <summary>
+    /// The shortcut is docked before the label, so the label is what trims when the rail is dragged
+    /// to its minimum width. A shortcut trimmed to "Ctrl+Al..." names no key the user can press.
+    /// </summary>
+    [Theory]
+    [InlineData("CaptureBtn", "CaptureHotkeyText")]
+    [InlineData("QuickLookupBtn", "QuickLookupHotkeyText")]
+    public void A_quick_tool_trims_its_name_rather_than_its_shortcut(string row, string hotkey)
+    {
+        var children = Row(row).Elements().Single().Elements().ToList();
+
+        var shortcutAt = children.FindIndex(e => (string?)e.Attribute(X + "Name") == hotkey);
+        var labelAt = children.FindIndex(e => (string?)e.Attribute("TextTrimming") is not null);
+
+        Assert.True(shortcutAt >= 0 && labelAt > shortcutAt);
+    }
+
+    /// <summary>
+    /// The drag area and the strip the user sees have to be the same strip: WindowChrome's caption
+    /// height is what makes the title bar draggable, and it knows nothing about the row the markup
+    /// draws there.
+    /// </summary>
+    [Fact]
+    public void The_draggable_caption_covers_exactly_the_title_row()
+    {
+        var doc = Window();
+
+        var chrome = doc.Descendants().Single(e => e.Name.LocalName == "WindowChrome");
+        var titleRow = doc.Descendants()
+            .First(e => e.Name.LocalName == "RowDefinition");
+
+        Assert.Equal((string?)titleRow.Attribute("Height"), (string?)chrome.Attribute("CaptionHeight"));
+    }
+
+    /// <summary>
+    /// Everything inside the caption strip is drag surface unless it says otherwise, so without
+    /// this the window's own buttons would move the window instead of pressing.
+    /// </summary>
+    [Fact]
+    public void The_caption_buttons_are_clickable_rather_than_drag_surface()
+    {
+        var buttons = Row("MinimizeBtn").Parent!;
+
+        Assert.Equal("True", (string?)buttons.Attribute(
+            XNamespace.Get("http://schemas.microsoft.com/winfx/2006/xaml/presentation") + "IsHitTestVisibleInChrome")
+            ?? (string?)buttons.Attribute("WindowChrome.IsHitTestVisibleInChrome"));
+    }
+
+    /// <summary>
+    /// The rail can be dragged away entirely, and the splitter is the only way back. In the rail's
+    /// own column it would sit at x=0 and reach off the window, so a collapsed rail could never be
+    /// brought back.
+    /// </summary>
+    [Fact]
+    public void The_splitter_stays_reachable_with_the_rail_collapsed()
+    {
+        var splitter = Row("SidebarSplitter");
+
+        Assert.Equal("1", (string?)splitter.Attribute("Grid.Column"));
+        Assert.Equal("Left", (string?)splitter.Attribute("HorizontalAlignment"));
+    }
+}

--- a/tests/OverTranslate.Tests/ShellWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/ShellWindowMarkupTests.cs
@@ -32,8 +32,8 @@ public class ShellWindowMarkupTests
     }
 
     /// <summary>
-    /// The shortcut is docked before the label, so the label is what trims when the rail is dragged
-    /// to its minimum width. A shortcut trimmed to "Ctrl+Al..." names no key the user can press.
+    /// The shortcut is docked before the label, so the label is what trims when a row's two halves
+    /// do not both fit. A shortcut trimmed to "Ctrl+Al..." names no key the user can press.
     /// </summary>
     [Theory]
     [InlineData("CaptureBtn", "CaptureHotkeyText")]
@@ -80,16 +80,39 @@ public class ShellWindowMarkupTests
     }
 
     /// <summary>
-    /// The rail can be dragged away entirely, and the splitter is the only way back. In the rail's
-    /// own column it would sit at x=0 and reach off the window, so a collapsed rail could never be
-    /// brought back.
+    /// The rail can be put away entirely, and this button is the only way back — so it has to live
+    /// outside the rail. Anywhere inside it would go away with it and strand a collapsed rail.
     /// </summary>
     [Fact]
-    public void The_splitter_stays_reachable_with_the_rail_collapsed()
+    public void The_rail_toggle_lives_outside_the_rail()
     {
-        var splitter = Row("SidebarSplitter");
+        var ancestors = Row("SidebarToggleBtn").Ancestors()
+            .Select(e => (string?)e.Attribute(X + "Name"));
 
-        Assert.Equal("1", (string?)splitter.Attribute("Grid.Column"));
-        Assert.Equal("Left", (string?)splitter.Attribute("HorizontalAlignment"));
+        Assert.DoesNotContain("RailPanel", ancestors);
+    }
+
+    /// <summary>
+    /// The toggle sits in the caption strip, which is drag surface unless a control says otherwise
+    /// — without this it would move the window instead of putting the rail away.
+    /// </summary>
+    [Fact]
+    public void The_rail_toggle_is_clickable_rather_than_drag_surface()
+    {
+        var toggle = Row("SidebarToggleBtn");
+
+        Assert.Equal("True", (string?)toggle.Attribute(
+            XNamespace.Get("http://schemas.microsoft.com/winfx/2006/xaml/presentation") + "IsHitTestVisibleInChrome")
+            ?? (string?)toggle.Attribute("WindowChrome.IsHitTestVisibleInChrome"));
+    }
+
+    /// <summary>
+    /// The rail is put away by animating its column to 0, and a column with a MinWidth can never be
+    /// taken there — not even from code.
+    /// </summary>
+    [Fact]
+    public void The_rail_column_can_be_taken_to_nothing()
+    {
+        Assert.Equal("0", (string?)Row("SidebarColumn").Attribute("MinWidth"));
     }
 }


### PR DESCRIPTION
主視窗改版：卡片式版面、自繪標題列、可收合側欄，並把最後一個系統標題列的視窗一併換掉。

## 主視窗

- 版面改為卡片式，標題列改為自繪（`WindowChrome`），側欄與內容區各自成卡。
- 側欄改由標題列最左的按鈕展開／收起，**移除原本的拖曳調寬**。寬度固定 248，收起時動畫到 0 由內容區接收整個寬度；動畫途中再次按下會從畫面上的當前寬度反向，不會等它跑完。開關刻意放在側欄之外，否則收起後就沒有路回來。
- 收起與否記在同一次執行期間，重開視窗會回到離開時的樣子。
- 最小尺寸由 840×520 提高到 960×640。840 其實已經在裁切東西：文字翻譯的四個選單是固定寬（162+32+162+180，含間距 554），扣掉側欄與各層邊距後需要 908 才放得下。
- 快速工具新增「取詞翻譯」。

## 更新視窗

- 全 app 最後一個還用系統原生標題列的視窗，改為與主視窗同一條自繪標題列（圓角、外框顏色、換主題重新套用都走 `WindowFrame`）。
- 更新進行中時標題列的關閉鈕停用並以 tooltip 說明原因，`Closing` 的攔截保留，負責擋 Alt+F4 與工作列關閉。
- 版本資訊由「目前版本／最新版本」兩列標籤，改為標題下方一行 `v1.2.3 → v1.2.5`；圖示移到強調色圓底上，與側欄更新膠囊同一個色票。
- 下載百分比從按鈕標籤移到進度條下方的狀態列，數字與 `%` 帶強調色；按鈕標籤只在失敗時改為「重試」。
- 重複的啟用／停用整理成 `SetUpdating`，狀態列走 `SetStatus` / `SetDownloadStatus`。

## 視窗動畫

- 自繪標題列的視窗補回 `WS_CAPTION`，恢復最大化／還原／最小化的系統動畫。這個緩動是 DWM 播的，而 DWM 只認樣式上有標題列的視窗，`WindowStyle="None"` 把它拿掉了才會整格跳過去。補回這個位不會長出標題列，因為 `WindowChrome` 已經把整個視窗劃給 client area。只補 `WS_CAPTION`、不碰 `WS_THICKFRAME`，能否調整大小仍由 `ResizeMode` 決定。

## 測試

- `ShellWindowMarkupTests` 更新：原本斷言拖曳把手位置的測試，換成「開關必須在側欄之外」「開關必須可點擊而非拖曳面」「側欄欄位 MinWidth 必須為 0」三條。
- 542 個測試通過（540 通過 / 2 略過）。
- 視窗動畫、更新視窗版面、側欄收合動畫為人工檢查；真實下載流程未在此驗證，需走 staging 倉的發版演練。
