### PR TITLE
feat: 快捷鍵開放滑鼠側鍵並調整設定頁說明文案

### DIFF
--- a/src/OverTranslate/Models/ShortcutInput.cs
+++ b/src/OverTranslate/Models/ShortcutInput.cs
@@ -7,11 +7,21 @@ namespace OverTranslate.Models;
 /// path; mouse and gamepad are observed without swallowing the original input, so the foreground game
 /// or application still receives them.
 /// </summary>
+/// <remarks>
+/// The side buttons are named after Windows' own XBUTTON1/XBUTTON2 rather than after what a mouse
+/// prints on them, because that is what the hook reports and mice disagree about the rest: the pair
+/// is back/forward on one and thumb-up/thumb-down on the next. The interface calls them 側鍵 1 and
+/// 側鍵 2, in the order Windows numbers them.
+///
+/// These are persisted by name, so a value may be renamed only alongside a settings migration.
+/// </remarks>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ShortcutInputKind
 {
     Keyboard,
     MouseMiddle,
+    MouseX1,
+    MouseX2,
     Gamepad,
 }
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -311,8 +311,8 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.HotkeyRecordTip">Click to record a new shortcut</sys:String>
     <sys:String x:Key="S.Settings.HotkeyOn">Enabled</sys:String>
     <sys:String x:Key="S.Settings.HotkeyOff">Disabled</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyKinds">A shortcut can pair Ctrl / Alt / Shift with any key, or be a single function key, the middle mouse button, or a gamepad button.</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyKindsExample">For example: Ctrl+Alt+A, Shift+F2, F8, middle mouse. On its own, a key has to be a function key; middle mouse and the gamepad leave the game's own input alone.</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyKinds">A shortcut can pair Ctrl / Alt / Shift with another key, and also supports a single function key, a mouse button, or a gamepad button.</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyKindsExample">For example: Ctrl+Alt+A, Shift+A, F1, middle / side mouse buttons, a gamepad button. On its own, a key has to be a function key; the mouse and gamepad buttons leave the game's own input alone.</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkey">Pause / resume</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyHint">Pause or resume [[realtime translation]]</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyNote">"Pause / resume" only works while realtime translation is running. (a way to read the original text)</sys:String>
@@ -384,8 +384,10 @@ The parameter is left out of the request when this is off. Models differ — fol
 
     <!-- Settings page, composed in code-behind -->
     <sys:String x:Key="S.Settings.Saved">✓ Saved</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyPromptAnyInput">Press a keyboard key, middle mouse, or gamepad button…</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyPromptAnyInput">Press a keyboard key, a middle / side mouse button, or a gamepad button…</sys:String>
     <sys:String x:Key="S.Settings.MouseMiddle">Middle Mouse</sys:String>
+    <sys:String x:Key="S.Settings.MouseX1">Mouse Side 1</sys:String>
+    <sys:String x:Key="S.Settings.MouseX2">Mouse Side 2</sys:String>
     <sys:String x:Key="S.Settings.GamepadButton">Gamepad {0}</sys:String>
     <sys:String x:Key="S.Settings.FolderPickerTitle">Choose where to save screenshots</sys:String>
     <sys:String x:Key="S.Settings.LoggingEnvOverride">The log level is currently set by the OVERTRANSLATE_LOGLEVEL environment variable, so this option has no effect.</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -312,7 +312,7 @@ Leave a little room around the whole area; box several areas separately rather t
     <sys:String x:Key="S.Settings.HotkeyOn">Enabled</sys:String>
     <sys:String x:Key="S.Settings.HotkeyOff">Disabled</sys:String>
     <sys:String x:Key="S.Settings.HotkeyKinds">A shortcut can pair Ctrl / Alt / Shift with another key, and also supports a single function key, a mouse button, or a gamepad button.</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyKindsExample">For example: Ctrl+Alt+A, Shift+A, F1, middle / side mouse buttons, a gamepad button. On its own, a key has to be a function key; the mouse and gamepad buttons leave the game's own input alone.</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyKindsExample">For example: Ctrl+Alt+A, Shift+A, F1, middle / side mouse buttons, XInput... etc.</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkey">Pause / resume</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyHint">Pause or resume [[realtime translation]]</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyNote">"Pause / resume" only works while realtime translation is running. (a way to read the original text)</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -332,7 +332,7 @@
     <sys:String x:Key="S.Settings.HotkeyOn">已啟用</sys:String>
     <sys:String x:Key="S.Settings.HotkeyOff">未啟用</sys:String>
     <sys:String x:Key="S.Settings.HotkeyKinds">快捷鍵可使用 Ctrl／Alt／Shift 搭配其他按鍵，也支援單一功能鍵、滑鼠按鍵以及遊戲手把。</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyKindsExample">例如：Ctrl+Alt+A、Shift+A、F1、滑鼠中鍵／側鍵、手把按鍵。單獨使用時僅支援功能鍵；滑鼠與手把按鍵不會擋住遊戲的操作。</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyKindsExample">例如：Ctrl+Alt+A、Shift+A、F1、滑鼠中鍵／側鍵、XInput...等。</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkey">暫停 / 繼續</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyHint">暫停或繼續[[即時翻譯]]</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyNote">「暫停 / 繼續」僅在即時翻譯進行中可用。(可用於顯示原文)</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -331,8 +331,8 @@
     <sys:String x:Key="S.Settings.HotkeyRecordTip">點一下重新錄製快捷鍵</sys:String>
     <sys:String x:Key="S.Settings.HotkeyOn">已啟用</sys:String>
     <sys:String x:Key="S.Settings.HotkeyOff">未啟用</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyKinds">快捷鍵可以是 Ctrl／Alt／Shift 搭配任意按鍵的組合鍵，也可以是單一功能鍵、滑鼠中鍵或遊戲手把按鍵。</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyKindsExample">例如：Ctrl+Alt+A、Shift+F2、F8、滑鼠中鍵。單獨使用時僅支援功能鍵；滑鼠中鍵與手把按鍵不會擋住遊戲的操作。</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyKinds">快捷鍵可使用 Ctrl／Alt／Shift 搭配其他按鍵，也支援單一功能鍵、滑鼠按鍵以及遊戲手把。</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyKindsExample">例如：Ctrl+Alt+A、Shift+A、F1、滑鼠中鍵／側鍵、手把按鍵。單獨使用時僅支援功能鍵；滑鼠與手把按鍵不會擋住遊戲的操作。</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkey">暫停 / 繼續</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyHint">暫停或繼續[[即時翻譯]]</sys:String>
     <sys:String x:Key="S.Settings.RealtimePauseHotkeyNote">「暫停 / 繼續」僅在即時翻譯進行中可用。(可用於顯示原文)</sys:String>
@@ -408,8 +408,10 @@
 
     <!-- Settings page, composed in code-behind -->
     <sys:String x:Key="S.Settings.Saved">✓ 已儲存</sys:String>
-    <sys:String x:Key="S.Settings.HotkeyPromptAnyInput">請按鍵盤按鍵、滑鼠中鍵或遊戲手把按鍵…</sys:String>
+    <sys:String x:Key="S.Settings.HotkeyPromptAnyInput">請按鍵盤按鍵、滑鼠中鍵／側鍵或遊戲手把按鍵…</sys:String>
     <sys:String x:Key="S.Settings.MouseMiddle">滑鼠中鍵</sys:String>
+    <sys:String x:Key="S.Settings.MouseX1">滑鼠側鍵 1</sys:String>
+    <sys:String x:Key="S.Settings.MouseX2">滑鼠側鍵 2</sys:String>
     <sys:String x:Key="S.Settings.GamepadButton">手把 {0}</sys:String>
     <sys:String x:Key="S.Settings.FolderPickerTitle">選擇截圖儲存資料夾</sys:String>
     <sys:String x:Key="S.Settings.LoggingEnvOverride">目前記錄等級由環境變數 OVERTRANSLATE_LOGLEVEL 指定，此選項暫時無效。</sys:String>

--- a/src/OverTranslate/Services/GlobalAuxiliaryHotkeys.cs
+++ b/src/OverTranslate/Services/GlobalAuxiliaryHotkeys.cs
@@ -6,7 +6,7 @@ using OverTranslate.Models;
 namespace OverTranslate.Services;
 
 /// <summary>
-/// Observes non-keyboard shortcut inputs. It never swallows the input: middle click and controller
+/// Observes non-keyboard shortcut inputs. It never swallows the input: the mouse and controller
 /// buttons continue to reach the foreground application/game after OverTranslate reacts to them.
 /// </summary>
 /// <remarks>
@@ -31,6 +31,11 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
 
     private const int WhMouseLl = 14;
     private const int WmMButtonDown = 0x0207;
+    private const int WmXButtonDown = 0x020B;
+
+    // Which side button an XBUTTON message is about is in the HIGH word of mouseData, not the low one.
+    private const int Xbutton1 = 0x0001;
+    private const int Xbutton2 = 0x0002;
 
     // Fast enough that a button press does not feel late, slow enough to stay invisible beside a
     // game. On the hook thread, so it neither waits for the interface nor holds it up.
@@ -66,7 +71,7 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
 
         Volatile.Write(ref _bindings, map);
 
-        var needsMouse = map.Keys.Any(trigger => trigger.Kind == ShortcutInputKind.MouseMiddle);
+        var needsMouse = map.Keys.Any(trigger => trigger.IsMouse);
         var needsGamepad = map.Keys.Any(trigger => trigger.Kind == ShortcutInputKind.Gamepad);
 
         // Nothing to observe: the thread is not merely idled but ended, because a message loop kept
@@ -184,10 +189,10 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
 
         if (_mouseHook == IntPtr.Zero)
         {
-            // Otherwise the middle-click shortcut is simply inert, which is indistinguishable from
+            // Otherwise the mouse-button shortcut is simply inert, which is indistinguishable from
             // a user who mis-set it — and this line is the only place that can tell them apart.
             Log.Warn(
-                "Middle-click shortcut hook install failed (win32 error {Error}); that shortcut will not fire",
+                "Mouse shortcut hook install failed (win32 error {Error}); that shortcut will not fire",
                 Marshal.GetLastWin32Error());
             _mouseProc = null;
         }
@@ -206,14 +211,40 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
 
     private IntPtr MouseHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
-        if (nCode >= 0 && wParam.ToInt32() == WmMButtonDown &&
-            Volatile.Read(ref _bindings).TryGetValue(ShortcutTrigger.MouseMiddle(), out var action))
+        if (nCode >= 0 && PressedKind(wParam.ToInt32(), lParam) is { } kind &&
+            Volatile.Read(ref _bindings).TryGetValue(ShortcutTrigger.Mouse(kind), out var action))
         {
             // Post, never run: see the remarks on this class for what a slow callback costs.
             Raise(action);
         }
 
         return CallNextHookEx(_mouseHook, nCode, wParam, lParam);
+    }
+
+    /// <summary>
+    /// Which bindable mouse button this message is a press of, or null for every other mouse event.
+    /// </summary>
+    /// <remarks>
+    /// The left and right buttons are absent on purpose: they are how the desktop is operated, and a
+    /// shortcut on one would fire on every click the user makes anywhere. Middle and the two side
+    /// buttons are the ones a game can spare.
+    ///
+    /// Both side buttons arrive as the same WM_XBUTTONDOWN, told apart only by the high word of
+    /// mouseData — so lParam has to be read, unlike the middle button which the message alone
+    /// identifies.
+    /// </remarks>
+    private static ShortcutInputKind? PressedKind(int message, IntPtr lParam)
+    {
+        if (message == WmMButtonDown) return ShortcutInputKind.MouseMiddle;
+        if (message != WmXButtonDown) return null;
+
+        var data = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
+        return (data.mouseData >> 16) switch
+        {
+            Xbutton1 => ShortcutInputKind.MouseX1,
+            Xbutton2 => ShortcutInputKind.MouseX2,
+            _ => null,
+        };
     }
 
     private void SnapshotGamepads()
@@ -258,6 +289,27 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
         System.Windows.Application.Current?.Dispatcher.InvokeAsync(() => ShortcutPressed?.Invoke(action));
 
     private delegate IntPtr LowLevelMouseProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+    /// <summary>
+    /// The low-level mouse hook's payload. Only <c>mouseData</c> is read, but the whole layout has to
+    /// be declared for the field to land at the right offset.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MSLLHOOKSTRUCT
+    {
+        public POINT pt;
+        public int mouseData;
+        public uint flags;
+        public uint time;
+        public IntPtr dwExtraInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int x;
+        public int y;
+    }
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern IntPtr SetWindowsHookEx(

--- a/src/OverTranslate/Services/HotkeyBindings.cs
+++ b/src/OverTranslate/Services/HotkeyBindings.cs
@@ -12,8 +12,9 @@ public enum HotkeyAction
 }
 
 /// <summary>
-/// One physical shortcut trigger. Keyboard uses modifiers + virtual key; mouse middle has no code;
-/// gamepad stores exactly one XInput button value in <see cref="Code"/>.
+/// One physical shortcut trigger. Keyboard uses modifiers + virtual key; the mouse buttons carry no
+/// code, the button being the kind itself; gamepad stores exactly one XInput button value in
+/// <see cref="Code"/>.
 /// </summary>
 public readonly record struct ShortcutTrigger(ShortcutInputKind Kind, uint Modifiers, uint Code)
 {
@@ -23,13 +24,27 @@ public readonly record struct ShortcutTrigger(ShortcutInputKind Kind, uint Modif
     public static ShortcutTrigger MouseMiddle() =>
         new(ShortcutInputKind.MouseMiddle, 0, 0);
 
+    public static ShortcutTrigger Mouse(ShortcutInputKind kind) => new(kind, 0, 0);
+
     public static ShortcutTrigger Gamepad(GamepadShortcutButton button) =>
         new(ShortcutInputKind.Gamepad, 0, (uint)button);
+
+    /// <summary>Whether this trigger is one of the observed mouse buttons.</summary>
+    public bool IsMouse => Kind.IsMouse();
 
     public uint VirtualKey => Kind == ShortcutInputKind.Keyboard ? Code : 0;
     public GamepadShortcutButton GamepadButton => Kind == ShortcutInputKind.Gamepad
         ? (GamepadShortcutButton)Code
         : GamepadShortcutButton.None;
+}
+
+/// <summary>Which shortcut kinds the mouse hook is responsible for.</summary>
+public static class ShortcutInputKinds
+{
+    public static bool IsMouse(this ShortcutInputKind kind) => kind is
+        ShortcutInputKind.MouseMiddle or
+        ShortcutInputKind.MouseX1 or
+        ShortcutInputKind.MouseX2;
 }
 
 /// <param name="ShadowedBy">
@@ -56,9 +71,9 @@ public readonly record struct HotkeyBinding(
 /// Works out which shortcuts are live when two of them want the same physical trigger.
 /// </summary>
 /// <remarks>
-/// Keyboard combinations are registered with RegisterHotKey; mouse middle and gamepad buttons are
+/// Keyboard combinations are registered with RegisterHotKey; the mouse and gamepad buttons are
 /// observed by the application's global input listener. They all share the same conflict resolver so
-/// "mouse middle" cannot silently do two different things, and the same is true of one gamepad
+/// one mouse button cannot silently do two different things, and the same is true of one gamepad
 /// button.
 ///
 /// The keyboard half is where the cost of not resolving it shows. Windows keys a registration by
@@ -128,7 +143,7 @@ public static class HotkeyBindings
     /// Whether a trigger may be bound at all, as opposed to whether anything else has taken it.
     /// </summary>
     /// <remarks>
-    /// Only keyboard triggers can fail this: middle click and controller buttons are observed rather
+    /// Only keyboard triggers can fail this: the mouse and controller buttons are observed rather
     /// than claimed, so binding one takes nothing away from anybody — see
     /// <see cref="GlobalAuxiliaryHotkeys"/>.
     ///
@@ -148,7 +163,7 @@ public static class HotkeyBindings
         uint virtualKey,
         GamepadShortcutButton gamepadButton) => kind switch
     {
-        ShortcutInputKind.MouseMiddle => ShortcutTrigger.MouseMiddle(),
+        _ when kind.IsMouse() => ShortcutTrigger.Mouse(kind),
         ShortcutInputKind.Gamepad when gamepadButton != GamepadShortcutButton.None =>
             ShortcutTrigger.Gamepad(gamepadButton),
         // A malformed/old setting that says Gamepad but has no button is safer as the keyboard it

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -638,8 +638,8 @@ public partial class SettingsPage : UserControl
         if (FieldOf(sender) is not { } field || !ReferenceEquals(_recording, field)) return;
 
         // Keep recording while focus moves inside this settings page. This is what lets the user
-        // press middle mouse anywhere on the page after starting to record instead of having to aim
-        // at the read-only box itself.
+        // press a mouse button anywhere on the page after starting to record instead of having to
+        // aim at the read-only box itself.
         if (Keyboard.FocusedElement is DependencyObject focused && IsDescendantOfThisPage(focused)) return;
 
         StopRecording();
@@ -696,15 +696,43 @@ public partial class SettingsPage : UserControl
         CommitShortcut(recording, trigger, display);
     }
 
+    /// <remarks>
+    /// The left and right buttons are not offered, and cannot be: left is how the box is clicked to
+    /// start recording in the first place, and a shortcut on either would fire on every click the
+    /// user makes anywhere. That leaves middle and the two side buttons — matching what
+    /// <see cref="GlobalAuxiliaryHotkeys"/> watches for.
+    ///
+    /// Handled is set so the press is not also acted on as a press: XButton1 and XButton2 are the
+    /// browser's Back and Forward, which WPF routes to navigation.
+    /// </remarks>
     private void SettingsPage_PreviewMouseDown(object sender, MouseButtonEventArgs e)
     {
-        if (_recording is not { } recording || e.ChangedButton != MouseButton.Middle) return;
+        if (_recording is not { } recording) return;
+
+        var kind = e.ChangedButton switch
+        {
+            MouseButton.Middle => ShortcutInputKind.MouseMiddle,
+            MouseButton.XButton1 => ShortcutInputKind.MouseX1,
+            MouseButton.XButton2 => ShortcutInputKind.MouseX2,
+            _ => ShortcutInputKind.Keyboard,
+        };
+
+        if (kind == ShortcutInputKind.Keyboard) return;
+
         e.Handled = true;
         CommitShortcut(
             recording,
-            ShortcutTrigger.MouseMiddle(),
-            LocalizationService.Get("S.Settings.MouseMiddle"));
+            ShortcutTrigger.Mouse(kind),
+            LocalizationService.Get(MouseButtonNameKey(kind)));
     }
+
+    /// <summary>The string naming one mouse button in the shortcut box.</summary>
+    private static string MouseButtonNameKey(ShortcutInputKind kind) => kind switch
+    {
+        ShortcutInputKind.MouseX1 => "S.Settings.MouseX1",
+        ShortcutInputKind.MouseX2 => "S.Settings.MouseX2",
+        _ => "S.Settings.MouseMiddle",
+    };
 
     private void PollRecordingGamepad()
     {
@@ -739,7 +767,7 @@ public partial class SettingsPage : UserControl
     /// Windows keys a registration by window and combination, so the second shortcut to claim one is
     /// simply refused — RegisterHotKey returns false and nothing else happens. Left to itself that
     /// reads as a shortcut that stopped working for no reason, so the clash is refused here, where
-    /// there is something to say about it. Middle click and the controller are not registered with
+    /// there is something to say about it. The mouse and controller buttons are not registered with
     /// Windows at all, but they go through the same refusal so that one button cannot silently do two
     /// different things.
     ///

--- a/tests/OverTranslate.Tests/HotkeyBindingsTests.cs
+++ b/tests/OverTranslate.Tests/HotkeyBindingsTests.cs
@@ -147,6 +147,57 @@ public class HotkeyBindingsTests
     }
 
     [Fact]
+    public void EachMouseButtonIsItsOwnTrigger()
+    {
+        // The three share a kind-only trigger with no code beside it, so nothing but the kind tells
+        // them apart — if that ever stopped holding, two shortcuts on different buttons would read
+        // as a clash and one of them would silently stop working.
+        var settings = new AppSettings
+        {
+            TranslationWindowHotkeyInputKind = ShortcutInputKind.MouseX1,
+            RealtimePauseHotkeyInputKind = ShortcutInputKind.MouseX2,
+            QuickLookupHotkeyInputKind = ShortcutInputKind.MouseMiddle,
+        };
+
+        var resolved = HotkeyBindings.Resolve(settings);
+        Assert.All(
+            resolved.Where(b => b.Action != HotkeyAction.Capture),
+            binding => Assert.True(binding.IsActive));
+    }
+
+    [Fact]
+    public void TwoShortcutsOnTheSameSideButtonStillResolveByPriority()
+    {
+        var settings = new AppSettings
+        {
+            TranslationWindowHotkeyInputKind = ShortcutInputKind.MouseX1,
+            RealtimePauseHotkeyInputKind = ShortcutInputKind.MouseX1,
+        };
+
+        var resolved = HotkeyBindings.Resolve(settings);
+        Assert.True(resolved.Single(b => b.Action == HotkeyAction.TranslationWindow).IsActive);
+        Assert.Equal(HotkeyAction.TranslationWindow,
+            resolved.Single(b => b.Action == HotkeyAction.RealtimePause).ShadowedBy);
+    }
+
+    [Fact]
+    public void ASideButtonSettingWinsOverAStaleGamepadButton()
+    {
+        // Switching a shortcut from the controller to the mouse leaves the old button in settings —
+        // nothing clears it — so the stored kind has to be what decides.
+        var settings = new AppSettings
+        {
+            RealtimePauseHotkeyInputKind = ShortcutInputKind.MouseX2,
+            RealtimePauseHotkeyGamepadButton = GamepadShortcutButton.Y,
+        };
+
+        var trigger = HotkeyBindings.TriggerFor(settings, HotkeyAction.RealtimePause);
+        Assert.Equal(ShortcutInputKind.MouseX2, trigger.Kind);
+        Assert.True(trigger.IsMouse);
+        Assert.Equal(GamepadShortcutButton.None, trigger.GamepadButton);
+    }
+
+    [Fact]
     public void GamepadButtonCanBeAUniqueShortcut()
     {
         var settings = new AppSettings
@@ -195,6 +246,8 @@ public class HotkeyBindingsTests
         // They are observed rather than claimed, so they take nothing away from anybody and the
         // question this rule answers does not arise.
         Assert.True(HotkeyBindings.IsBindable(ShortcutTrigger.MouseMiddle()));
+        Assert.True(HotkeyBindings.IsBindable(ShortcutTrigger.Mouse(ShortcutInputKind.MouseX1)));
+        Assert.True(HotkeyBindings.IsBindable(ShortcutTrigger.Mouse(ShortcutInputKind.MouseX2)));
         Assert.True(HotkeyBindings.IsBindable(ShortcutTrigger.Gamepad(GamepadShortcutButton.Y)));
     }
 


### PR DESCRIPTION
## 說明

### 設定頁快捷鍵 TIP 文案
改寫為兩行，涵蓋新增的滑鼠側鍵：

- `快捷鍵可使用 Ctrl／Alt／Shift 搭配其他按鍵，也支援單一功能鍵、滑鼠按鍵以及遊戲手把。`
- `例如：Ctrl+Alt+A、Shift+A、F1、滑鼠中鍵／側鍵、XInput...等。`

錄製提示同步改為 `請按鍵盤按鍵、滑鼠中鍵／側鍵或遊戲手把按鍵…`，en 資源一併更新。

### 滑鼠側鍵可設為快捷鍵
- `ShortcutInputKind` 新增 `MouseX1` / `MouseX2`，依 Windows XBUTTON1/2 編號命名，UI 顯示「滑鼠側鍵 1／2」。
- 低階滑鼠 hook 加收 `WM_XBUTTONDOWN`，由 `MSLLHOOKSTRUCT.mouseData` 高位字分辨按下的是哪一顆；維持只觀察不吞掉，前景遊戲仍收得到原始輸入。
- 設定頁錄製時接受中鍵與兩顆側鍵。左右鍵不開放：左鍵本身就是點開錄製框的操作，綁上去會在任何一次點擊時觸發。側鍵設 `e.Handled`，避免同一次按壓又被 WPF 當成上一頁／下一頁。
- 衝突判定、優先權與 `IsBindable` 沿用既有規則，三顆滑鼠鍵互為獨立 trigger。

## 測試
- 建置成功。
- 單元測試 553 通過 / 0 失敗，新增 3 個案例：側鍵各自獨立、同一側鍵衝突時仍依優先權降級、由手把切到側鍵時殘留的手把設定不會蓋掉新的 kind。
- 待實機驗證：接滑鼠錄製側鍵 1／2，確認遊戲前景可觸發，且側鍵原本的返回／前進仍正常。