### PR TITLE
feat: 取詞翻譯操作性調整，並將 TTS 與交換邏輯帶回文字翻譯

### DIFF
--- a/src/OverTranslate/Layout/QuickLookupLift.cs
+++ b/src/OverTranslate/Layout/QuickLookupLift.cs
@@ -24,30 +24,34 @@ internal static class QuickLookupLift
     /// already lifted always fits where it has been lifted to, so it would never come back down, and
     /// every translation would walk it a little further up the screen.
     ///
-    /// A popup taller than the work area cannot be contained. It is pinned to the top edge, which
-    /// keeps the box and the beginning of the result readable and loses the end off the bottom —
-    /// the opposite way round from doing nothing.
+    /// The two limits are the range the window may occupy, not the work area. They are not the same
+    /// thing: this window is larger than the card it draws by a transparent margin the shadow fades
+    /// out into, and those pixels are nothing. Measured against the work area itself, the bottom of
+    /// every screen would be refused to a card that could plainly still go there — which is a gap
+    /// the user can see and cannot explain. The caller is what subtracts the margin.
+    ///
+    /// A popup taller than the range cannot be contained. It is pinned to the top, which keeps the
+    /// box and the beginning of the result readable and loses the end off the bottom — the opposite
+    /// way round from doing nothing.
     /// </remarks>
     /// <param name="currentTop">Where the window is now, in physical pixels.</param>
     /// <param name="restingTop">Where it belongs when nothing is lifting it, or null if that is where it already is.</param>
-    /// <param name="height">The window's current height, result panel and shadow margin included.</param>
-    /// <param name="areaTop">Top of the work area it is on.</param>
-    /// <param name="areaBottom">Bottom of that work area.</param>
-    /// <param name="edge">Margin to leave against either edge.</param>
+    /// <param name="height">The height the window is taking, in physical pixels, shadow margin included.</param>
+    /// <param name="limitTop">Lowest top the window may have — the work area's top, less the margin above the card.</param>
+    /// <param name="limitBottom">Highest bottom the window may have — the work area's bottom, plus the margin below the card.</param>
     /// <returns>
     /// The top to move to, and the resting top to carry forward — null once the window fits where it
     /// belongs, which is what stops a later collapse from moving a window nobody asked to move.
     /// </returns>
     public static (int Top, int? RestingTop) Place(
-        int currentTop, int? restingTop, int height, int areaTop, int areaBottom, int edge)
+        int currentTop, int? restingTop, int height, int limitTop, int limitBottom)
     {
         int resting = restingTop ?? currentTop;
 
-        // Math.Clamp throws when the popup is taller than the work area has room for.
-        int minY = areaTop + edge;
-        int maxY = Math.Max(minY, areaBottom - height - edge);
+        // Math.Clamp throws when the popup is taller than the range has room for.
+        int maxTop = Math.Max(limitTop, limitBottom - height);
 
-        int top = Math.Clamp(resting, minY, maxY);
+        int top = Math.Clamp(resting, limitTop, maxTop);
 
         return (top, top < resting ? resting : null);
     }

--- a/src/OverTranslate/Layout/QuickLookupLift.cs
+++ b/src/OverTranslate/Layout/QuickLookupLift.cs
@@ -1,0 +1,54 @@
+namespace OverTranslate.Layout;
+
+/// <summary>
+/// Keeps 取詞翻譯's popup on the screen while its result panel is open, and puts it back after.
+/// </summary>
+/// <remarks>
+/// The popup is <c>SizeToContent="Height"</c>: the header stays where it is and a translation grows
+/// out of the bottom of it. Summoned or dragged near the foot of the screen, the answer therefore
+/// grows straight off the desktop — the user typed a word, something happened, and there is nothing
+/// to read.
+///
+/// Lifting the whole window rather than growing it upwards. Growing the other way would move the box
+/// the user is typing in, taking the field and its buttons up from under the pointer mid-sentence,
+/// which is worse than moving a window nobody is touching.
+/// </remarks>
+internal static class QuickLookupLift
+{
+    /// <summary>
+    /// Where the popup should sit at its current height, and the resting top to keep hold of.
+    /// </summary>
+    /// <remarks>
+    /// The lift is a loan against a position the user chose, and <paramref name="restingTop"/> is
+    /// what repays it. Judging the fit from where the window currently is would not work: a popup
+    /// already lifted always fits where it has been lifted to, so it would never come back down, and
+    /// every translation would walk it a little further up the screen.
+    ///
+    /// A popup taller than the work area cannot be contained. It is pinned to the top edge, which
+    /// keeps the box and the beginning of the result readable and loses the end off the bottom —
+    /// the opposite way round from doing nothing.
+    /// </remarks>
+    /// <param name="currentTop">Where the window is now, in physical pixels.</param>
+    /// <param name="restingTop">Where it belongs when nothing is lifting it, or null if that is where it already is.</param>
+    /// <param name="height">The window's current height, result panel and shadow margin included.</param>
+    /// <param name="areaTop">Top of the work area it is on.</param>
+    /// <param name="areaBottom">Bottom of that work area.</param>
+    /// <param name="edge">Margin to leave against either edge.</param>
+    /// <returns>
+    /// The top to move to, and the resting top to carry forward — null once the window fits where it
+    /// belongs, which is what stops a later collapse from moving a window nobody asked to move.
+    /// </returns>
+    public static (int Top, int? RestingTop) Place(
+        int currentTop, int? restingTop, int height, int areaTop, int areaBottom, int edge)
+    {
+        int resting = restingTop ?? currentTop;
+
+        // Math.Clamp throws when the popup is taller than the work area has room for.
+        int minY = areaTop + edge;
+        int maxY = Math.Max(minY, areaBottom - height - edge);
+
+        int top = Math.Clamp(resting, minY, maxY);
+
+        return (top, top < resting ? resting : null);
+    }
+}

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -81,10 +81,9 @@
     <sys:String x:Key="S.Translation.ClearSource">Clear the source text</sys:String>
     <sys:String x:Key="S.Translation.SpeakSource">Read the source aloud</sys:String>
     <sys:String x:Key="S.Translation.SpeakSourceOpenAi">With the OpenAI service, choose a source language to read the source aloud.</sys:String>
-    <sys:String x:Key="S.Translation.SpeakSourceOpenAiShort">OpenAI needs a source language</sys:String>
     <sys:String x:Key="S.Translation.SpeakSourceUnknown">The language of the source is not known yet. It can be read aloud once the translation is back.</sys:String>
-    <!-- The short note and the tooltip say the same thing at two lengths; the note is what is read,
-         the tooltip is for whoever hovers the greyed speaker. -->
+    <!-- The note at the foot of the page and the greyed speaker's tooltip are the same sentence:
+         the note is what is read, the tooltip is for whoever hovers the button instead. -->
     <sys:String x:Key="S.Translation.Source">Source</sys:String>
     <sys:String x:Key="S.Translation.SpeakResult">Read the translation aloud</sys:String>
     <sys:String x:Key="S.Translation.Result">Translation</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -80,8 +80,9 @@
     <sys:String x:Key="S.Translation.SwapTip">Swap languages and text</sys:String>
     <sys:String x:Key="S.Translation.ClearSource">Clear the source text</sys:String>
     <sys:String x:Key="S.Translation.SpeakSource">Read the source aloud</sys:String>
-    <sys:String x:Key="S.Translation.SpeakSourceAutomatic">Reading the source aloud is unavailable while the source language is set to Automatic.</sys:String>
-    <sys:String x:Key="S.Translation.SpeakSourceAutomaticShort">No voice for Automatic</sys:String>
+    <sys:String x:Key="S.Translation.SpeakSourceOpenAi">With the OpenAI service, choose a source language to read the source aloud.</sys:String>
+    <sys:String x:Key="S.Translation.SpeakSourceOpenAiShort">OpenAI needs a source language</sys:String>
+    <sys:String x:Key="S.Translation.SpeakSourceUnknown">The language of the source is not known yet. It can be read aloud once the translation is back.</sys:String>
     <!-- The short note and the tooltip say the same thing at two lengths; the note is what is read,
          the tooltip is for whoever hovers the greyed speaker. -->
     <sys:String x:Key="S.Translation.Source">Source</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -98,7 +98,7 @@ Translation failed: {1}</sys:String>
     <sys:String x:Key="S.QuickLookup.Placeholder">Type text to translate...</sys:String>
     <sys:String x:Key="S.QuickLookup.Settings">Quick lookup settings</sys:String>
     <sys:String x:Key="S.QuickLookup.BackToResult">Back to the translation</sys:String>
-    <sys:String x:Key="S.QuickLookup.Pin">Pin, so it stays when you click away</sys:String>
+    <sys:String x:Key="S.QuickLookup.Pin">Pin to stop the window closing on its own</sys:String>
     <sys:String x:Key="S.QuickLookup.Unpin">Unpin</sys:String>
     <sys:String x:Key="S.QuickLookup.Copy">Copy</sys:String>
     <sys:String x:Key="S.QuickLookup.Copied">Copied</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -87,8 +87,6 @@
     <!-- 來源語言為「自動」時，朗讀原文靠的是引擎回報的偵測結果；OpenAI 相容服務不會回報，所以那個
          組合是唯一永遠等不到答案、必須直接停用的狀態，這句就是使用者唯一能得知原因的地方。 -->
     <sys:String x:Key="S.Translation.SpeakSourceOpenAi">使用 OpenAI 翻譯服務時，請先指定來源語言，才能朗讀原文。</sys:String>
-    <!-- 標題列裡的短版，寬度吃緊時會被截斷，完整句子留在上面那個 tooltip。 -->
-    <sys:String x:Key="S.Translation.SpeakSourceOpenAiShort">OpenAI 需指定來源語言</sys:String>
     <!-- 另一種還沒有語言可用的狀態：引擎只是還沒回答，等翻譯回來就會好，所以只給 tooltip 不給短註記。 -->
     <sys:String x:Key="S.Translation.SpeakSourceUnknown">還不知道原文是什麼語言，翻譯完成後就可以朗讀。</sys:String>
     <sys:String x:Key="S.Translation.Source">原文</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -84,11 +84,13 @@
     <sys:String x:Key="S.Translation.SwapTip">對調語言與內容</sys:String>
     <sys:String x:Key="S.Translation.ClearSource">清除原文</sys:String>
     <sys:String x:Key="S.Translation.SpeakSource">朗讀原文</sys:String>
-    <!-- 朗讀鈕在自動模式下是停用的，這句就是使用者唯一能得知原因的地方 —— TtsService 把「自動」對應
-         到中文語音，英日韓原文會被用中文口音唸出來。 -->
-    <sys:String x:Key="S.Translation.SpeakSourceAutomatic">來源語言設為「自動」時，無法使用原文朗讀。</sys:String>
+    <!-- 來源語言為「自動」時，朗讀原文靠的是引擎回報的偵測結果；OpenAI 相容服務不會回報，所以那個
+         組合是唯一永遠等不到答案、必須直接停用的狀態，這句就是使用者唯一能得知原因的地方。 -->
+    <sys:String x:Key="S.Translation.SpeakSourceOpenAi">使用 OpenAI 翻譯服務時，請先指定來源語言，才能朗讀原文。</sys:String>
     <!-- 標題列裡的短版，寬度吃緊時會被截斷，完整句子留在上面那個 tooltip。 -->
-    <sys:String x:Key="S.Translation.SpeakSourceAutomaticShort">自動偵測無法使用語音</sys:String>
+    <sys:String x:Key="S.Translation.SpeakSourceOpenAiShort">OpenAI 需指定來源語言</sys:String>
+    <!-- 另一種還沒有語言可用的狀態：引擎只是還沒回答，等翻譯回來就會好，所以只給 tooltip 不給短註記。 -->
+    <sys:String x:Key="S.Translation.SpeakSourceUnknown">還不知道原文是什麼語言，翻譯完成後就可以朗讀。</sys:String>
     <sys:String x:Key="S.Translation.Source">原文</sys:String>
     <sys:String x:Key="S.Translation.SpeakResult">朗讀譯文</sys:String>
     <sys:String x:Key="S.Translation.Result">譯文</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -103,7 +103,7 @@
     <sys:String x:Key="S.QuickLookup.Placeholder">輸入要翻譯的文字…</sys:String>
     <sys:String x:Key="S.QuickLookup.Settings">取詞翻譯設定</sys:String>
     <sys:String x:Key="S.QuickLookup.BackToResult">返回翻譯結果</sys:String>
-    <sys:String x:Key="S.QuickLookup.Pin">釘選，點到別處也不關閉</sys:String>
+    <sys:String x:Key="S.QuickLookup.Pin">釘選後，可避免視窗自動關閉</sys:String>
     <sys:String x:Key="S.QuickLookup.Unpin">取消釘選</sys:String>
     <sys:String x:Key="S.QuickLookup.Copy">複製</sys:String>
     <sys:String x:Key="S.QuickLookup.Copied">已複製</sys:String>

--- a/src/OverTranslate/Services/ScreenGeometry.cs
+++ b/src/OverTranslate/Services/ScreenGeometry.cs
@@ -74,6 +74,17 @@ internal static class ScreenGeometry
         return 1.0;
     }
 
+    // Where a window actually is, in pixels. The counterpart to MoveToPhysical and needed for the
+    // same reason: Window.Left/Top/ActualHeight are DIP, converted with the DPI of the monitor WPF
+    // believes the window is on, so a window that has been placed with MoveToPhysical cannot be read
+    // back through them without the conversion drifting. Empty when the handle does not exist yet.
+    public static Rectangle PhysicalBounds(Window window)
+    {
+        IntPtr hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero || !GetWindowRect(hwnd, out RECT r)) return Rectangle.Empty;
+        return Rectangle.FromLTRB(r.Left, r.Top, r.Right, r.Bottom);
+    }
+
     // Moves a window to an exact pixel position, leaving its size to WPF. Window.Left/Top would be
     // converted with the DPI of the monitor the window is on before the move, so a window crossing
     // to a monitor at another scale lands off by that scale factor.
@@ -104,6 +115,13 @@ internal static class ScreenGeometry
 
     [StructLayout(LayoutKind.Sequential)]
     private struct POINT { public int X; public int Y; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
 
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -304,13 +304,45 @@ public partial class MainWindow : Window
         Dispatcher.Invoke(() => Views.Realtime.RealtimeSessionController.Instance.TogglePause());
 
     /// <summary>
-    /// Brings 取詞翻譯's popup up over whatever the user is reading.
+    /// Brings 取詞翻譯's popup up over whatever the user is reading, unpinned.
     /// </summary>
     /// <remarks>
     /// Not a toggle, unlike the shortcut below it: pressed again it refills the popup with the new
     /// selection rather than dismissing it, because the popup already goes away on its own and the
     /// thing a second press means is "this word now".
     ///
+    /// Unpinned, because dismissing itself is what makes this shortcut cheap to press: it is used
+    /// on a word mid-sentence, and a popup left behind after every press would be litter the user
+    /// has to clear. <see cref="StartQuickLookupFromShell"/> is the door that opens it pinned.
+    /// </remarks>
+    private void OnQuickLookupHotkeyPressed(object? sender, EventArgs e) =>
+        StartQuickLookup(pinned: false);
+
+    /// <summary>
+    /// Opens 取詞翻譯 from the shell window's nav rail, pinned.
+    /// </summary>
+    /// <remarks>
+    /// Through <see cref="StartQuickLookup"/> rather than calling <c>SummonAsync</c> itself: the two
+    /// states a popup must not appear in are about the screen, not about which control asked, and a
+    /// second entry point with its own guards is one that can fall out of step with them. The rail's
+    /// own button being disabled during a realtime session is a presentation detail on top of this,
+    /// not a replacement for it.
+    ///
+    /// Pinned, which is the one thing this door does differently. Someone arriving by the shortcut
+    /// has already been told what it does; someone who found the feature in the nav rail is meeting
+    /// it, and a popup that dismissed itself the moment they looked back at their text would be a
+    /// rule they were never told — they would press the button again, and again. The pin is on the
+    /// popup's own header for them to turn off once they know.
+    ///
+    /// The shell stays where it is. Unlike a capture, this puts a popup over the screen rather than
+    /// photographing it, so there is nothing to get out of the way of.
+    /// </remarks>
+    public void StartQuickLookupFromShell() => StartQuickLookup(pinned: true);
+
+    /// <summary>
+    /// The one way in to 取詞翻譯, holding the guards both doors have to pass.
+    /// </summary>
+    /// <remarks>
     /// Turned away in the two states where a window of ours must not appear, and for two different
     /// reasons. During a capture the user is framing or reading a screen of their own and a popup
     /// dropped into it takes the foreground away mid-gesture — the same reason the translation
@@ -320,29 +352,14 @@ public partial class MainWindow : Window
     /// translating this window's text back to the user. That one is announced, because the shortcut
     /// is otherwise available everywhere and silence would read as breakage.
     /// </remarks>
-    private void OnQuickLookupHotkeyPressed(object? sender, EventArgs e) =>
+    private void StartQuickLookup(bool pinned) =>
         Dispatcher.Invoke(async () =>
         {
             if (HasActiveSession) return;
             if (RefuseWhileRealtimeRuns()) return;
 
-            await Views.QuickLookup.QuickLookupWindow.SummonAsync();
+            await Views.QuickLookup.QuickLookupWindow.SummonAsync(pinned);
         });
-
-    /// <summary>
-    /// Opens 取詞翻譯 from the shell window's nav rail.
-    /// </summary>
-    /// <remarks>
-    /// Straight through <see cref="OnQuickLookupHotkeyPressed"/> rather than calling
-    /// <c>SummonAsync</c> itself: the two states a popup must not appear in are about the screen,
-    /// not about which control asked, and a second entry point with its own guards is one that can
-    /// fall out of step with them. The rail's own button being disabled during a realtime session
-    /// is a presentation detail on top of this, not a replacement for it.
-    ///
-    /// The shell stays where it is. Unlike a capture, this puts a popup over the screen rather than
-    /// photographing it, so there is nothing to get out of the way of.
-    /// </remarks>
-    public void StartQuickLookupFromShell() => OnQuickLookupHotkeyPressed(this, EventArgs.Empty);
 
     /// <summary>
     /// Opens the translation window, and during a realtime session brings its layers to the front

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -295,16 +295,25 @@
                                   Width="78"
                                   SelectedValuePath="Code"/>
 
-                        <!-- Quieter than the two names it sits between: it is punctuation, not a
-                             third thing to read, and at the same weight it was the darkest mark in
-                             a header made of light ones. -->
-                        <TextBlock Text="→"
-                                   FontFamily="{StaticResource AppFont}"
-                                   FontSize="11"
-                                   Foreground="{DynamicResource AppTextSecondary}"
-                                   Opacity="0.45"
-                                   VerticalAlignment="Center"
-                                   Margin="4,1,4,0"/>
+                        <!-- Was a → held at 0.45 opacity, on the reasoning that it was punctuation
+                             rather than a third thing to read. It is a control now, so it is drawn
+                             at the same weight as the pin, gear and close beside it: a button faded
+                             to nearly half is one nobody tries to press.
+
+                             ⇄ in the interface font rather than 截圖翻譯's icon-font glyph, because
+                             what it replaces is a typographic mark between two words and the row is
+                             built out of light text — the same swap 文字翻譯 puts between its two
+                             pickers, which is where someone would have met this before. -->
+                        <Button Content="⇄"
+                                Style="{StaticResource IconButton}"
+                                FontFamily="{StaticResource AppFont}"
+                                FontSize="13"
+                                Width="24" Height="26" Padding="0"
+                                Margin="2,0"
+                                VerticalAlignment="Center"
+                                ToolTip="{DynamicResource S.Translation.SwapTip}"
+                                AutomationProperties.Name="{DynamicResource S.Translation.SwapTip}"
+                                Click="SwapBtn_Click"/>
 
                         <ComboBox x:Name="TgtLangBox"
                                   Style="{StaticResource QuietComboBox}"

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -227,16 +227,20 @@
                            VerticalAlignment="Center"
                            RenderOptions.BitmapScalingMode="HighQuality"/>
 
-                    <!-- The box and its placeholder share one cell, so the prompt sits exactly where
-                         the first character will land. -->
+                    <!-- The box, its placeholder and its clear button share one cell, so the prompt
+                         sits exactly where the first character will land and the button sits inside
+                         the field rather than beside it. -->
                     <Grid Grid.Column="1">
+                        <!-- The right padding is the clear button's room, and it is held whether or
+                             not the button is showing: reclaiming it on an empty box would slide
+                             every character sideways on the keystroke that empties it. -->
                         <TextBox x:Name="SourceTextBox"
                                  Style="{StaticResource ModernTextBox}"
                                  Background="Transparent"
                                  BorderBrush="Transparent"
                                  Height="34"
                                  FontSize="15"
-                                 Padding="8,0"
+                                 Padding="8,0,30,0"
                                  TextChanged="SourceTextBox_TextChanged"/>
 
                         <!-- Fainter than secondary text: this is a prompt standing in for content
@@ -251,6 +255,33 @@
                                    IsHitTestVisible="False"
                                    Margin="10,0,0,0"
                                    VerticalAlignment="Center"/>
+
+                        <!-- Only present when there is something to clear, the same rule 文字翻譯
+                             gives its own clear button: a button that cannot do anything should not
+                             be sitting in the field.
+
+                             Focusable="False" because the box behind it must keep the caret. The
+                             header draws the field filled only while it holds keyboard focus (see
+                             RenderChrome), so a button that took focus would blank the field's own
+                             background at the moment it is being used.
+
+                             Same glyph and size as 文字翻譯's, and deliberately not the 關閉 X in
+                             this header: two identical marks in one row, one clearing a word and
+                             one closing the window, is a slip waiting to happen. -->
+                        <Button x:Name="ClearBtn"
+                                Content="&#xE8BB;"
+                                FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                FontSize="9"
+                                Width="24" Height="24" Padding="0"
+                                Margin="0,0,5,0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                Style="{StaticResource IconButton}"
+                                Focusable="False"
+                                Visibility="Collapsed"
+                                ToolTip="{DynamicResource S.Translation.ClearSource}"
+                                AutomationProperties.Name="{DynamicResource S.Translation.ClearSource}"
+                                Click="ClearBtn_Click"/>
                     </Grid>
 
                     <Rectangle Grid.Column="2"

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -644,7 +644,8 @@ public partial class QuickLookupWindow : Window
     }
 
     /// <summary>
-    /// Settles the header's quiet controls against where the pointer is and whether it is pinned.
+    /// Settles the header against where the pointer is, whether it is pinned, and whether the box
+    /// has anything in it.
     /// </summary>
     /// <remarks>
     /// The pin is always on the header. It was faded in on hover while dragging was the main way to
@@ -671,9 +672,29 @@ public partial class QuickLookupWindow : Window
         SourceTextBox.SetResourceReference(
             BorderBrushProperty, showField ? "AppInputBorder" : "AppSurfaceBg");
 
-        Placeholder.Visibility = SourceTextBox.Text.Length == 0
-            ? Visibility.Visible
-            : Visibility.Collapsed;
+        var empty = SourceTextBox.Text.Length == 0;
+        Placeholder.Visibility = empty ? Visibility.Visible : Visibility.Collapsed;
+
+        // On the text alone, not on the pointer, unlike everything else this method settles. The
+        // controls above are chrome the user goes looking for; this one is the answer to a box that
+        // already has the wrong words in it, and it has to be there when they look down at it.
+        ClearBtn.Visibility = empty ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    /// <remarks>
+    /// Cleared through the selection rather than by assigning Text, so it lands on the TextBox's own
+    /// undo stack and Ctrl+Z puts the text back — the same reasoning as 文字翻譯's clear button, and
+    /// it applies harder here: the text this destroys is usually a selection the user carried in
+    /// from somewhere else, and retyping it means going back for it.
+    /// </remarks>
+    private void ClearBtn_Click(object sender, RoutedEventArgs e)
+    {
+        SourceTextBox.SelectAll();
+        SourceTextBox.SelectedText = "";
+
+        // They cleared it in order to type something else, and the button they clicked has just
+        // gone — without this they would have to click into the box before typing.
+        SourceTextBox.Focus();
     }
 
     // ══════════════════════════ Translating ══════════════════════════

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Interop;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using NLog;
+using OverTranslate.Layout;
 using OverTranslate.Models;
 using OverTranslate.Services;
 using OverTranslate.Views.Shell;
@@ -132,6 +133,17 @@ public partial class QuickLookupWindow : Window
 
     /// <summary>The button currently driving playback, so a second click stops rather than replays.</summary>
     private Button? _ttsActiveBtn;
+
+    /// <summary>
+    /// Where the popup belongs when nothing is holding it up, or null when nothing is.
+    /// </summary>
+    /// <remarks>
+    /// Physical pixels, because that is what <see cref="KeepBodyOnScreen"/> works in and what the
+    /// window was placed with. Null is the ordinary state and means "where it is now is where it
+    /// belongs"; anything that means the user has chosen a new place — a drag, a re-placement at the
+    /// pointer — sets it back to null rather than sending the popup somewhere they left.
+    /// </remarks>
+    private int? _restingTop;
 
     /// <summary>
     /// Brings the popup up over the foreground application, carrying whatever is selected there.
@@ -305,6 +317,11 @@ public partial class QuickLookupWindow : Window
             };
         }
 
+        // Every change of height, not just the result opening: the settings panel is a different
+        // height again, and a long enough original wraps the box onto a second line. All of them
+        // grow out of the bottom, so all of them can run off it.
+        SizeChanged += (_, e) => { if (e.HeightChanged) KeepBodyOnScreen(); };
+
         MouseEnter += OnPointerEnter;
         MouseLeave += OnPointerLeave;
         PreviewKeyDown += OnPreviewKeyDown;
@@ -382,6 +399,9 @@ public partial class QuickLookupWindow : Window
     /// </remarks>
     private void PositionAtPointer()
     {
+        // A fresh placement is a new resting place, and the old one is not somewhere to go back to.
+        _restingTop = null;
+
         var pointer = System.Windows.Forms.Cursor.Position;
         var area = System.Windows.Forms.Screen.FromPoint(pointer).WorkingArea;
         var scale = ScreenGeometry.ScaleAt(pointer.X, pointer.Y);
@@ -408,6 +428,38 @@ public partial class QuickLookupWindow : Window
         Surface.RenderTransformOrigin = new Point(
             Math.Clamp((pointer.X - x) / Math.Max(w, 1), 0, 1),
             Math.Clamp((pointer.Y - y) / Math.Max(h, 1), 0, 1));
+    }
+
+    /// <summary>
+    /// Lifts the popup off the bottom edge while the result is open, and puts it back after.
+    /// </summary>
+    /// <remarks>
+    /// The header is the whole window until a translation arrives, and the result grows out of the
+    /// bottom of it — <c>SizeToContent="Height"</c>, so the top stays put and the window gets taller.
+    /// A popup summoned or dragged near the foot of the screen therefore grows the answer straight
+    /// off the desktop: the user typed a word, something happened, and there is nothing to read.
+    ///
+    /// The arithmetic is <see cref="QuickLookupLift"/>'s, which is where it can be tested; this is
+    /// the half that has to ask Windows where the window and the monitor actually are.
+    ///
+    /// Physical pixels throughout, for the reason <see cref="PositionAtPointer"/> gives.
+    /// </remarks>
+    private void KeepBodyOnScreen()
+    {
+        if (_closing) return;
+
+        var bounds = ScreenGeometry.PhysicalBounds(this);
+        if (bounds.IsEmpty) return;
+
+        var area = System.Windows.Forms.Screen.FromRectangle(bounds).WorkingArea;
+        var edge = (int)Math.Round(4 * ScreenGeometry.ScaleAt(bounds.Left, bounds.Top));
+
+        var (top, resting) = QuickLookupLift.Place(
+            bounds.Top, _restingTop, bounds.Height, area.Top, area.Bottom, edge);
+
+        _restingTop = resting;
+
+        if (top != bounds.Top) ScreenGeometry.MoveToPhysical(this, bounds.Left, top);
     }
 
     /// <remarks>
@@ -632,6 +684,11 @@ public partial class QuickLookupWindow : Window
             // DragMove throws when the button is already up by the time it runs, which a fast click
             // can manage. There is nothing to move and nothing to report.
         }
+
+        // Wherever they let go is the resting place now. Keeping the old one would send the popup
+        // back to somewhere they had already moved it away from, the next time the result closed.
+        _restingTop = null;
+        KeepBodyOnScreen();
     }
 
     private void PinBtn_Click(object sender, RoutedEventArgs e) => SetPinned(!_pinned);

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -803,18 +803,25 @@ public partial class QuickLookupWindow : Window
         ShowResult();
     }
 
-    // ══════════════════════════ Reading aloud ══════════════════════════
-
     /// <summary>
-    /// The language 朗讀原文 would read in, or empty when there is not one yet.
+    /// What language the text in the box is actually in, or empty when nobody knows yet.
     /// </summary>
+    /// <remarks>
+    /// The picker's own value answers this except when it says 自動, which is its default and the
+    /// setting most people never touch — so on its own it is unknown most of the time. The engine's
+    /// answer is what fills that in, and the two callers are the two places where 自動 is not an
+    /// answer they can use: 朗讀原文 has to pick a voice, and <see cref="SwapBtn_Click"/> has to put
+    /// something on the target side.
+    /// </remarks>
     /// <inheritdoc cref="_detectedLang"/>
-    private string SourceVoiceLanguage()
+    private string EffectiveSourceLanguage()
     {
         var chosen = SrcLangBox.SelectedValue as string;
         if (!LanguageData.IsAutomaticSource(chosen)) return LanguageData.GetValidSourceCode(chosen);
         return _detectedLang;
     }
+
+    // ══════════════════════════ Reading aloud ══════════════════════════
 
     /// <summary>
     /// Settles 朗讀原文 against whether there is a language to read the original in.
@@ -838,7 +845,7 @@ public partial class QuickLookupWindow : Window
             LanguageData.IsAutomaticSource(SrcLangBox.SelectedValue as string);
 
         var available = !openAiAutomatic &&
-                        SourceVoiceLanguage().Length > 0 &&
+                        EffectiveSourceLanguage().Length > 0 &&
                         SourceTextBox.Text.Length > 0;
 
         SrcTtsBtn.IsEnabled = available;
@@ -854,7 +861,7 @@ public partial class QuickLookupWindow : Window
     }
 
     private async void SrcTtsBtn_Click(object sender, RoutedEventArgs e)
-        => await ToggleTtsAsync(SrcTtsBtn, SourceTextBox.Text, SourceVoiceLanguage());
+        => await ToggleTtsAsync(SrcTtsBtn, SourceTextBox.Text, EffectiveSourceLanguage());
 
     private async void TgtTtsBtn_Click(object sender, RoutedEventArgs e)
         => await ToggleTtsAsync(
@@ -1008,7 +1015,17 @@ public partial class QuickLookupWindow : Window
     private void LangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (_suppressAuto) return;
+        ApplyLanguagePair();
+    }
 
+    /// <summary>Saves the pair as the shared preference and re-translates under it.</summary>
+    /// <remarks>
+    /// Its own method because <see cref="SwapBtn_Click"/> moves both pickers and must not do this
+    /// twice: reading either half while the other has already moved would save a pair the user never
+    /// chose, and send a translation off under it.
+    /// </remarks>
+    private void ApplyLanguagePair()
+    {
         var settings = SettingsService.Instance.Current;
         settings.SourceLanguage = LanguageData.GetValidSourceCode(SrcLangBox.SelectedValue as string);
         settings.TargetLanguage = LanguageData.GetValidTargetCode(TgtLangBox.SelectedValue as string);
@@ -1018,6 +1035,74 @@ public partial class QuickLookupWindow : Window
         _detectedLang = "";
         RenderSourceTtsAvailability();
         RequestTranslate();
+    }
+
+    /// <summary>
+    /// Turns the pair around, carrying the translation back into the box as the new original.
+    /// </summary>
+    /// <remarks>
+    /// The languages alone would not be a swap here, which is where this parts company with
+    /// 截圖翻譯's toolbar button. There the source text is the screen and cannot move; here it is a
+    /// box with a word in it, and turning the pair around without turning the text around leaves the
+    /// popup translating 「hello」 out of 繁體中文 — a round trip through the wrong direction, which
+    /// is not what anybody presses this for. 文字翻譯 swaps both for the same reason.
+    ///
+    /// 自動 is the source language most of the time, and it cannot move to the target side: there is
+    /// no such thing as translating into "whatever". <see cref="EffectiveSourceLanguage"/> is what
+    /// makes the button work from there anyway — the engine has already said what the original was,
+    /// and that answer is what goes across.
+    /// </remarks>
+    private void SwapBtn_Click(object sender, RoutedEventArgs e)
+    {
+        // Both read before anything moves: the detected language describes the text that is about to
+        // stop being the original, and ApplyLanguagePair clears it.
+        var srcVal = EffectiveSourceLanguage();
+        var tgtVal = TgtLangBox.SelectedValue as string;
+
+        _suppressAuto = true;
+
+        if (TranslatedText.Text.Length > 0)
+        {
+            var wasOriginal = SourceTextBox.Text;
+
+            // Through the selection, so Ctrl+Z puts the original back — the same reason 清除 does it
+            // that way, and the same text at stake: usually something carried in from another window.
+            SourceTextBox.SelectAll();
+            SourceTextBox.SelectedText = TranslatedText.Text;
+
+            // Shown flipped now rather than left saying the old thing until the round trip lands.
+            // Translating a translation back gives the text it came from, so this already is the
+            // answer; waiting for the engine to agree would just read as lag.
+            TranslatedText.Text = wasOriginal;
+        }
+
+        // Anything already in flight was asked under the old pair and would overwrite both.
+        _seq++;
+
+        // Target → source. ZH-HANT has to stay traditional rather than collapse to ZH, which is what
+        // the mapping is for.
+        if (tgtVal != null)
+        {
+            SrcLangBox.SelectedValue = LanguageData.MapTargetToSourceCode(tgtVal);
+            if (SrcLangBox.SelectedValue == null) SrcLangBox.SelectedIndex = 0;
+        }
+
+        // Source → target. With 自動 and nothing detected — an empty box, or an engine that has not
+        // answered — there is nothing to carry across, and English is the fallback: it is what most
+        // of what people point this at is written in, and it is one click to correct.
+        TgtLangBox.SelectedValue = LanguageData.MapSourceToTargetCode(
+            srcVal.Length > 0 ? srcVal : "EN");
+        if (TgtLangBox.SelectedValue == null) TgtLangBox.SelectedIndex = 0;
+
+        _suppressAuto = false;
+
+        ApplyLanguagePair();
+
+        // The box holds text the user may well want to edit now, and the click left the caret on a
+        // button. Caret after Focus, which selects the whole box on its own when focus arrives
+        // programmatically — see Refill.
+        SourceTextBox.Focus();
+        SourceTextBox.CaretIndex = SourceTextBox.Text.Length;
     }
 
     private void ProviderBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -93,10 +93,14 @@ public partial class QuickLookupWindow : Window
 
     /// <summary>True while the popup is pinned, which is what keeps it through a deactivation.</summary>
     /// <remarks>
-    /// Per window and stored nowhere. Pinning answers "keep this one on screen while I work", which
-    /// is a statement about the popup in front of the user right now — a remembered pin would mean
-    /// every later summon opened a window that never goes away, which is the opposite of what this
-    /// feature is.
+    /// Pinning answers "keep this one on screen while I work". Everything it holds against is the
+    /// popup acting on its own — closing itself when attention moves, moving itself to the pointer
+    /// on the next summon — and nothing it holds against is the user: a pinned popup still drags,
+    /// and the close button still closes it.
+    ///
+    /// Per window and stored nowhere, because it is a statement about the popup in front of the
+    /// user right now. What sets it on the way in is which door was used, not what was set last
+    /// time — see <see cref="SummonAsync"/>.
     /// </remarks>
     private bool _pinned;
 
@@ -139,19 +143,39 @@ public partial class QuickLookupWindow : Window
     /// An already-open popup is refilled rather than replaced, so pressing the shortcut twice does
     /// not throw away a pin or a position the user has set.
     /// </remarks>
-    public static async Task SummonAsync()
+    /// <param name="pinned">
+    /// Whether to open the popup already pinned, which is how the two doors differ.
+    /// <para>
+    /// The shortcut is used mid-sentence, on a word, and the popup that answers it is meant to be
+    /// glanced at and gone — dismissing itself is the whole of why it costs nothing to press. The
+    /// entry on the main window is the opposite errand: the user went looking for the feature and
+    /// clicked it, and a window that disappeared while they were still turning back to their text
+    /// would look broken to someone who has not yet met the shortcut.
+    /// </para>
+    /// <para>
+    /// It only ever turns the pin on. Off is the user's word, and a shortcut press landing on a
+    /// popup they pinned must not quietly take that back.
+    /// </para>
+    /// </param>
+    public static async Task SummonAsync(bool pinned = false)
     {
         var selection = await SelectedTextReader.ReadAsync();
 
         if (_current is { _closing: false } open)
         {
             open.Refill(selection);
+            if (pinned) open.SetPinned(true);
             open.ReacquireForeground();
             return;
         }
 
         var window = new QuickLookupWindow();
         _current = window;
+
+        // Before Show: showing a window can hand activation straight back, and OnDeactivated closes
+        // an unpinned popup without asking how old it is.
+        if (pinned) window.SetPinned(true);
+
         window.Show();
         window.ReacquireForeground();
         window.Refill(selection);
@@ -591,15 +615,14 @@ public partial class QuickLookupWindow : Window
     /// want it to stay there — but the pin is on the header at all times now, so the guess buys
     /// nothing, and a window that pins itself is one the user has to notice and undo.
     ///
-    /// The relationship runs the other way instead: pinning stops the dragging.
+    /// Pinning does not stop dragging either, which it briefly did. A pinned popup is the one the
+    /// user is going to keep for a while, so it is the one they most need to move out of the way of
+    /// what they are reading — locking it in place took that away from exactly the case that wanted
+    /// it. What the pin holds against is the popup moving on its own, which is a different thing
+    /// from the user moving it: see <see cref="Refill"/>.
     /// </remarks>
     private void Surface_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
-        // Pinning fixes the window where it is, so it also takes dragging away: the same pin already
-        // stops a later summon from moving the popup to the pointer, and a pin that held against one
-        // way of moving it but not the other would mean two different things.
-        if (_pinned) return;
-
         try
         {
             DragMove();
@@ -611,9 +634,12 @@ public partial class QuickLookupWindow : Window
         }
     }
 
-    private void PinBtn_Click(object sender, RoutedEventArgs e)
+    private void PinBtn_Click(object sender, RoutedEventArgs e) => SetPinned(!_pinned);
+
+    /// <summary>Sets the pin and redraws the header, which is the only thing that reports it.</summary>
+    private void SetPinned(bool pinned)
     {
-        _pinned = !_pinned;
+        _pinned = pinned;
         RenderChrome();
     }
 

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -55,6 +55,18 @@ public partial class QuickLookupWindow : Window
     private const int BodyMs  = 150;
 
     /// <summary>
+    /// The transparent band above and below the card, in DIP.
+    /// </summary>
+    /// <remarks>
+    /// These are the top and bottom of the shadow margin on the root Grid — <c>Margin="26,24,26,30"</c>
+    /// in the XAML, which says why it is there. They have to be kept in step with it: they are what
+    /// <see cref="KeepBodyOnScreen"/> subtracts to find the card inside the window, and a stale value
+    /// would put the card that far off the edge it was told to sit against.
+    /// </remarks>
+    private const double ShadowMarginTop    = 24;
+    private const double ShadowMarginBottom = 30;
+
+    /// <summary>
     /// How often Windows is asked which window is actually in front.
     /// </summary>
     /// <remarks>
@@ -317,9 +329,12 @@ public partial class QuickLookupWindow : Window
             };
         }
 
-        // Every change of height, not just the result opening: the settings panel is a different
-        // height again, and a long enough original wraps the box onto a second line. All of them
-        // grow out of the bottom, so all of them can run off it.
+        // The mop-up half of the lift. OnWindowPosChanging does the work, and does it atomically,
+        // but the height it is offered is the one Windows is about to apply and that is occasionally
+        // a pixel or two short of where the resize settles — enough to leave the bottom row of the
+        // card over the edge. By here the resize has landed and the window can be asked how tall it
+        // really is. A correction this small is not a movement anybody sees; the lift it is
+        // correcting already happened in the same frame as the resize.
         SizeChanged += (_, e) => { if (e.HeightChanged) KeepBodyOnScreen(); };
 
         MouseEnter += OnPointerEnter;
@@ -430,6 +445,17 @@ public partial class QuickLookupWindow : Window
             Math.Clamp((pointer.Y - y) / Math.Max(h, 1), 0, 1));
     }
 
+    /// <remarks>
+    /// The handle is what the message hook needs, and this is the first moment there is one.
+    /// </remarks>
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+
+        if (PresentationSource.FromVisual(this) is HwndSource source)
+            source.AddHook(OnWindowPosChanging);
+    }
+
     /// <summary>
     /// Lifts the popup off the bottom edge while the result is open, and puts it back after.
     /// </summary>
@@ -439,10 +465,78 @@ public partial class QuickLookupWindow : Window
     /// A popup summoned or dragged near the foot of the screen therefore grows the answer straight
     /// off the desktop: the user typed a word, something happened, and there is nothing to read.
     ///
+    /// Caught on the way in, in <c>WM_WINDOWPOSCHANGING</c>, rather than answered afterwards from
+    /// <c>SizeChanged</c>. Two reasons, and the first is that afterwards does not work: WPF resizes
+    /// the HWND after the layout pass, so a handler that asked Windows how tall the window was would
+    /// be told the height it had a moment ago, wave the grow through, and only catch it on some
+    /// later pass — the window visibly drops off the bottom of the screen and is then yanked back.
+    /// The second is that this is one operation instead of two: Windows is already about to move and
+    /// size this window, and editing the rectangle it is going to use means there is never a frame
+    /// where the popup has grown but not yet moved.
+    ///
     /// The arithmetic is <see cref="QuickLookupLift"/>'s, which is where it can be tested; this is
     /// the half that has to ask Windows where the window and the monitor actually are.
     ///
-    /// Physical pixels throughout, for the reason <see cref="PositionAtPointer"/> gives.
+    /// Physical pixels throughout — which is what <c>WINDOWPOS</c> is already in, for the reason
+    /// <see cref="PositionAtPointer"/> gives.
+    /// </remarks>
+    private IntPtr OnWindowPosChanging(
+        IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        if (msg != WmWindowPosChanging || _closing) return IntPtr.Zero;
+
+        var pos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
+
+        // Nothing to catch when the height is not changing: our own corrections come through here
+        // as pure moves, and answering them would be a loop.
+        if ((pos.flags & SwpNoSize) != 0) return IntPtr.Zero;
+
+        var bounds = ScreenGeometry.PhysicalBounds(this);
+        if (bounds.IsEmpty) return IntPtr.Zero;
+
+        // x and y are undefined when the caller said not to move, so the window's own position is
+        // what the new height has to be judged against.
+        var moving = (pos.flags & SwpNoMove) == 0;
+        var left = moving ? pos.x : bounds.Left;
+        var top  = moving ? pos.y : bounds.Top;
+
+        // A drag arrives here as a move that carries the size along with it, one message per step,
+        // and pos.y is where the drag wants the window rather than where it has been allowed to sit.
+        // That is the definition of the resting place, so each step replaces it: without this, the
+        // first step that overflowed would be remembered as home and the rest of the drag ignored.
+        if (moving) _restingTop = null;
+
+        var area = System.Windows.Forms.Screen.FromRectangle(bounds).WorkingArea;
+        var scale = ScreenGeometry.ScaleAt(left, top);
+
+        // The card may go all the way to the edge; the window may go further, because the last
+        // ShadowMargin* pixels of it are the transparent border the shadow fades out into. Holding
+        // the window itself inside the work area would keep the card that much clear of the bottom
+        // of every screen, which is a band of empty desktop under a popup for no stated reason.
+        var (wanted, resting) = QuickLookupLift.Place(
+            top,
+            _restingTop,
+            pos.cy,
+            area.Top - (int)Math.Round(ShadowMarginTop * scale),
+            area.Bottom + (int)Math.Round(ShadowMarginBottom * scale));
+
+        _restingTop = resting;
+
+        if (wanted == top) return IntPtr.Zero;
+
+        pos.x = left;
+        pos.y = wanted;
+        pos.flags &= ~SwpNoMove;
+        Marshal.StructureToPtr(pos, lParam, fDeleteOld: false);
+
+        return IntPtr.Zero;
+    }
+
+    /// <summary>Re-checks the fit after something moved the window without resizing it.</summary>
+    /// <remarks>
+    /// <see cref="OnWindowPosChanging"/> only hears about resizes, and a drag is not one. Reading
+    /// the height back from the window is safe here for the same reason it is wrong there: nothing
+    /// is in flight, so what Windows reports is what is on the screen.
     /// </remarks>
     private void KeepBodyOnScreen()
     {
@@ -452,14 +546,34 @@ public partial class QuickLookupWindow : Window
         if (bounds.IsEmpty) return;
 
         var area = System.Windows.Forms.Screen.FromRectangle(bounds).WorkingArea;
-        var edge = (int)Math.Round(4 * ScreenGeometry.ScaleAt(bounds.Left, bounds.Top));
+        var scale = ScreenGeometry.ScaleAt(bounds.Left, bounds.Top);
 
         var (top, resting) = QuickLookupLift.Place(
-            bounds.Top, _restingTop, bounds.Height, area.Top, area.Bottom, edge);
+            bounds.Top,
+            _restingTop,
+            bounds.Height,
+            area.Top - (int)Math.Round(ShadowMarginTop * scale),
+            area.Bottom + (int)Math.Round(ShadowMarginBottom * scale));
 
         _restingTop = resting;
 
         if (top != bounds.Top) ScreenGeometry.MoveToPhysical(this, bounds.Left, top);
+    }
+
+    private const int WmWindowPosChanging = 0x0046;
+    private const uint SwpNoSize = 0x0001;
+    private const uint SwpNoMove = 0x0002;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct WINDOWPOS
+    {
+        public IntPtr hwnd;
+        public IntPtr hwndInsertAfter;
+        public int x;
+        public int y;
+        public int cx;
+        public int cy;
+        public uint flags;
     }
 
     /// <remarks>
@@ -685,10 +799,9 @@ public partial class QuickLookupWindow : Window
             // can manage. There is nothing to move and nothing to report.
         }
 
-        // Wherever they let go is the resting place now. Keeping the old one would send the popup
-        // back to somewhere they had already moved it away from, the next time the result closed.
-        _restingTop = null;
-        KeepBodyOnScreen();
+        // Nothing to do afterwards. Windows sends the drag through OnWindowPosChanging step by step,
+        // so the popup has been kept on screen the whole way down and the place they let go of it is
+        // already recorded. Resetting anything here would throw that away.
     }
 
     private void PinBtn_Click(object sender, RoutedEventArgs e) => SetPinned(!_pinned);

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml
@@ -129,8 +129,9 @@
                                  than behind a hover: a tooltip on a disabled control is found only
                                  by someone who already suspects there is something to find. Fills
                                  the row's spare width and is right-aligned against the buttons, so
-                                 the header's height never changes and nothing moves when the source
-                                 language does. Trims rather than pushes when the pane is narrow.
+                                 the header's height never changes and nothing moves when the engine
+                                 or the source language does. Trims rather than pushes when the pane
+                                 is narrow.
 
                                  The same font size as the 原文 label beside it, and that is the
                                  point rather than an accident. At 11 against the label's 12 both
@@ -143,8 +144,8 @@
                             <!-- Colour: AppTextSecondary rather than AppError, because nothing has
                                  gone wrong — a mode simply cannot do a thing. An alarm colour in a
                                  header that is on screen for the whole session would be shouting. -->
-                            <TextBlock x:Name="SrcAutoTtsNote"
-                                       Text="{DynamicResource S.Translation.SpeakSourceAutomaticShort}"
+                            <TextBlock x:Name="SrcTtsNote"
+                                       Text="{DynamicResource S.Translation.SpeakSourceOpenAiShort}"
                                        FontFamily="{StaticResource AppFont}"
                                        FontSize="12"
                                        Foreground="{DynamicResource AppTextSecondary}"

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml
@@ -8,6 +8,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- ── Page header ── -->
@@ -85,7 +86,13 @@
                              where E711 and the rest of the ✕ glyphs come in 0.41px high. The sizes
                              differ only to make the two inks the same height (11.00 against 10.96);
                              neither affects the alignment. -->
-                        <DockPanel VerticalAlignment="Center">
+                        <!-- LastChildFill="False" because there is no longer a child meant to take
+                             the middle. A DockPanel hands the leftover width to its last child
+                             whatever that child asked for, so with the note gone the clear button
+                             inherited the gap and centred itself in it, adrift from the speaker it
+                             belongs beside. The 譯文 header opposite still fills, and should: its
+                             last child is the label, which is what the space there is for. -->
+                        <DockPanel VerticalAlignment="Center" LastChildFill="False">
                             <TextBlock DockPanel.Dock="Left"
                                        Text="{DynamicResource S.Translation.Source}"
                                        FontFamily="{StaticResource AppFont}"
@@ -125,35 +132,12 @@
                                     AutomationProperties.Name="{DynamicResource S.Translation.ClearSource}"
                                     Click="SrcClearBtn_Click"/>
 
-                            <!-- Why the speaker is greyed, said where the greyed button is rather
-                                 than behind a hover: a tooltip on a disabled control is found only
-                                 by someone who already suspects there is something to find. Fills
-                                 the row's spare width and is right-aligned against the buttons, so
-                                 the header's height never changes and nothing moves when the engine
-                                 or the source language does. Trims rather than pushes when the pane
-                                 is narrow.
-
-                                 The same font size as the 原文 label beside it, and that is the
-                                 point rather than an accident. At 11 against the label's 12 both
-                                 were centred to within 0.02px and it still read as sitting low:
-                                 centring two different sizes separately puts their baselines half a
-                                 pixel apart, and the eye lines text up by its baseline, so the
-                                 shorter one looks dropped. Matching the size makes the baselines
-                                 identical by construction; the hierarchy is carried by weight
-                                 instead, which the label already had. -->
-                            <!-- Colour: AppTextSecondary rather than AppError, because nothing has
-                                 gone wrong — a mode simply cannot do a thing. An alarm colour in a
-                                 header that is on screen for the whole session would be shouting. -->
-                            <TextBlock x:Name="SrcTtsNote"
-                                       Text="{DynamicResource S.Translation.SpeakSourceOpenAiShort}"
-                                       FontFamily="{StaticResource AppFont}"
-                                       FontSize="12"
-                                       Foreground="{DynamicResource AppTextSecondary}"
-                                       HorizontalAlignment="Right"
-                                       VerticalAlignment="Center"
-                                       Margin="10,0,8,0"
-                                       TextTrimming="CharacterEllipsis"
-                                       Visibility="Collapsed"/>
+                            <!-- The 原文 label used to share this row with a note explaining the
+                                 greyed speaker. It has moved to the foot of the page: a short
+                                 sentence squeezed between the label and the buttons had to be cut
+                                 down to fit, and the cut-down version named the rule without saying
+                                 what to do about it. The full sentence is downstairs now, where
+                                 there is room for it. -->
                         </DockPanel>
                     </Border>
                     <TextBox Grid.Row="1"
@@ -242,5 +226,40 @@
                        FontSize="12"
                        Foreground="{DynamicResource AppTextSecondary}"/>
         </DockPanel>
+
+        <!-- Why 朗讀原文 is greyed, and only in the one state that earns saying it: OpenAI-compatible
+             servers are never asked what language the original was in — the prompt they are sent
+             belongs to the user and cannot carry a second answer — so with 自動 there is no voice to
+             read it in and there never will be. Every other engine answers as a by-product of
+             translating, which is a wait rather than a wall and needs no note.
+
+             A row of its own below the footer rather than a share of it: this stays for as long as
+             the engine and the source language do, while the status line beside it comes and goes
+             with each translation, and a permanent sentence that kept resizing around a transient
+             one would read as unstable. Auto height, so it costs nothing when it is not there.
+
+             The same wording and the same ⓘ as 取詞翻譯's, because it is the same rule and someone
+             who has met it once should recognise it rather than have to read it again.
+
+             AppTextSecondary rather than AppError: nothing has gone wrong, a combination simply
+             cannot do a thing. An alarm colour on a line that is on screen for the whole session
+             would be shouting. -->
+        <StackPanel Grid.Row="4"
+                    x:Name="SrcTtsNote"
+                    Orientation="Horizontal"
+                    Margin="0,10,0,0"
+                    Visibility="Collapsed">
+            <TextBlock Text="&#xE946;"
+                       FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                       FontSize="11"
+                       Foreground="{DynamicResource AppTextSecondary}"
+                       VerticalAlignment="Center"
+                       Margin="0,0,6,0"/>
+            <TextBlock Text="{DynamicResource S.Translation.SpeakSourceOpenAi}"
+                       Style="{StaticResource FieldHint}"
+                       Margin="0"
+                       TextWrapping="Wrap"
+                       VerticalAlignment="Center"/>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml
@@ -8,7 +8,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- ── Page header ── -->
@@ -217,6 +216,43 @@
                     Visibility="Collapsed"
                     Margin="0,0,12,0"
                     Click="RetryBtn_Click"/>
+
+            <!-- Why 朗讀原文 is greyed, and only in the one state that earns saying it:
+                 OpenAI-compatible servers are never asked what language the original was in — the
+                 prompt they are sent belongs to the user and cannot carry a second answer — so with
+                 自動 there is no voice to read it in and there never will be. Every other engine
+                 answers as a by-product of translating, which is a wait rather than a wall and needs
+                 no note.
+
+                 The same line as the status text, not a row of its own. This line is empty almost
+                 all of the time, so the note lives in it rather than adding height the page has to
+                 keep whether or not anything is being said — see RenderFooter for which of the two
+                 wins when both have something.
+
+                 The same wording and the same ⓘ as 取詞翻譯's, because it is the same rule and
+                 someone who has met it once should recognise it rather than read it again.
+
+                 AppTextSecondary rather than AppError: nothing has gone wrong, a combination simply
+                 cannot do a thing. An alarm colour on a line that is on screen for the whole session
+                 would be shouting. -->
+            <StackPanel x:Name="SrcTtsNote"
+                        DockPanel.Dock="Left"
+                        Orientation="Horizontal"
+                        VerticalAlignment="Center"
+                        Visibility="Collapsed">
+                <TextBlock Text="&#xE946;"
+                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                           FontSize="11"
+                           Foreground="{DynamicResource AppTextSecondary}"
+                           VerticalAlignment="Center"
+                           Margin="0,0,6,0"/>
+                <TextBlock Text="{DynamicResource S.Translation.SpeakSourceOpenAi}"
+                           Style="{StaticResource FieldHint}"
+                           Margin="0"
+                           TextWrapping="Wrap"
+                           VerticalAlignment="Center"/>
+            </StackPanel>
+
             <!-- Wraps so a long engine error keeps its second line inside the window
                  instead of being clipped at the right edge. -->
             <TextBlock x:Name="StatusText"
@@ -226,40 +262,5 @@
                        FontSize="12"
                        Foreground="{DynamicResource AppTextSecondary}"/>
         </DockPanel>
-
-        <!-- Why 朗讀原文 is greyed, and only in the one state that earns saying it: OpenAI-compatible
-             servers are never asked what language the original was in — the prompt they are sent
-             belongs to the user and cannot carry a second answer — so with 自動 there is no voice to
-             read it in and there never will be. Every other engine answers as a by-product of
-             translating, which is a wait rather than a wall and needs no note.
-
-             A row of its own below the footer rather than a share of it: this stays for as long as
-             the engine and the source language do, while the status line beside it comes and goes
-             with each translation, and a permanent sentence that kept resizing around a transient
-             one would read as unstable. Auto height, so it costs nothing when it is not there.
-
-             The same wording and the same ⓘ as 取詞翻譯's, because it is the same rule and someone
-             who has met it once should recognise it rather than have to read it again.
-
-             AppTextSecondary rather than AppError: nothing has gone wrong, a combination simply
-             cannot do a thing. An alarm colour on a line that is on screen for the whole session
-             would be shouting. -->
-        <StackPanel Grid.Row="4"
-                    x:Name="SrcTtsNote"
-                    Orientation="Horizontal"
-                    Margin="0,10,0,0"
-                    Visibility="Collapsed">
-            <TextBlock Text="&#xE946;"
-                       FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                       FontSize="11"
-                       Foreground="{DynamicResource AppTextSecondary}"
-                       VerticalAlignment="Center"
-                       Margin="0,0,6,0"/>
-            <TextBlock Text="{DynamicResource S.Translation.SpeakSourceOpenAi}"
-                       Style="{StaticResource FieldHint}"
-                       Margin="0"
-                       TextWrapping="Wrap"
-                       VerticalAlignment="Center"/>
-        </StackPanel>
     </Grid>
 </UserControl>

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -44,6 +44,15 @@ public partial class TranslationPage : UserControl
     /// </remarks>
     private string _detectedLang = "";
 
+    /// <summary>True while the engine and source language are the pair that has no voice coming.</summary>
+    /// <remarks>
+    /// Kept rather than recomputed, because the footer is settled from two directions: this is
+    /// decided by <see cref="RenderSourceActions"/>, and the line it has to share is written by
+    /// <see cref="SetStatus"/> and <see cref="SetTranslating"/>, neither of which has any business
+    /// working out which engine is selected.
+    /// </remarks>
+    private bool _srcTtsBlocked;
+
     public TranslationPage()
     {
         InitializeComponent();
@@ -122,7 +131,8 @@ public partial class TranslationPage : UserControl
         //
         // Only for the state that stays: an engine that simply has not answered yet is a second or
         // two, and a note appearing and going again on its own is noise rather than information.
-        SrcTtsNote.Visibility = openAiAutomatic ? Visibility.Visible : Visibility.Collapsed;
+        _srcTtsBlocked = openAiAutomatic;
+        RenderFooter();
 
         // Read through the service rather than bound with DynamicResource, because which string
         // applies is a state and not a constant. Re-read on Reload, which is where a change of
@@ -381,6 +391,11 @@ public partial class TranslationPage : UserControl
         {
             StatusText.Text       = LocalizationService.Get("S.Translation.Translating");
             StatusText.Foreground = (System.Windows.Media.Brush)FindResource("AppAccent");
+
+            // 翻譯中 has taken the footer, so whatever was sharing it steps aside. Only on the way
+            // in: switching off leaves the text for the caller to clear or replace, which is where
+            // the note gets its line back.
+            RenderFooter();
         }
     }
 
@@ -463,6 +478,29 @@ public partial class TranslationPage : UserControl
         StatusText.Foreground = isError
             ? (System.Windows.Media.Brush)FindResource("AppError")
             : (System.Windows.Media.Brush)FindResource("AppTextSecondary");
+
+        RenderFooter();
+    }
+
+    /// <summary>
+    /// Settles the single line at the foot of the page, which two things want.
+    /// </summary>
+    /// <remarks>
+    /// The status text wins whenever it has anything to say. It is the answer to what the user just
+    /// did — a translation running, an engine that failed — and it is gone again a moment later,
+    /// while the note is a standing condition that will still be true once it goes. Covering the
+    /// note for those few seconds costs nothing; making the reader find the status somewhere else,
+    /// or read the two side by side, costs them the thing they were waiting for.
+    ///
+    /// One line rather than two rows, because the status line is empty almost all of the time. A row
+    /// of its own would have the page grow the moment somebody picks OpenAI and shuffle again on
+    /// every translation, which is movement in return for nothing.
+    /// </remarks>
+    private void RenderFooter()
+    {
+        SrcTtsNote.Visibility = _srcTtsBlocked && StatusText.Text.Length == 0
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     private void InitializeSelectors(string sourceLang, string targetLang)

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -116,7 +116,7 @@ public partial class TranslationPage : UserControl
 
         SrcTtsBtn.IsEnabled = available;
 
-        // The note is what tells the user; the tooltip is the longer sentence for whoever hovers.
+        // The note at the foot of the page says the same sentence the greyed speaker's tooltip does.
         // A tooltip alone would have been found only by someone who already suspected there was
         // something to find, which is the wrong bar for the one explanation that exists.
         //

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -33,6 +33,17 @@ public partial class TranslationPage : UserControl
     // The TTS button currently driving playback (so a second click stops instead of replaying).
     private Button? _ttsActiveBtn;
 
+    /// <summary>
+    /// The language the engine said the source was in, or empty.
+    /// </summary>
+    /// <remarks>
+    /// 自動 is the default source language and the one most people never change, so without this the
+    /// page does not know what it is looking at most of the time — which is why 朗讀原文 used to be
+    /// switched off outright there. Every engine but one answers the question as a by-product of
+    /// translating, and its answer is a better one than the picker can give.
+    /// </remarks>
+    private string _detectedLang = "";
+
     public TranslationPage()
     {
         InitializeComponent();
@@ -66,12 +77,17 @@ public partial class TranslationPage : UserControl
     /// otherwise move under the pointer of anyone reaching for it — and so the two panes' speakers
     /// stay on the same line across the divider.</para>
     ///
-    /// <para><b>Speak</b> is switched off while the source language is 自動, because there is no
-    /// such thing as an automatic voice: <see cref="TtsService"/> maps 自動 onto Chinese, so English
-    /// or Japanese source text is read aloud in a Chinese voice. That used to happen silently, and
-    /// the user was left to work out from the sound that a language picker three controls away was
-    /// the cause. Disabled with the reason one hover away says the same thing before it is heard.
-    /// </para>
+    /// <para><b>Speak</b> needs a language to read in, because there is no such thing as an
+    /// automatic voice: <see cref="TtsService"/> maps 自動 onto Chinese, so English or Japanese
+    /// source text would be read aloud in a Chinese voice. That used to happen silently, and the
+    /// user was left to work out from the sound that a language picker three controls away was the
+    /// cause.</para>
+    ///
+    /// <para>It used to be refused for the whole of 自動, which is the default and the setting most
+    /// people never touch — so the button was off almost always, including for everyone whose engine
+    /// had already said what the text was. It is the answer that decides now, not the picker:
+    /// <see cref="EffectiveSourceLanguage"/>. What is left refused is the one case where no answer
+    /// is ever coming, and the note names it rather than making anyone wait to find out.</para>
     ///
     /// <para>Not extended to "no text yet", which would also be a button that can do nothing: that
     /// state lasts a keystroke, and a speaker that greys out every time the box empties reads as
@@ -83,24 +99,55 @@ public partial class TranslationPage : UserControl
             ? Visibility.Visible
             : Visibility.Collapsed;
 
-        var automatic = LanguageData.IsAutomaticSource(SrcLangBox.SelectedValue as string);
+        // The one state that never resolves, and the only one left that has to be refused outright.
+        // Every other engine says what language the original was in as a by-product of translating,
+        // so 自動 is a state the next result gets the page out of; an OpenAI-compatible server is
+        // never asked, and cannot be — the prompt it is sent belongs to the user, so the reply
+        // cannot be made to carry a second field. Waiting is not going to help there.
+        var openAiAutomatic =
+            SettingsService.Instance.Current.Provider == TranslationProvider.OpenAI &&
+            LanguageData.IsAutomaticSource(SrcLangBox.SelectedValue as string);
 
-        // Switching to 自動 mid-sentence would otherwise leave the source playing with no way to
+        var available = !openAiAutomatic && EffectiveSourceLanguage().Length > 0;
+
+        // Losing the language mid-sentence would otherwise leave the source playing with no way to
         // stop it, since the button that stops it is the one being disabled.
-        if (automatic && ReferenceEquals(_ttsActiveBtn, SrcTtsBtn)) _tts.Stop();
+        if (!available && ReferenceEquals(_ttsActiveBtn, SrcTtsBtn)) _tts.Stop();
 
-        SrcTtsBtn.IsEnabled = !automatic;
+        SrcTtsBtn.IsEnabled = available;
 
         // The note is what tells the user; the tooltip is the longer sentence for whoever hovers.
         // A tooltip alone would have been found only by someone who already suspected there was
         // something to find, which is the wrong bar for the one explanation that exists.
-        SrcAutoTtsNote.Visibility = automatic ? Visibility.Visible : Visibility.Collapsed;
+        //
+        // Only for the state that stays: an engine that simply has not answered yet is a second or
+        // two, and a note appearing and going again on its own is noise rather than information.
+        SrcTtsNote.Visibility = openAiAutomatic ? Visibility.Visible : Visibility.Collapsed;
 
-        // Read through the service rather than bound with DynamicResource, because which of the two
-        // strings applies is a state and not a constant. Re-read on Reload, which is where a change
-        // of interface language arrives.
+        // Read through the service rather than bound with DynamicResource, because which string
+        // applies is a state and not a constant. Re-read on Reload, which is where a change of
+        // interface language arrives.
         SrcTtsBtn.ToolTip = LocalizationService.Get(
-            automatic ? "S.Translation.SpeakSourceAutomatic" : "S.Translation.SpeakSource");
+            available ? "S.Translation.SpeakSource"
+            : openAiAutomatic ? "S.Translation.SpeakSourceOpenAi"
+            : "S.Translation.SpeakSourceUnknown");
+    }
+
+    /// <summary>
+    /// What language the source text is actually in, or empty when nobody knows yet.
+    /// </summary>
+    /// <remarks>
+    /// The picker's own value answers this except when it says 自動, and that is where
+    /// <see cref="_detectedLang"/> takes over. The two callers are the two places 自動 is not an
+    /// answer they can use: 朗讀原文 has to pick a voice, and <see cref="SwapBtn_Click"/> has to put
+    /// something on the target side.
+    /// </remarks>
+    /// <inheritdoc cref="_detectedLang"/>
+    private string EffectiveSourceLanguage()
+    {
+        var chosen = SrcLangBox.SelectedValue as string;
+        if (!LanguageData.IsAutomaticSource(chosen)) return LanguageData.GetValidSourceCode(chosen);
+        return _detectedLang;
     }
 
     /// <remarks>
@@ -165,10 +212,16 @@ public partial class TranslationPage : UserControl
     private void SrcLangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (!_reloadingPreferences) SaveCurrentLanguageSelection();
+
+        // The engine was asked about a pair that is no longer the one on screen.
+        _detectedLang = "";
         RenderSourceActions();
         RequestTranslate();
     }
 
+    // The target says nothing about what the source text is, so the detected language survives it.
+    // Clearing it here would grey 朗讀原文 out and back for every change of target under 自動, which
+    // is flicker rather than information — the same reason "no text yet" is not a state either.
     private void TgtLangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (!_reloadingPreferences) SaveCurrentLanguageSelection();
@@ -179,6 +232,11 @@ public partial class TranslationPage : UserControl
     {
         if (ProviderBox.SelectedValue is not TranslationProvider provider) return;
         if (!_reloadingPreferences) SaveProviderSelection(provider);
+
+        // The answer belongs to the engine that gave it, and the new one may not answer at all —
+        // which is the whole of what RenderSourceActions has to settle here.
+        _detectedLang = "";
+        RenderSourceActions();
         RequestTranslate();
     }
 
@@ -204,9 +262,19 @@ public partial class TranslationPage : UserControl
         _debounce.Start();
     }
 
+    /// <remarks>
+    /// 自動 cannot move to the target side — there is no such thing as translating into "whatever" —
+    /// and it is the source language most of the time, so read through
+    /// <see cref="EffectiveSourceLanguage"/>: the engine has already said what the original was, and
+    /// that answer is what goes across. Without it this button read the picker's literal 自動, found
+    /// nothing to map, and fell to the first entry in the list, which is right for English text and
+    /// wrong for everything else.
+    /// </remarks>
     private void SwapBtn_Click(object sender, RoutedEventArgs e)
     {
-        var srcVal = SrcLangBox.SelectedValue as string;
+        // Before anything moves: the detected language describes the text that is about to stop
+        // being the original, and the picker changes below clear it.
+        var srcVal = EffectiveSourceLanguage();
         var tgtVal = TgtLangBox.SelectedValue as string;
 
         // Swap texts programmatically (suppressed); the language changes below trigger one re-translate
@@ -222,12 +290,11 @@ public partial class TranslationPage : UserControl
             if (SrcLangBox.SelectedValue == null) SrcLangBox.SelectedIndex = 0;
         }
 
-        // Swap source → target using explicit language mapping
-        if (srcVal != null)
-        {
-            var targetCode = LanguageData.MapSourceToTargetCode(srcVal);
-            TgtLangBox.SelectedValue = targetCode;
-        }
+        // Swap source → target. With 自動 and nothing detected — an empty box, or an engine that has
+        // not answered — there is nothing to carry across, and English is the fallback: it is what
+        // most of what people paste in is written in, and it is one click to correct.
+        TgtLangBox.SelectedValue = LanguageData.MapSourceToTargetCode(
+            srcVal.Length > 0 ? srcVal : "EN");
         if (TgtLangBox.SelectedValue == null) TgtLangBox.SelectedIndex = 0;
 
         RequestTranslate(); // ensure the swapped direction is translated even if a language was unchanged
@@ -272,13 +339,18 @@ public partial class TranslationPage : UserControl
         try
         {
             var block = new OcrTextBlock(text, new Rect());
-            var (results, _) = await _translationService.TranslateAsync([block], srcLang, tgtLang, apiKey, resilient: false);
+            var (results, detected) = await _translationService.TranslateAsync([block], srcLang, tgtLang, apiKey, resilient: false);
             if (seq != _seq) return;    // a newer request superseded this one — let it own the UI
 
+            _detectedLang = detected ?? "";
             TranslatedTextBox.Text = results.FirstOrDefault()?.TranslatedText ?? "";
             _lastDone = key;
             SetTranslating(false);
             SetStatus("", isError: false);
+
+            // The answer is what 朗讀原文 was waiting on under 自動, so the speaker comes back here
+            // rather than on the next thing the user happens to touch.
+            RenderSourceActions();
         }
         catch (Exception ex)
         {
@@ -313,8 +385,7 @@ public partial class TranslationPage : UserControl
     }
 
     private async void SrcTtsBtn_Click(object sender, RoutedEventArgs e)
-        => await ToggleTtsAsync(SrcTtsBtn, SourceTextBox.Text,
-                                LanguageData.GetValidSourceCode(SrcLangBox.SelectedValue as string));
+        => await ToggleTtsAsync(SrcTtsBtn, SourceTextBox.Text, EffectiveSourceLanguage());
 
     private async void TgtTtsBtn_Click(object sender, RoutedEventArgs e)
         => await ToggleTtsAsync(TgtTtsBtn, TranslatedTextBox.Text,

--- a/tests/OverTranslate.Tests/QuickLookupLiftTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupLiftTests.cs
@@ -5,16 +5,22 @@ namespace OverTranslate.Tests;
 
 public class QuickLookupLiftTests
 {
-    // A 1080p work area with the taskbar taken off it, and the popup's own 4px edge margin.
+    // A 1080p desktop with the taskbar taken off it, and the popup's transparent shadow margin
+    // folded into the limits the way QuickLookupWindow folds it in: the card may reach the edge of
+    // the work area, so the window may reach ShadowMarginBottom past it.
     private const int AreaTop = 0;
     private const int AreaBottom = 1040;
-    private const int Edge = 4;
+    private const int MarginTop = 24;
+    private const int MarginBottom = 30;
+
+    private const int LimitTop = AreaTop - MarginTop;          // -24
+    private const int LimitBottom = AreaBottom + MarginBottom; // 1070
 
     private const int HeaderOnly = 120;   // the popup before a translation arrives
     private const int WithResult = 300;   // the same popup with the result panel open
 
     private static (int Top, int? RestingTop) Place(int currentTop, int? restingTop, int height)
-        => QuickLookupLift.Place(currentTop, restingTop, height, AreaTop, AreaBottom, Edge);
+        => QuickLookupLift.Place(currentTop, restingTop, height, LimitTop, LimitBottom);
 
     [Fact]
     public void WithRoomBelow_LeavesTheWindowAlone()
@@ -26,13 +32,28 @@ public class QuickLookupLiftTests
     }
 
     [Fact]
+    public void TheCardMayTouchTheBottomOfTheWorkArea()
+    {
+        // The regression this guards: measuring the window rather than the card refused the last
+        // ShadowMarginBottom pixels of the screen, leaving a visible band of desktop under a popup
+        // that could plainly still go there. A card whose own bottom lands exactly on the work
+        // area's must not be moved at all.
+        int top = AreaBottom + MarginBottom - WithResult;   // 770 — card bottom sits on 1040
+
+        var (placed, resting) = Place(top, restingTop: null, height: WithResult);
+
+        Assert.Equal(top, placed);
+        Assert.Null(resting);
+    }
+
+    [Fact]
     public void ResultGrowingPastTheBottom_LiftsItJustInside()
     {
-        // Dropped 900px down: the header fits, but 900 + 300 = 1200 runs 160px off a 1040px desktop.
+        // Dropped 900px down: the header fits, but the result would put the card's bottom at 1170.
         var (top, resting) = Place(currentTop: 900, restingTop: null, height: WithResult);
 
-        Assert.Equal(AreaBottom - WithResult - Edge, top);   // 736 — the whole result is on screen
-        Assert.Equal(900, resting);                          // and this is where it came from
+        Assert.Equal(LimitBottom - WithResult, top);   // 770 — the whole card is on screen
+        Assert.Equal(900, resting);                    // and this is where it came from
     }
 
     [Fact]
@@ -57,7 +78,7 @@ public class QuickLookupLiftTests
         for (int i = 0; i < 5; i++)
         {
             (top, resting) = Place(top, resting, WithResult);   // a result opens
-            Assert.Equal(AreaBottom - WithResult - Edge, top);
+            Assert.Equal(LimitBottom - WithResult, top);
 
             (top, resting) = Place(top, resting, HeaderOnly);   // and closes again
             Assert.Equal(home, top);
@@ -70,32 +91,32 @@ public class QuickLookupLiftTests
     {
         // A second, longer translation while the first is still open: it lifts further, and what it
         // has to come back to is the user's position, not the height it was lifted to before.
-        var (_, resting) = Place(currentTop: 900, restingTop: null, height: WithResult);
-        var (top, stillHeld) = Place(736, resting, height: 500);
+        var (lifted, resting) = Place(currentTop: 900, restingTop: null, height: WithResult);
+        var (top, stillHeld) = Place(lifted, resting, height: 500);
 
-        Assert.Equal(AreaBottom - 500 - Edge, top);
+        Assert.Equal(LimitBottom - 500, top);
         Assert.Equal(900, stillHeld);
     }
 
     [Fact]
-    public void TallerThanTheWorkArea_PinsToTheTopRatherThanAbove()
+    public void TallerThanTheScreen_PinsToTheTopRatherThanAbove()
     {
         // Math.Clamp throws if the bottom bound falls below the top one, and a window pushed above
         // the work area loses the box the user types in — the one part that must stay reachable.
         var (top, resting) = Place(currentTop: 200, restingTop: null, height: 2000);
 
-        Assert.Equal(AreaTop + Edge, top);
+        Assert.Equal(LimitTop, top);
         Assert.Equal(200, resting);
     }
 
     [Fact]
     public void SittingAboveTheWorkArea_ComesDownToTheEdge()
     {
-        // A second monitor above this one puts negative tops in range; the popup still belongs on
-        // the monitor it is being measured against.
-        var (top, _) = Place(currentTop: -50, restingTop: null, height: HeaderOnly);
+        // A second monitor above this one puts tops in this range; the popup still belongs on the
+        // monitor it is being measured against.
+        var (top, _) = Place(currentTop: -400, restingTop: null, height: HeaderOnly);
 
-        Assert.Equal(AreaTop + Edge, top);
+        Assert.Equal(LimitTop, top);
     }
 
     [Fact]
@@ -103,21 +124,21 @@ public class QuickLookupLiftTests
     {
         // Only being pushed up is a loan that has to be repaid. Clamping downwards is the window
         // arriving where it belongs, and remembering the position above it would drag it back there.
-        var (top, resting) = Place(currentTop: -50, restingTop: null, height: HeaderOnly);
+        var (top, resting) = Place(currentTop: -400, restingTop: null, height: HeaderOnly);
 
-        Assert.True(top > -50);
+        Assert.True(top > -400);
         Assert.Null(resting);
     }
 
     [Fact]
     public void AWorkAreaNotStartingAtZero_IsRespectedAtBothEnds()
     {
-        // A monitor to the right of the primary one, or one with the taskbar at the top.
+        // A monitor below the primary one, or one with the taskbar at the top.
         var (top, resting) = QuickLookupLift.Place(
             currentTop: 1900, restingTop: null, height: WithResult,
-            areaTop: 1080, areaBottom: 2120, edge: Edge);
+            limitTop: 1080 - MarginTop, limitBottom: 2120 + MarginBottom);
 
-        Assert.Equal(2120 - WithResult - Edge, top);
+        Assert.Equal(2120 + MarginBottom - WithResult, top);
         Assert.Equal(1900, resting);
     }
 }

--- a/tests/OverTranslate.Tests/QuickLookupLiftTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupLiftTests.cs
@@ -1,0 +1,123 @@
+using OverTranslate.Layout;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class QuickLookupLiftTests
+{
+    // A 1080p work area with the taskbar taken off it, and the popup's own 4px edge margin.
+    private const int AreaTop = 0;
+    private const int AreaBottom = 1040;
+    private const int Edge = 4;
+
+    private const int HeaderOnly = 120;   // the popup before a translation arrives
+    private const int WithResult = 300;   // the same popup with the result panel open
+
+    private static (int Top, int? RestingTop) Place(int currentTop, int? restingTop, int height)
+        => QuickLookupLift.Place(currentTop, restingTop, height, AreaTop, AreaBottom, Edge);
+
+    [Fact]
+    public void WithRoomBelow_LeavesTheWindowAlone()
+    {
+        var (top, resting) = Place(currentTop: 300, restingTop: null, height: WithResult);
+
+        Assert.Equal(300, top);
+        Assert.Null(resting);
+    }
+
+    [Fact]
+    public void ResultGrowingPastTheBottom_LiftsItJustInside()
+    {
+        // Dropped 900px down: the header fits, but 900 + 300 = 1200 runs 160px off a 1040px desktop.
+        var (top, resting) = Place(currentTop: 900, restingTop: null, height: WithResult);
+
+        Assert.Equal(AreaBottom - WithResult - Edge, top);   // 736 — the whole result is on screen
+        Assert.Equal(900, resting);                          // and this is where it came from
+    }
+
+    [Fact]
+    public void ResultClosing_PutsItBackWhereTheUserLeftIt()
+    {
+        var (lifted, resting) = Place(currentTop: 900, restingTop: null, height: WithResult);
+        var (top, stillHeld) = Place(lifted, resting, HeaderOnly);
+
+        Assert.Equal(900, top);
+        Assert.Null(stillHeld);
+    }
+
+    [Fact]
+    public void RepeatedTranslations_DoNotWalkTheWindowUpTheScreen()
+    {
+        // The bug this exists to prevent: judging the fit from where the window currently is means
+        // a lifted popup always fits, so it never comes down and each result lifts it again.
+        int home = 900;
+        int? resting = null;
+        int top = home;
+
+        for (int i = 0; i < 5; i++)
+        {
+            (top, resting) = Place(top, resting, WithResult);   // a result opens
+            Assert.Equal(AreaBottom - WithResult - Edge, top);
+
+            (top, resting) = Place(top, resting, HeaderOnly);   // and closes again
+            Assert.Equal(home, top);
+            Assert.Null(resting);
+        }
+    }
+
+    [Fact]
+    public void AlreadyLiftedAndStillTooTall_HoldsTheSameRestingPlace()
+    {
+        // A second, longer translation while the first is still open: it lifts further, and what it
+        // has to come back to is the user's position, not the height it was lifted to before.
+        var (_, resting) = Place(currentTop: 900, restingTop: null, height: WithResult);
+        var (top, stillHeld) = Place(736, resting, height: 500);
+
+        Assert.Equal(AreaBottom - 500 - Edge, top);
+        Assert.Equal(900, stillHeld);
+    }
+
+    [Fact]
+    public void TallerThanTheWorkArea_PinsToTheTopRatherThanAbove()
+    {
+        // Math.Clamp throws if the bottom bound falls below the top one, and a window pushed above
+        // the work area loses the box the user types in — the one part that must stay reachable.
+        var (top, resting) = Place(currentTop: 200, restingTop: null, height: 2000);
+
+        Assert.Equal(AreaTop + Edge, top);
+        Assert.Equal(200, resting);
+    }
+
+    [Fact]
+    public void SittingAboveTheWorkArea_ComesDownToTheEdge()
+    {
+        // A second monitor above this one puts negative tops in range; the popup still belongs on
+        // the monitor it is being measured against.
+        var (top, _) = Place(currentTop: -50, restingTop: null, height: HeaderOnly);
+
+        Assert.Equal(AreaTop + Edge, top);
+    }
+
+    [Fact]
+    public void DownwardMove_NeverCountsAsALift()
+    {
+        // Only being pushed up is a loan that has to be repaid. Clamping downwards is the window
+        // arriving where it belongs, and remembering the position above it would drag it back there.
+        var (top, resting) = Place(currentTop: -50, restingTop: null, height: HeaderOnly);
+
+        Assert.True(top > -50);
+        Assert.Null(resting);
+    }
+
+    [Fact]
+    public void AWorkAreaNotStartingAtZero_IsRespectedAtBothEnds()
+    {
+        // A monitor to the right of the primary one, or one with the taskbar at the top.
+        var (top, resting) = QuickLookupLift.Place(
+            currentTop: 1900, restingTop: null, height: WithResult,
+            areaTop: 1080, areaBottom: 2120, edge: Edge);
+
+        Assert.Equal(2120 - WithResult - Edge, top);
+        Assert.Equal(1900, resting);
+    }
+}


### PR DESCRIPTION
圍繞取詞翻譯的一組操作性調整，以及把其中兩項邏輯帶回文字翻譯。

## 取詞翻譯

### 釘選
- **釘選後仍可拖曳**。釘選現在只擋「視窗自己動」——失去焦點自動關閉、下次快捷鍵把視窗移到滑鼠旁；不擋使用者自己動它。原本連拖曳都鎖住，等於把最需要挪開位置的那個情境（要留著看一陣子的視窗）給擋掉了。
- **從主視窗入口開啟時直接啟用釘選**，快捷鍵開啟則維持未釘選。用快捷鍵的人已經知道它會自動關閉；從導覽列找到這個功能的人是第一次接觸，視窗在他回頭看原文時就消失會像壞掉。只會把釘選打開，不會關掉——使用者自己釘的不該被下一次快捷鍵偷偷取消。
- 提示文字改為「釘選後，可避免視窗自動關閉」。

### 輸入框
- **框內右側加入清除按鈕**，有文字才顯示。規格沿用文字翻譯既有的那顆：同字符、同字級，清除走 selection 而非直接指派 `Text`，所以 **Ctrl+Z 救得回來**——這裡的文字通常是從別的視窗選取帶進來的，重打得回頭去找。
- 右側 padding 不論按鈕在不在都保留，否則刪到最後一個字的瞬間整行字會往右滑一格。

### 語言交換
- **`→` 改為可點擊的 `⇄`**，一併對調語言與內容（譯文搬進輸入框）。只換語言會立刻拿原文用反方向再翻一次，結果無意義。
- 來源語言是「自動」時，用**引擎回報的偵測結果**當新的目標語言；偵測不到或沒文字才退回英文。原本讀選單字面的 `AUTO`，對不到就落到清單第一項，英文剛好對、日韓就是錯的。
- 兩顆下拉在交換過程中會各自觸發事件，改為以 `_suppressAuto` 蓋住、最後只套用一次，避免存到「只換了一半」的語言對。

### 結果展開時的位置
- 視窗是 `SizeToContent="Height"`，靠近螢幕下緣時結果會直接長到畫面外。現在會**自動上移**讓卡片完整留在畫面內，**結果收合後回到原本的位置**。
- 實作在 `WM_WINDOWPOSCHANGING` 內完成而非事後修正：`SizeToContent` 是在版面計算之後才調整 HWND，事後處理拿到的是舊高度，會先放行、視窗掉出畫面、下一輪才拉回來。攔在訊息裡等於編輯 Windows 正要使用的矩形，**不存在「已經長大但還沒移動」的那一幀**。
- 以**卡片**而非整個視窗計算邊界。視窗比卡片高出一段透明的陰影帶，拿視窗去卡會在底部留下一條沒有理由的空白。
- 拖曳的每一步都帶著尺寸送同一個訊息，所以拖曳過程也是即時夾住的，且放手的位置就是新的休息位置。
- 純計算抽成 `Layout/QuickLookupLift.cs`，比照 `RealtimeBandPlacement` 的慣例，附 10 個單元測試（含「連續翻譯不會讓視窗往上爬」這個最容易寫錯的點）。

## 文字翻譯

把上面兩項邏輯帶回這一頁：

- **原文朗讀改看引擎回報的偵測語言**，不再是來源語言為「自動」就無腦停用。「自動」是預設值也是多數人的狀態，等於這顆按鈕幾乎永遠是灰的，包括引擎其實早就說出語言的情況。
- **只有「OpenAI + 自動」才停用**：OpenAI 相容服務不會回報偵測語言（送過去的 prompt 是使用者自己的，回覆塞不進第二個欄位），是唯一永遠等不到答案的組合。「引擎還沒回答」只給 tooltip，不顯示提示行——那狀態一兩秒就過去，跳出來又消失是雜訊。
- 提示行**從原文標題列移到頁面底部**，與狀態訊息共用同一行，**訊息出現時讓位**。這行平時是空的，另開一列會讓頁面在選到 OpenAI 的瞬間變高、每次翻譯又抖一下。
- **交換按鈕同樣改用偵測語言**，沒偵測結果時退回英文。

### 順帶修正
移除原文標題列的提示後，清除鈕會遞補成 DockPanel 的填滿子元素而跑到列的正中間，已加上 `LastChildFill="False"`。

## 驗證

- 552 個單元測試全過（新增 10 個）。
- 取詞翻譯的位置行為以實機量測驗證（實體像素，工作區底部 1440）：

| 情境 | 結果 |
|---|---|
| 空間充足時展開 | 完全沒動 |
| 拖到下緣後展開 | 上移，卡片底部貼齊 1440，溢出 0 |
| 結果收合 | 回到放手的位置 |
| 再翻一次 → 再收合 | 同上，沒有往上爬 |

### 仍需人工檢查

- 展開瞬間的流暢度（有沒有任何一幀掉出畫面）。
- 卡片貼齊底部的視覺感受，要不要留一點縫。
- `⇄` 在標題列裡的視覺重量與左右間距。
- 文字翻譯底部提示與狀態訊息交替時的觀感。
