### PR TITLE
fix: #116 改用 D3D11 同步 readback，修正 Windows 10 擷取第一張 frame 就死鎖

### DIFF
--- a/src/OverTranslate/Services/Realtime/Capture/WgcInterop.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcInterop.cs
@@ -2,22 +2,19 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Windows.Graphics.Capture;
 using Windows.Graphics.DirectX.Direct3D11;
-using Windows.Graphics.Imaging;
 
 namespace OverTranslate.Services.Realtime.Capture;
 
 /// <summary>
 /// The COM plumbing between WPF and Windows.Graphics.Capture: the two things the projection cannot
-/// give on its own — a capture item for an HWND, and a Direct3D device to receive frames on — plus
-/// the readback that turns a captured surface into the <see cref="System.Drawing.Bitmap"/> the rest
-/// of this application already speaks.
+/// give on its own — a capture item for an HWND, and a Direct3D device to receive frames on. Turning
+/// the frames themselves into bitmaps is <see cref="WgcSurfaceReader"/>'s.
 /// </summary>
 /// <remarks>
 /// Hand-written rather than pulled in with a D3D wrapper library. What is needed here is narrow —
 /// create a device, hold it, hand it to the frame pool, never draw anything — and the surface a
 /// wrapper would add is much wider than that, on a project whose whole dependency list is five
-/// packages. The one thing worth borrowing from D3D, a GPU-side crop, is deliberately not done yet:
-/// correctness of the capture semantics comes first and readback is measured afterwards.
+/// packages.
 ///
 /// Everything here is 1903 or older. The types are attributed accordingly so the callers are forced
 /// to say out loud which Windows they need, because the application itself still runs on 1809.
@@ -91,19 +88,21 @@ internal static class WgcInterop
     }
 
     /// <summary>
-    /// A Direct3D device for the frame pool to hand frames back on, and the raw D3D11 device behind
-    /// it, which the caller must release when it is done.
+    /// A Direct3D device for the frame pool to hand frames back on, plus the raw D3D11 device and
+    /// its immediate context behind it, which the caller must release when it is done — usually by
+    /// handing both to a <see cref="WgcSurfaceReader"/>, which owns them from then on.
     /// </summary>
     /// <remarks>
     /// BGRA support is required, not optional: the frame pool is created for
     /// <c>B8G8R8A8UIntNormalized</c>, which is also the one format that maps onto a 32bpp GDI bitmap
     /// without a channel shuffle. The device is created without a debug layer and without a swap
     /// chain — nothing here presents anything.
+    ///
+    /// The immediate context used to be released here, on the grounds that frames arrive already
+    /// copied into the pool's textures and nothing needed it. Reading one of those textures back is
+    /// what needs it, and that is now done through D3D rather than through an async WinRT call —
+    /// see <see cref="WgcSurfaceReader"/> for why that had to change.
     /// </remarks>
-    public static IDirect3DDevice CreateDirect3DDevice(out IntPtr rawDevice) =>
-        CreateDirect3DDevice(IntPtr.Zero, false, out rawDevice, out _);
-
-    /// <inheritdoc cref="CreateDirect3DDevice(out IntPtr)"/>
     /// <param name="preferredMonitor">
     /// The monitor the capture source is on, or <see cref="IntPtr.Zero"/> for no preference. Used to
     /// pick the adapter the device is created on.
@@ -127,7 +126,8 @@ internal static class WgcInterop
     /// passing null gets.
     /// </remarks>
     public static IDirect3DDevice CreateDirect3DDevice(
-        IntPtr preferredMonitor, bool forceWarp, out IntPtr rawDevice, out string description)
+        IntPtr preferredMonitor, bool forceWarp, out IntPtr rawDevice, out IntPtr immediateContext,
+        out string description)
     {
         const int DriverTypeUnknown = 0;
         const int DriverTypeHardware = 1;
@@ -180,11 +180,11 @@ internal static class WgcInterop
             if (hr >= 0) description = "WARP (software) adapter";
         }
 
-        if (hr < 0) Marshal.ThrowExceptionForHR(hr);
-
-        // The immediate context is never used here — frames arrive already copied into the pool's
-        // textures — so it is released straight away rather than carried around.
-        if (context != IntPtr.Zero) Marshal.Release(context);
+        if (hr < 0)
+        {
+            if (context != IntPtr.Zero) Marshal.Release(context);
+            Marshal.ThrowExceptionForHR(hr);
+        }
 
         var dxgi = IntPtr.Zero;
         var abi = IntPtr.Zero;
@@ -195,7 +195,9 @@ internal static class WgcInterop
             Marshal.ThrowExceptionForHR(CreateDirect3D11DeviceFromDXGIDevice(dxgi, out abi));
 
             rawDevice = device;
+            immediateContext = context;
             device = IntPtr.Zero;
+            context = IntPtr.Zero;
             return WinRT.MarshalInterface<IDirect3DDevice>.FromAbi(abi);
         }
         finally
@@ -203,91 +205,7 @@ internal static class WgcInterop
             if (abi != IntPtr.Zero) Marshal.Release(abi);
             if (dxgi != IntPtr.Zero) Marshal.Release(dxgi);
             if (device != IntPtr.Zero) Marshal.Release(device);
-        }
-    }
-
-    /// <summary>
-    /// Reads a captured surface back into a bitmap on the CPU, which is what recognition needs.
-    /// </summary>
-    /// <remarks>
-    /// This is the expensive half of the whole path — a full GPU-to-CPU copy of the captured window
-    /// — which is exactly why the backend does it at poll rate and not at frame rate, and why one
-    /// readback serves every region rather than one per region.
-    ///
-    /// <c>CreateCopyFromSurfaceAsync</c> rather than a staging texture and a map: it is the only
-    /// step of the D3D dance the projection will do on our behalf, and doing it by hand would mean
-    /// defining ID3D11Device, ID3D11Texture2D and ID3D11DeviceContext to save one copy that has not
-    /// yet been shown to cost anything. If measurement says otherwise, this is the one function that
-    /// changes.
-    /// </remarks>
-    /// <param name="width">
-    /// How much of the surface is actually the window. A capture texture is allocated to the size
-    /// the pool was created for and is routinely larger than the content in it — the extra columns
-    /// and rows are whatever was last in that memory — so the content size travels with every frame
-    /// and is what gets copied out.
-    /// </param>
-    public static unsafe System.Drawing.Bitmap ReadBack(IDirect3DSurface surface, int width, int height)
-    {
-        using var software = SoftwareBitmap.CreateCopyFromSurfaceAsync(
-            surface, BitmapAlphaMode.Premultiplied).AsTask().GetAwaiter().GetResult();
-
-        var bitmap = new System.Drawing.Bitmap(
-            Math.Clamp(width, 1, software.PixelWidth),
-            Math.Clamp(height, 1, software.PixelHeight),
-            System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-
-        try
-        {
-            using var buffer = software.LockBuffer(BitmapBufferAccessMode.Read);
-            using var reference = buffer.CreateReference();
-
-            // Not a plain cast. A projected WinRT object is not a classic COM callable wrapper, so
-            // casting it to a [ComImport] interface throws — the pixels have to be reached by going
-            // out to the ABI pointer and querying for the byte-access interface there.
-            var abi = WinRT.MarshalInspectable<Windows.Foundation.IMemoryBufferReference>.FromManaged(reference);
-            IMemoryBufferByteAccess access;
-            try
-            {
-                access = (IMemoryBufferByteAccess)Marshal.GetObjectForIUnknown(abi);
-            }
-            finally
-            {
-                Marshal.Release(abi);
-            }
-
-            // Valid only while the reference above is open, which is the whole of this scope.
-            access.GetBuffer(out var source, out _);
-
-            var plane = buffer.GetPlaneDescription(0);
-            var locked = bitmap.LockBits(
-                new System.Drawing.Rectangle(0, 0, bitmap.Width, bitmap.Height),
-                System.Drawing.Imaging.ImageLockMode.WriteOnly,
-                System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-            try
-            {
-                // Row by row: the two strides agree in practice and must not be assumed to, and a
-                // row is a memcpy either way.
-                var rowBytes = bitmap.Width * 4;
-                for (var y = 0; y < bitmap.Height; y++)
-                {
-                    Buffer.MemoryCopy(
-                        source + plane.StartIndex + (plane.Stride * y),
-                        (byte*)locked.Scan0 + (locked.Stride * y),
-                        rowBytes,
-                        rowBytes);
-                }
-            }
-            finally
-            {
-                bitmap.UnlockBits(locked);
-            }
-
-            return bitmap;
-        }
-        catch
-        {
-            bitmap.Dispose();
-            throw;
+            if (context != IntPtr.Zero) Marshal.Release(context);
         }
     }
 
@@ -400,14 +318,6 @@ internal static class WgcInterop
     {
         void CreateForWindow(IntPtr window, ref Guid iid, out IntPtr result);
         void CreateForMonitor(IntPtr monitor, ref Guid iid, out IntPtr result);
-    }
-
-    [ComImport]
-    [Guid("5B0D3235-4DBA-4D44-865E-8F1D0E4FD04D")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    private interface IMemoryBufferByteAccess
-    {
-        unsafe void GetBuffer(out byte* buffer, out uint capacity);
     }
 
     // ── DXGI, only far enough to name the adapter behind a monitor ───────────────────────────────

--- a/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcMonitorCaptureBackend.cs
@@ -59,7 +59,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
     private readonly Func<IntPtr> _resolveMonitor;
     private readonly Func<IReadOnlyList<IntPtr>> _resolveOverlays;
     private readonly IDirect3DDevice _device;
-    private readonly IntPtr _rawDevice;
+    private readonly WgcSurfaceReader _reader;
 
     private readonly object _sync = new();
     private GraphicsCaptureItem? _item;
@@ -95,12 +95,12 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
         Func<IntPtr> resolveMonitor,
         Func<IReadOnlyList<IntPtr>> resolveOverlays,
         IDirect3DDevice device,
-        IntPtr rawDevice)
+        WgcSurfaceReader reader)
     {
         _resolveMonitor = resolveMonitor;
         _resolveOverlays = resolveOverlays;
         _device = device;
-        _rawDevice = rawDevice;
+        _reader = reader;
     }
 
     /// <summary>
@@ -144,16 +144,18 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
         if (monitor == IntPtr.Zero) return null;
 
         IDirect3DDevice? device = null;
-        var rawDevice = IntPtr.Zero;
+        WgcSurfaceReader? reader = null;
         WgcMonitorCaptureBackend? backend = null;
         try
         {
             // On the adapter driving this monitor rather than on whichever one is listed first: a
             // capture served by another adapter is not refused, it simply never delivers a frame.
-            device = WgcInterop.CreateDirect3DDevice(monitor, false, out rawDevice, out var adapter);
+            device = WgcInterop.CreateDirect3DDevice(
+                monitor, false, out var rawDevice, out var context, out var adapter);
             Log.Debug("Realtime monitor capture using {Adapter}", adapter);
 
-            backend = new WgcMonitorCaptureBackend(resolveMonitor, resolveOverlays, device, rawDevice);
+            reader = new WgcSurfaceReader(rawDevice, context);
+            backend = new WgcMonitorCaptureBackend(resolveMonitor, resolveOverlays, device, reader);
             if (!backend.Attach(monitor)) throw new InvalidOperationException("the monitor refused capture");
             if (!backend.WaitForIsolatedFrame(FirstFrameTimeout))
                 throw new InvalidOperationException("no frame arrived with the exclusion list in effect");
@@ -170,7 +172,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
             if (backend is null)
             {
                 (device as IDisposable)?.Dispose();
-                if (rawDevice != IntPtr.Zero) Marshal.Release(rawDevice);
+                reader?.Dispose();
             }
             return null;
         }
@@ -438,7 +440,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
             }
 
             var started = Stopwatch.GetTimestamp();
-            var bitmap = WgcInterop.ReadBack(frame.Surface, content.Width, content.Height);
+            var bitmap = _reader.Read(frame.Surface, content.Width, content.Height);
             Interlocked.Add(ref _readbackTicks, Stopwatch.GetTimestamp() - started);
             Interlocked.Increment(ref _framesRead);
 
@@ -606,7 +608,7 @@ public sealed class WgcMonitorCaptureBackend : IRealtimeCaptureBackend
 
         _frameSignal.Dispose();
         (_device as IDisposable)?.Dispose();
-        if (_rawDevice != IntPtr.Zero) Marshal.Release(_rawDevice);
+        _reader.Dispose();
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/OverTranslate/Services/Realtime/Capture/WgcSurfaceReader.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcSurfaceReader.cs
@@ -1,0 +1,313 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Windows.Graphics.DirectX.Direct3D11;
+
+namespace OverTranslate.Services.Realtime.Capture;
+
+/// <summary>
+/// Copies a captured frame's surface down to a <see cref="System.Drawing.Bitmap"/>, synchronously,
+/// through Direct3D 11 itself.
+/// </summary>
+/// <remarks>
+/// This used to be one line — <c>SoftwareBitmap.CreateCopyFromSurfaceAsync(...).GetAwaiter()
+/// .GetResult()</c> — and that line is what #116 turned out to be. It is an asynchronous WinRT
+/// operation, and it was being waited on from inside <c>FrameArrived</c>, which the capture stack
+/// raises on a thread of its own choosing. On Windows 11 that thread's apartment lets the completion
+/// arrive elsewhere and the wait ends. On Windows 10 it does not: the completion is queued back to
+/// the very thread that is blocked waiting for it, and the readback never returns.
+///
+/// From the outside that deadlock is indistinguishable from a capture that produces nothing. The
+/// frame handler is serialised, so the first frame going in and never coming out means no second
+/// frame is delivered either, and the counters read <c>received=1 read=0</c> — which is exactly what
+/// the Windows 10 reports show, on the hardware adapter and on WARP alike, which is why neither
+/// #117's adapter selection nor its software retry moved them.
+///
+/// So the async call is gone and the copy is done by hand: a staging texture, a
+/// <c>CopySubresourceRegion</c>, a <c>Map</c>. Every step is synchronous, none of it touches the
+/// WinRT threading model, and it cannot be deadlocked by the thread it is called on. It is also the
+/// cheaper path — one GPU-to-CPU copy of just the content region into a staging texture that is
+/// reused between frames, rather than a fresh <c>SoftwareBitmap</c> allocated per frame.
+///
+/// The interop is by vtable slot rather than by declaring these interfaces method for method.
+/// D3D11's are large, and three of the four calls needed here sit late in them; a slot index that is
+/// wrong is caught by the first call that uses it, while a mis-declared method thirty slots earlier
+/// is not caught at all.
+/// </remarks>
+[SupportedOSPlatform("windows10.0.18362.0")]
+internal sealed unsafe class WgcSurfaceReader : IDisposable
+{
+    private static readonly Guid IidDxgiInterfaceAccess = new("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1");
+    private static readonly Guid IidTexture2D = new("6F15AAF2-D208-4E89-9AB4-489535D34F9C");
+
+    // IDirect3DDxgiInterfaceAccess::GetInterface, the first method after IUnknown.
+    private const int AccessGetInterface = 3;
+
+    // ID3D11Device::CreateTexture2D.
+    private const int DeviceCreateTexture2D = 5;
+
+    // ID3D11Texture2D::GetDesc — after IUnknown, ID3D11DeviceChild and ID3D11Resource.
+    private const int TextureGetDesc = 10;
+
+    // ID3D11DeviceContext::Map / Unmap / CopySubresourceRegion.
+    private const int ContextMap = 14;
+    private const int ContextUnmap = 15;
+    private const int ContextCopySubresourceRegion = 46;
+
+    private const int UsageStaging = 3;
+    private const uint CpuAccessRead = 0x20000;
+    private const int MapRead = 1;
+
+    private readonly IntPtr _device;
+    private readonly IntPtr _context;
+
+    // Kept between frames: every frame of a session is the same size until the window is resized,
+    // and allocating a full-frame staging texture four times a second is the one cost this path does
+    // not have to pay. Also what makes the whole read one lock: the staging texture is shared state.
+    private readonly object _sync = new();
+    private IntPtr _staging;
+    private uint _stagingWidth;
+    private uint _stagingHeight;
+    private int _stagingFormat;
+    private bool _disposed;
+
+    /// <summary>
+    /// Takes ownership of both pointers — the D3D11 device frames are delivered on, and its
+    /// immediate context. Both are released by <see cref="Dispose"/>.
+    /// </summary>
+    public WgcSurfaceReader(IntPtr device, IntPtr context)
+    {
+        _device = device;
+        _context = context;
+    }
+
+    /// <summary>
+    /// Reads a captured surface back into a bitmap on the CPU, which is what recognition needs.
+    /// </summary>
+    /// <param name="width">
+    /// How much of the surface is actually the content. A capture texture is allocated to the size
+    /// the pool was created for and is routinely larger than the content in it — the extra columns
+    /// and rows are whatever was last in that memory — so the content size travels with every frame
+    /// and is what gets copied out.
+    /// </param>
+    public System.Drawing.Bitmap Read(IDirect3DSurface surface, int width, int height)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var source = GetTexture(surface);
+        try
+        {
+            D3D11_TEXTURE2D_DESC desc;
+            ((delegate* unmanaged[Stdcall]<IntPtr, D3D11_TEXTURE2D_DESC*, void>)
+                Slot(source, TextureGetDesc))(source, &desc);
+
+            var copyWidth = (uint)Math.Clamp(width, 1, (int)Math.Max(desc.Width, 1));
+            var copyHeight = (uint)Math.Clamp(height, 1, (int)Math.Max(desc.Height, 1));
+
+            lock (_sync)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                EnsureStaging(copyWidth, copyHeight, desc.Format);
+
+                var box = new D3D11_BOX
+                {
+                    Left = 0,
+                    Top = 0,
+                    Front = 0,
+                    Right = copyWidth,
+                    Bottom = copyHeight,
+                    Back = 1,
+                };
+
+                ((delegate* unmanaged[Stdcall]<
+                        IntPtr, IntPtr, uint, uint, uint, uint, IntPtr, uint, D3D11_BOX*, void>)
+                    Slot(_context, ContextCopySubresourceRegion))(
+                    _context, _staging, 0, 0, 0, 0, source, 0, &box);
+
+                D3D11_MAPPED_SUBRESOURCE mapped;
+                Marshal.ThrowExceptionForHR(
+                    ((delegate* unmanaged[Stdcall]<
+                            IntPtr, IntPtr, uint, int, uint, D3D11_MAPPED_SUBRESOURCE*, int>)
+                        Slot(_context, ContextMap))(_context, _staging, 0, MapRead, 0, &mapped));
+
+                try
+                {
+                    return CopyOut(mapped, (int)copyWidth, (int)copyHeight);
+                }
+                finally
+                {
+                    ((delegate* unmanaged[Stdcall]<IntPtr, IntPtr, uint, void>)
+                        Slot(_context, ContextUnmap))(_context, _staging, 0);
+                }
+            }
+        }
+        finally
+        {
+            Marshal.Release(source);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            if (_staging != IntPtr.Zero) Marshal.Release(_staging);
+            _staging = IntPtr.Zero;
+        }
+
+        if (_context != IntPtr.Zero) Marshal.Release(_context);
+        if (_device != IntPtr.Zero) Marshal.Release(_device);
+    }
+
+    private static System.Drawing.Bitmap CopyOut(
+        D3D11_MAPPED_SUBRESOURCE mapped, int width, int height)
+    {
+        // B8G8R8A8 is what the frame pool is created for, and it is also the byte order a 32bpp GDI
+        // bitmap uses, so this is a memcpy per row rather than a channel shuffle.
+        var bitmap = new System.Drawing.Bitmap(
+            width, height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        try
+        {
+            var locked = bitmap.LockBits(
+                new System.Drawing.Rectangle(0, 0, width, height),
+                System.Drawing.Imaging.ImageLockMode.WriteOnly,
+                System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            try
+            {
+                // Row by row: the two strides agree in practice and must not be assumed to, and a
+                // row is a memcpy either way.
+                var rowBytes = width * 4;
+                for (var y = 0; y < height; y++)
+                {
+                    Buffer.MemoryCopy(
+                        (byte*)mapped.Data + ((long)mapped.RowPitch * y),
+                        (byte*)locked.Scan0 + ((long)locked.Stride * y),
+                        rowBytes,
+                        rowBytes);
+                }
+            }
+            finally
+            {
+                bitmap.UnlockBits(locked);
+            }
+
+            return bitmap;
+        }
+        catch
+        {
+            bitmap.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// The ID3D11Texture2D behind a projected capture surface, as a pointer the caller releases.
+    /// </summary>
+    private static IntPtr GetTexture(IDirect3DSurface surface)
+    {
+        // Not a plain cast. A projected WinRT object is not a classic COM callable wrapper, so the
+        // D3D texture inside it has to be reached by going out to the ABI pointer and asking the
+        // interop interface there for it.
+        var inspectable = WinRT.MarshalInspectable<IDirect3DSurface>.FromManaged(surface);
+        var access = IntPtr.Zero;
+        try
+        {
+            var accessIid = IidDxgiInterfaceAccess;
+            Marshal.ThrowExceptionForHR(Marshal.QueryInterface(inspectable, ref accessIid, out access));
+
+            var textureIid = IidTexture2D;
+            IntPtr texture;
+            Marshal.ThrowExceptionForHR(
+                ((delegate* unmanaged[Stdcall]<IntPtr, Guid*, IntPtr*, int>)
+                    Slot(access, AccessGetInterface))(access, &textureIid, &texture));
+
+            return texture;
+        }
+        finally
+        {
+            if (access != IntPtr.Zero) Marshal.Release(access);
+            if (inspectable != IntPtr.Zero) Marshal.Release(inspectable);
+        }
+    }
+
+    /// <summary>Caller holds <see cref="_sync"/>.</summary>
+    private void EnsureStaging(uint width, uint height, int format)
+    {
+        if (_staging != IntPtr.Zero
+            && _stagingWidth == width
+            && _stagingHeight == height
+            && _stagingFormat == format)
+            return;
+
+        if (_staging != IntPtr.Zero)
+        {
+            Marshal.Release(_staging);
+            _staging = IntPtr.Zero;
+        }
+
+        var desc = new D3D11_TEXTURE2D_DESC
+        {
+            Width = width,
+            Height = height,
+            MipLevels = 1,
+            ArraySize = 1,
+            Format = format,
+            SampleCount = 1,
+            SampleQuality = 0,
+            Usage = UsageStaging,
+            BindFlags = 0,
+            CpuAccessFlags = CpuAccessRead,
+            MiscFlags = 0,
+        };
+
+        IntPtr staging;
+        Marshal.ThrowExceptionForHR(
+            ((delegate* unmanaged[Stdcall]<IntPtr, D3D11_TEXTURE2D_DESC*, void*, IntPtr*, int>)
+                Slot(_device, DeviceCreateTexture2D))(_device, &desc, null, &staging));
+
+        _staging = staging;
+        _stagingWidth = width;
+        _stagingHeight = height;
+        _stagingFormat = format;
+    }
+
+    /// <summary>The function at <paramref name="slot"/> of a COM pointer's vtable.</summary>
+    private static void* Slot(IntPtr instance, int slot) => (*(void***)instance)[slot];
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct D3D11_TEXTURE2D_DESC
+    {
+        public uint Width;
+        public uint Height;
+        public uint MipLevels;
+        public uint ArraySize;
+        public int Format;
+        public uint SampleCount;
+        public uint SampleQuality;
+        public int Usage;
+        public uint BindFlags;
+        public uint CpuAccessFlags;
+        public uint MiscFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct D3D11_BOX
+    {
+        public uint Left;
+        public uint Top;
+        public uint Front;
+        public uint Right;
+        public uint Bottom;
+        public uint Back;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct D3D11_MAPPED_SUBRESOURCE
+    {
+        public IntPtr Data;
+        public uint RowPitch;
+        public uint DepthPitch;
+    }
+}

--- a/src/OverTranslate/Services/Realtime/Capture/WgcWindowCaptureBackend.cs
+++ b/src/OverTranslate/Services/Realtime/Capture/WgcWindowCaptureBackend.cs
@@ -69,7 +69,7 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
 
     private readonly Func<IntPtr> _resolveSource;
     private readonly IDirect3DDevice _device;
-    private readonly IntPtr _rawDevice;
+    private readonly WgcSurfaceReader _reader;
 
     // Guards the whole capture chain below, which is torn down and rebuilt on a resize and on the
     // source window being replaced.
@@ -109,11 +109,12 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
     private string _adapter = "unknown";
     private string? _firstFault;
 
-    private WgcWindowCaptureBackend(Func<IntPtr> resolveSource, IDirect3DDevice device, IntPtr rawDevice)
+    private WgcWindowCaptureBackend(
+        Func<IntPtr> resolveSource, IDirect3DDevice device, WgcSurfaceReader reader)
     {
         _resolveSource = resolveSource;
         _device = device;
-        _rawDevice = rawDevice;
+        _reader = reader;
     }
 
     /// <summary>
@@ -186,16 +187,17 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
         var timeout = forceWarp ? FirstFrameTimeout / 2 : FirstFrameTimeout;
 
         IDirect3DDevice? device = null;
-        var rawDevice = IntPtr.Zero;
+        WgcSurfaceReader? reader = null;
         WgcWindowCaptureBackend? backend = null;
         var outcome = WindowCaptureOutcome.Refused;
         try
         {
             device = WgcInterop.CreateDirect3DDevice(
                 MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST), forceWarp,
-                out rawDevice, out var adapter);
+                out var rawDevice, out var context, out var adapter);
 
-            backend = new WgcWindowCaptureBackend(resolveSource, device, rawDevice) { _adapter = adapter };
+            reader = new WgcSurfaceReader(rawDevice, context);
+            backend = new WgcWindowCaptureBackend(resolveSource, device, reader) { _adapter = adapter };
             if (!backend.Attach(hwnd)) throw new InvalidOperationException("the window refused capture");
 
             outcome = backend.WaitForUsableFrame(timeout);
@@ -218,7 +220,7 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
             if (backend is null)
             {
                 (device as IDisposable)?.Dispose();
-                if (rawDevice != IntPtr.Zero) Marshal.Release(rawDevice);
+                reader?.Dispose();
             }
             return (null, outcome);
         }
@@ -419,7 +421,7 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
             }
 
             var started = Stopwatch.GetTimestamp();
-            var bitmap = WgcInterop.ReadBack(frame.Surface, content.Width, content.Height);
+            var bitmap = _reader.Read(frame.Surface, content.Width, content.Height);
             Interlocked.Add(ref _readbackTicks, Stopwatch.GetTimestamp() - started);
             Interlocked.Increment(ref _framesRead);
 
@@ -669,7 +671,7 @@ public sealed class WgcWindowCaptureBackend : IRealtimeCaptureBackend
 
         _frameSignal.Dispose();
         (_device as IDisposable)?.Dispose();
-        if (_rawDevice != IntPtr.Zero) Marshal.Release(_rawDevice);
+        _reader.Dispose();
     }
 
     private const uint DWMWA_EXTENDED_FRAME_BOUNDS = 9;


### PR DESCRIPTION
Fixes #116

## 問題

Windows 10 使用者的視窗擷取固定失敗。#117 加的計數器指出了真正的位置：

```
received=1 read=0 avgReadback=0.0ms rebuilds=0
```

收到 1 張、讀出 0 張，而且硬體 adapter 與 WARP 兩次一模一樣 —— frame 有進來，卡的是讀回。

卡住的是 `WgcInterop.ReadBack` 的第一行：

```csharp
SoftwareBitmap.CreateCopyFromSurfaceAsync(...).AsTask().GetAwaiter().GetResult();
```

非同步 WinRT 呼叫，卻在 `FrameArrived` 回呼執行緒上同步等待。Windows 11 的回呼執行緒 apartment 允許完成通知落在別條執行緒，等待就結束；Windows 10 會把完成通知排回那條正被阻塞的執行緒，於是永遠不返回。frame handler 是序列化的，第一張進去沒出來，之後再也沒有 frame，從外面看就是「produced no frame at all」。

**#116 原本推測的「`item.Size` 含隱形邊框 → 第一張就觸發 `Recreate` → 死鎖」不是本案成因**：實測 `rebuilds=0`，那條路沒被走到。#117 延後 `Recreate` 修的是另一個真實隱患，值得留著，但它解釋不了這個症狀，這也是為什麼 #117 之後問題原封不動。

## 改動

新增 `WgcSurfaceReader`，改用 D3D11 自己做讀回：staging texture → `CopySubresourceRegion`（只複製 content 區域）→ `Map`。全程同步，不碰 WinRT threading model，不可能被呼叫它的執行緒鎖死；staging texture 跨 frame 重用，也比每張新配一個 `SoftwareBitmap` 便宜。

- `WgcInterop`：移除 `ReadBack` 與 `IMemoryBufferByteAccess`；`CreateDirect3DDevice` 改為把 immediate context 一起交出來（以前建完就直接 Release），連同 device 交給 reader 持有
- 視窗／螢幕兩個 backend 都改走新路徑，`_rawDevice` 換成 `_reader`
- interop 以 vtable slot 直接呼叫，不逐一宣告 D3D11 那兩個大介面 —— slot 錯了第一次呼叫就會炸，方法宣告錯了則不會

## 驗證

### Windows 11 開發機（`tools/WgcProbe`）

- `overlay`：疊圖在桌面擷取 98.5%、在視窗擷取 0.0% → PASS，PNG 顏色與位置正確（無通道錯位、無 stride 歪斜）
- `region`：真實遊戲視窗 1922x1239，`received=302 read=38 avgReadback=12.9ms rebuilds=0`
- 單元測試 540 passed / 0 failed

### Windows 10 重現環境（VMware Workstation + Windows 10 22H2 build 19045.3803）

環境有效性先確認：`capture=True`、adapter 為 `VMware SVGA 3D (vendor=15AD device=0405)`、`displaySession=False`。

修正前／修正後交替執行，四次版本切換、五個 session：

| 時間 | 版本 | 結果 |
|---|---|---|
| 22:58:14 | 修正前 | ❌ `received=1 read=0`（硬體）→ WARP 重試 `received=1 read=0` |
| 22:58:55 | 修正後 | ✅ `received=44 read=11 avgReadback=29.5ms` |
| 22:59:12 | 修正後 | ✅ `received=111 read=21`，翻譯完成 |
| 23:00:45 | 修正前 | ❌ `received=1 read=0`（硬體）→ WARP `received=1 read=0` |
| 23:01:53 | 修正後 | ✅ `received=111 read=25`，OCR 讀到文字、翻譯完成 |

修正前的失敗簽章與使用者回報的 log 一字不差。兩台重現機 patch level 不同（`19045.6466` / `19045.3803`）皆必中，屬 Windows 10 的性質而非特定累積更新。

## 影響範圍

只有 `src/OverTranslate/Services/Realtime/Capture/` 底下三個檔案，兩個呼叫點。不影響截圖翻譯（走 GDI）與 OCR／翻譯管線。
