### PR TITLE
fix: #121 Windows 10 改用 GDI 圓角區域裁切視窗，修正主視窗與更新視窗圓角失效

### DIFF
--- a/src/OverTranslate/Views/Shell/WindowFrame.cs
+++ b/src/OverTranslate/Views/Shell/WindowFrame.cs
@@ -33,6 +33,30 @@ internal static class WindowFrame
     private const int DWMWA_BORDER_COLOR = 34;
     private const int DWMWCP_ROUND = 2;
 
+    private const int WM_SIZE = 0x0005;
+
+    /// <summary>
+    /// The radius the compositor rounds a window to on Windows 11, in device-independent units,
+    /// for the fallback below to match.
+    /// </summary>
+    private const double LegacyCornerRadius = 8;
+
+    /// <summary>
+    /// Whether the desktop compositor rounds windows itself.
+    /// </summary>
+    /// <remarks>
+    /// DWMWA_WINDOW_CORNER_PREFERENCE arrived with Windows 11 (build 22000) and is rejected outright
+    /// below it — DwmSetWindowAttribute returns E_INVALIDARG and the window simply stays square. So
+    /// this is the line between the two paths <see cref="ApplyAppearance"/> takes, and it is read
+    /// once: the answer cannot change while the process is running.
+    ///
+    /// OVERTRANSLATE_LEGACY_WINDOW_CORNERS=1 forces the Windows 10 path on where it is not needed,
+    /// which is the only way to look at that path on a Windows 11 development machine.
+    /// </remarks>
+    private static readonly bool DwmRoundsCorners =
+        Environment.OSVersion.Version is { Major: >= 10, Build: >= 22000 }
+        && Environment.GetEnvironmentVariable("OVERTRANSLATE_LEGACY_WINDOW_CORNERS") != "1";
+
     /// <summary>
     /// Takes the frame over for as long as <paramref name="window"/> lives. Safe to call before the
     /// window has a handle — everything that needs one waits for it.
@@ -79,6 +103,15 @@ internal static class WindowFrame
         var hwnd = new WindowInteropHelper(window).Handle;
         if (hwnd == IntPtr.Zero) return;
 
+        // Windows 10 knows neither of the two attributes below: it neither rounds a window on
+        // request nor lets one colour its own outer edge. The shape is worth having anyway, so it
+        // is cut out by hand there; the edge colour has nowhere to go and is simply not asked for.
+        if (!DwmRoundsCorners)
+        {
+            ApplyLegacyCorners(window, hwnd);
+            return;
+        }
+
         var round = DWMWCP_ROUND;
         DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref round, sizeof(int));
 
@@ -88,6 +121,61 @@ internal static class WindowFrame
         // system default colour instead of the one named here.
         var colorRef = border.Color.R | (border.Color.G << 8) | (border.Color.B << 16);
         DwmSetWindowAttribute(hwnd, DWMWA_BORDER_COLOR, ref colorRef, sizeof(int));
+    }
+
+    /// <summary>
+    /// Rounds the window by clipping it to a rounded rectangle, for the versions of Windows whose
+    /// compositor will not round it on request.
+    /// </summary>
+    /// <remarks>
+    /// The same GDI region every Windows 10-era application used for the same effect, and the only
+    /// route left once DWMWA_WINDOW_CORNER_PREFERENCE is refused: the other one — AllowsTransparency,
+    /// which would let WPF draw the curve itself the way 取詞翻譯 does — is the trade ApplyAppearance
+    /// already turned down, and it would cost ClearType on every glyph in the window.
+    ///
+    /// It is a harder edge than the compositor’s. A region is a one-bit mask, so the curve is
+    /// aliased where DWM’s is antialiased; that is the whole of what this costs, and it is what
+    /// Windows 10 charged everybody else too.
+    ///
+    /// A maximised window gets no region at all. Windows draws those square, and rounding one only
+    /// cuts notches out of the screen’s own corners.
+    ///
+    /// IsZoomed rather than the window’s WindowState: this runs from the WM_SIZE that announces the
+    /// maximise, and hooks are called before WPF has read that message, so WindowState is still the
+    /// state being left. The size is taken from GetWindowRect for the same kind of reason — a region
+    /// is physical pixels measured from the window’s own top-left corner, which is exactly what that
+    /// call gives and what device-independent units are not.
+    /// </remarks>
+    private static void ApplyLegacyCorners(Window window, IntPtr hwnd)
+    {
+        // Minimised, GetWindowRect answers with the icon's old off-screen rectangle rather than the
+        // window's, and a region cut to that shape would be the one the window came back wearing for
+        // as long as it took the restore's own WM_SIZE to arrive.
+        if (IsIconic(hwnd)) return;
+
+        if (IsZoomed(hwnd))
+        {
+            SetWindowRgn(hwnd, IntPtr.Zero, true);
+            return;
+        }
+
+        if (!GetWindowRect(hwnd, out var rect)) return;
+
+        var width  = rect.right - rect.left;
+        var height = rect.bottom - rect.top;
+        if (width <= 0 || height <= 0) return;
+
+        // CreateRoundRectRgn’s last two arguments are the corner ellipse’s width and height, so a
+        // radius of r is asked for as 2r. The rectangle excludes its right and bottom edge, hence
+        // the +1 on each: without them the window loses its last column and row of pixels.
+        var dpi = VisualTreeHelper.GetDpi(window);
+        var diameter = (int)Math.Round(LegacyCornerRadius * 2 * dpi.DpiScaleX);
+        var region = CreateRoundRectRgn(0, 0, width + 1, height + 1, diameter, diameter);
+        if (region == IntPtr.Zero) return;
+
+        // On success the window owns the region and will delete it itself, so it must not be
+        // deleted here; on failure nothing else ever will, so it must.
+        if (SetWindowRgn(hwnd, region, true) == 0) DeleteObject(region);
     }
 
     /// <summary>
@@ -125,6 +213,15 @@ internal static class WindowFrame
 
     private static IntPtr Hook(Window window, IntPtr hwnd, int msg, IntPtr lParam, ref bool handled)
     {
+        // A region is a fixed set of pixels, so every new size needs a new one. WM_SIZE is where
+        // they all arrive — a drag of the border, a maximise or restore, and the resize a move to a
+        // monitor at another scale factor brings with it. Left unhandled: WPF needs it too.
+        if (msg == WM_SIZE)
+        {
+            if (!DwmRoundsCorners) ApplyLegacyCorners(window, hwnd);
+            return IntPtr.Zero;
+        }
+
         if (msg != WM_GETMINMAXINFO) return IntPtr.Zero;
 
         var monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
@@ -208,6 +305,30 @@ internal static class WindowFrame
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool GetMonitorInfo(IntPtr monitor, ref MONITORINFO info);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsZoomed(IntPtr hwnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsIconic(IntPtr hwnd);
+
+    [DllImport("user32.dll")]
+    private static extern int SetWindowRgn(IntPtr hwnd, IntPtr region,
+        [MarshalAs(UnmanagedType.Bool)] bool redraw);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateRoundRectRgn(int left, int top, int right, int bottom,
+        int ellipseWidth, int ellipseHeight);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteObject(IntPtr obj);
 
     [DllImport("dwmapi.dll", PreserveSig = true)]
     private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);


### PR DESCRIPTION
Fixes #121

## 問題

Windows 10 上主視窗（`ShellWindow`）與更新視窗（`UpdateWindow`）的圓角失效，四角是直角。同一台機器上截圖工具列、即時翻譯懸浮工具列、取詞翻譯的圓角完全正常。

不是頁面設計不同，是**圓角由誰畫**不同。

圓角正常的三個視窗是 `AllowsTransparency="True"` + 內容裡一個 `Border CornerRadius`，由 WPF 自己在圖層視窗上算，與 OS 版本無關。

失效的兩個走 `WindowFrame.ApplyAppearance()`，請桌面合成器代勞：

```csharp
DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE /* 33 */, ref round, sizeof(int));
```

這個屬性是 **Windows 11（build 22000）才加入的**，Win10 上回 `E_INVALIDARG` 而不做任何事。原本的程式碼沒檢查回傳值，所以是靜靜地失敗。緊接著的 `DWMWA_BORDER_COLOR /* 34 */` 同樣是 Win11 才有，所以 Win10 上這兩個視窗連主題色外緣也沒有。

這兩個視窗當初刻意不用 `AllowsTransparency`，理由寫在原本的註解裡：整個視窗變成 layered surface 會失去 ClearType 次像素反鋸齒與硬體加速，對一個幾乎全是文字的視窗划不來。這個取捨仍然成立，所以修法不是把它們改成透明視窗。

## 改動

只動 `WindowFrame.cs` 一個檔案。新增 `DwmRoundsCorners` 分流，Win11 路徑一行未變；Win10 走傳統的 GDI 視窗區域。

- `ApplyLegacyCorners()`：`CreateRoundRectRgn` + `SetWindowRgn`。半徑 8 DIP 乘當下 DPI；`CreateRoundRectRgn` 最後兩個參數是角落橢圓的**寬高**不是半徑，所以傳 `2r`。矩形用 `GetWindowRect` 量 —— 區域是相對視窗左上角的**實體像素**，DIP 在這裡是錯的單位；右下各 `+1`，否則會裁掉最後一行／一列像素。
- 區域的所有權在 `SetWindowRgn` 成功後轉移給視窗，不能再 `DeleteObject`；失敗才要自己刪。
- 在既有的 hook 裡加收 `WM_SIZE` 重算 —— 拖邊框、最大化／還原、跨螢幕換 DPI 全都經過它。不設 `handled`，WPF 照常收到。
- 最大化時把區域拿掉（最大化本來就該是直角）。判定用 `IsZoomed(hwnd)` 而非 `WindowState`：hook 比 WPF 早讀到那個 `WM_SIZE`，此時 `WindowState` 還停在即將離開的狀態。
- 最小化 `IsIconic` 直接跳過：`GetWindowRect` 這時回的是離螢幕的圖示矩形。
- `OVERTRANSLATE_LEGACY_WINDOW_CORNERS=1` 可在 Win11 上強制走 Win10 路徑，否則這條路在開發機上看不到。

## 已知代價

GDI 的 region 是 1-bit 遮罩，每個像素非有即無，存不下部分覆蓋率 —— 所以裁出來的曲線在定義上不可能抗鋸齒，Win10 上的圓角會有階梯狀鋸齒。這是 Win10 時代所有 app 共同的代價。

兩條想繞過去的路都試過並否決，過程記在 #121：

- **在裁切邊界內側畫抗鋸齒圓角外框**：無效。看得到的那一階是「視窗背景 ↔ 背後未知桌面」的硬跳變，外框只碰得到內側。用高對比假色測會有錯覺上的改善，換成真實的 `AppBorder`（深 `#3C3C3C` on `#202020`、淺 `#E0E0E0` on `#F3F3F3`）後深色只多一條幾乎看不見的灰線，淺色兩張分辨不出來。已回退。
- **把半徑砍到 4**（= Win11 的 `DWMWCP_ROUNDSMALL`）：階梯確實從約六階降到兩三階，但實機看過後判斷太方，比階梯更難看。已撤回，維持 8。

要真正消除鋸齒只有讓整個視窗帶 alpha 一途，代價是 ClearType 與硬體加速，不划算。

## 驗證

### Windows 11 開發機

- 拋棄式 WPF probe（同樣的 `WindowChrome` 設定、同樣的呼叫與參數）：`SetWindowRgn` 回 1，四角確實被裁圓，放大到像素層級可見 GDI 的階梯（預期內），視窗上的文字仍保有 ClearType 次像素著色 —— 正是不用 `AllowsTransparency` 想保住的東西。
- Win11 路徑不受影響：`ApplyLegacyCorners` 永遠不會被呼叫，視覺樹與改動前相同。唯一新增的是 `WM_SIZE` 裡一個讀 static bool 就 return 的分支。
- 單元測試 540 passed / 0 failed。

### Windows 10 實機（VM）

- 主視窗圓角正常。

### 尚未確認

視窗陰影 —— 設了 window region 之後 DWM 投影是否消失或沿原本方形邊界被裁出破綻。合併前值得在 Win10 上再看一眼。
