### PR TITLE
feat: 設定頁加上匯出診斷檔與開啟記錄資料夾

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -86,7 +86,7 @@ When "Record detailed information" is switched on in Settings, the log also reco
 
 
 
-Settings offers "Export diagnostics", which packs the log files, information about the device, and the current settings into a single zip file on the user's desktop. API keys are replaced by a note giving only their length. The zip file is written to the user's own device; the user decides whether to share it and with whom.
+Settings offers "Export diagnostics", which packs the log files, information about the device, and the current settings into a single zip file stored with the application's own data on the user's device. API keys are replaced by a note giving only their length. Nothing is uploaded; the user decides whether to share the file and with whom.
 
 
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -74,6 +74,22 @@ These settings are used only for application functionality.
 
 
 
+## Logs and Diagnostics
+
+
+
+OverTranslate writes a log file to the user's own device. It is never sent anywhere automatically.
+
+
+
+When "Record detailed information" is switched on in Settings, the log also records text recognised on screen. That setting is off by default and is intended for troubleshooting.
+
+
+
+Settings offers "Export diagnostics", which packs the log files, information about the device, and the current settings into a single zip file on the user's desktop. API keys are replaced by a note giving only their length. The zip file is written to the user's own device; the user decides whether to share it and with whom.
+
+
+
 ## Contact
 
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -379,6 +379,10 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.Logging">Logging</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">Record detailed information</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">Records more information about the app; only recommended while troubleshooting.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsHint">When reporting a problem, you can pack the log files, system information and your current settings into a single zip on your desktop and attach it to the report. API keys are not included; the zip stays on your computer and is never uploaded anywhere.</sys:String>
+    <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
+    <sys:String x:Key="S.Settings.ExportDiagnosticsTip">Pack the logs and system information onto your desktop</sys:String>
+    <sys:String x:Key="S.Settings.OpenLogFolder">Open log folder</sys:String>
 
     <sys:String x:Key="S.Settings.AutoSaveHint">Changes are saved automatically</sys:String>
 
@@ -393,6 +397,8 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.LoggingEnvOverride">The log level is currently set by the OVERTRANSLATE_LOGLEVEL environment variable, so this option has no effect.</sys:String>
     <sys:String x:Key="S.Settings.StartupFailed">✗ Could not change the startup setting: {0}</sys:String>
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ Could not open the folder: {0}</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExported">✓ Diagnostics exported to your desktop</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ Could not export diagnostics: {0}</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} is already assigned to "{1}"</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -379,9 +379,8 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.Logging">Logging</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">Record detailed information</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">Records more information about the app; only recommended while troubleshooting.</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsHint">When reporting a problem, you can pack the log files, system information and your current settings into a single zip on your desktop and attach it to the report. API keys are not included; the zip stays on your computer and is never uploaded anywhere.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
-    <sys:String x:Key="S.Settings.ExportDiagnosticsTip">Pack the logs and system information onto your desktop</sys:String>
     <sys:String x:Key="S.Settings.OpenLogFolder">Open log folder</sys:String>
 
     <sys:String x:Key="S.Settings.AutoSaveHint">Changes are saved automatically</sys:String>
@@ -397,7 +396,7 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.LoggingEnvOverride">The log level is currently set by the OVERTRANSLATE_LOGLEVEL environment variable, so this option has no effect.</sys:String>
     <sys:String x:Key="S.Settings.StartupFailed">✗ Could not change the startup setting: {0}</sys:String>
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ Could not open the folder: {0}</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsExported">✓ Diagnostics exported to your desktop</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExported">✓ Diagnostics exported</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ Could not export diagnostics: {0}</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} is already assigned to "{1}"</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -403,9 +403,8 @@
     <sys:String x:Key="S.Settings.Logging">應用紀錄</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">記錄詳細資訊</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">啟用後會記錄更多應用程式資訊，僅建議於問題排查時開啟。</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsHint">回報問題時，可將記錄檔、系統資訊與目前設定打包成一個壓縮檔存到桌面，附在回報中即可。API 金鑰不會包含在內；壓縮檔只會存在你的電腦上，不會上傳到任何地方。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
-    <sys:String x:Key="S.Settings.ExportDiagnosticsTip">打包記錄檔與系統資訊到桌面</sys:String>
     <sys:String x:Key="S.Settings.OpenLogFolder">開啟記錄資料夾</sys:String>
 
     <sys:String x:Key="S.Settings.AutoSaveHint">設定變更後會自動儲存</sys:String>
@@ -421,7 +420,7 @@
     <sys:String x:Key="S.Settings.LoggingEnvOverride">目前記錄等級由環境變數 OVERTRANSLATE_LOGLEVEL 指定，此選項暫時無效。</sys:String>
     <sys:String x:Key="S.Settings.StartupFailed">✗ 無法設定開機啟動：{0}</sys:String>
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ 無法開啟資料夾：{0}</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsExported">✓ 已匯出診斷資訊到桌面</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExported">✓ 已匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ 無法匯出診斷資訊：{0}</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} 已指派給「{1}」</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -403,6 +403,10 @@
     <sys:String x:Key="S.Settings.Logging">應用紀錄</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">記錄詳細資訊</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">啟用後會記錄更多應用程式資訊，僅建議於問題排查時開啟。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsHint">回報問題時，可將記錄檔、系統資訊與目前設定打包成一個壓縮檔存到桌面，附在回報中即可。API 金鑰不會包含在內；壓縮檔只會存在你的電腦上，不會上傳到任何地方。</sys:String>
+    <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
+    <sys:String x:Key="S.Settings.ExportDiagnosticsTip">打包記錄檔與系統資訊到桌面</sys:String>
+    <sys:String x:Key="S.Settings.OpenLogFolder">開啟記錄資料夾</sys:String>
 
     <sys:String x:Key="S.Settings.AutoSaveHint">設定變更後會自動儲存</sys:String>
 
@@ -417,6 +421,8 @@
     <sys:String x:Key="S.Settings.LoggingEnvOverride">目前記錄等級由環境變數 OVERTRANSLATE_LOGLEVEL 指定，此選項暫時無效。</sys:String>
     <sys:String x:Key="S.Settings.StartupFailed">✗ 無法設定開機啟動：{0}</sys:String>
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ 無法開啟資料夾：{0}</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExported">✓ 已匯出診斷資訊到桌面</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ 無法匯出診斷資訊：{0}</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} 已指派給「{1}」</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Services/DiagnosticBundleService.cs
+++ b/src/OverTranslate/Services/DiagnosticBundleService.cs
@@ -1,0 +1,334 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Encodings.Web;
+using NLog;
+using NLog.Targets;
+
+namespace OverTranslate.Services;
+
+/// <summary>
+/// Packs the log files and a description of the machine into one zip on the desktop, so reporting a
+/// problem is a drag and a drop instead of being talked through where %AppData% is.
+/// </summary>
+/// <remarks>
+/// Everything here stays on the user's disk: nothing is sent anywhere, and the file is left
+/// somewhere they can open it and read what they are about to hand over. That is the whole privacy
+/// story, and it is why the bundle can afford to contain the log verbatim — 記錄詳細資訊 puts the
+/// recognised text in there, which is whatever was on their screen.
+///
+/// The one thing that is not verbatim is the settings file: an API key is a credential, it is of no
+/// diagnostic use, and a user pasting a zip into a public forum thread cannot be expected to think
+/// of it. See <see cref="RedactSettings"/>.
+/// </remarks>
+public static class DiagnosticBundleService
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    /// <summary>The NLog target whose file name tells us where the log actually is.</summary>
+    private const string FileTargetName = "file";
+
+    /// <summary>
+    /// Property-name endings whose value is a credential. Matched on the ending rather than a list
+    /// of the three names that exist today, so a provider added later is covered by default — the
+    /// failure mode of a new key leaking is worse than that of a new field being hidden.
+    /// </summary>
+    /// <remarks>
+    /// "Key" alone is deliberately not here: <c>HotkeyVirtualKey</c> and its siblings end in it, and
+    /// hiding which key a user's shortcut is bound to would remove one of the more useful things in
+    /// the file.
+    /// </remarks>
+    private static readonly string[] SecretSuffixes = { "ApiKey", "Token", "Secret", "Password" };
+
+    /// <summary>
+    /// Where NLog is writing, asked of NLog rather than restated from NLog.config — the two would
+    /// otherwise have to be kept in step by hand, and an environment that redirected the log is
+    /// exactly the kind whose log we would then fail to collect.
+    /// </summary>
+    public static string LogDirectory
+    {
+        get
+        {
+            try
+            {
+                if (LogManager.Configuration?.FindTargetByName(FileTargetName) is FileTarget target)
+                {
+                    var rendered = target.FileName.Render(LogEventInfo.CreateNullEvent());
+                    var directory = Path.GetDirectoryName(rendered);
+                    if (!string.IsNullOrWhiteSpace(directory))
+                        return directory;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex, "Could not read the log path from the NLog configuration");
+            }
+
+            return DefaultLogDirectory;
+        }
+    }
+
+    /// <summary>What NLog.config resolves to when nothing has moved it.</summary>
+    private static string DefaultLogDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OverTranslate", "logs");
+
+    /// <summary>
+    /// Opens the log folder in Explorer, creating it first so the button works on a machine that has
+    /// not written a line yet.
+    /// </summary>
+    public static void OpenLogFolder()
+    {
+        var directory = LogDirectory;
+        Directory.CreateDirectory(directory);
+        Process.Start(new ProcessStartInfo(directory) { UseShellExecute = true });
+    }
+
+    /// <summary>
+    /// Writes the bundle and returns its full path. Blocking — call it off the UI thread.
+    /// </summary>
+    /// <param name="destinationDirectory">
+    /// Where to put the zip, or null for the desktop. The desktop is the default because the file
+    /// exists to be dragged into a forum post, and a folder the user has to go and find is the
+    /// problem this feature is trying to remove.
+    /// </param>
+    public static string Export(string? destinationDirectory = null)
+    {
+        // Taken now rather than trusted to still be in the log: the launch snapshot is the only one
+        // shipped builds keep, and on a machine that has been up for days the rolling archive has
+        // long since dropped it. This one is written at Info so it survives the same trimming.
+        DisplayDiagnostics.LogSnapshot("diagnostic-export", level: LogLevel.Info);
+
+        // keepFileOpen is on, so the most recent lines — including the snapshot above — are still in
+        // NLog's buffer and would be missing from the copy taken below.
+        LogManager.Flush();
+
+        var directory = ResolveDestination(destinationDirectory);
+        Directory.CreateDirectory(directory);
+
+        var path = Path.Combine(
+            directory,
+            $"OverTranslate-diagnostics-{DateTime.Now:yyyyMMdd-HHmmss}.zip");
+
+        using (var archive = ZipFile.Open(path, ZipArchiveMode.Create))
+        {
+            AddText(archive, "environment.txt", BuildEnvironmentReport());
+            AddText(archive, "appsettings.redacted.json", ReadRedactedSettings());
+            AddLogs(archive);
+        }
+
+        Log.Info("Diagnostic bundle written to {0}", path);
+        return path;
+    }
+
+    /// <summary>Opens Explorer with the file already selected.</summary>
+    public static void Reveal(string path)
+    {
+        // No space after the comma: explorer treats "/select, C:\..." as two arguments and opens the
+        // Documents folder instead of the one asked for.
+        Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{path}\"")
+        {
+            UseShellExecute = true
+        });
+    }
+
+    /// <summary>
+    /// Returns the settings JSON with every credential replaced by a note saying one was there.
+    /// </summary>
+    /// <remarks>
+    /// A note rather than an empty string, and with the length in it: "is a key set at all, and is
+    /// it the length a key of this kind should be" answers a good share of the reports this file is
+    /// collected for, and neither question can be asked of a blank.
+    ///
+    /// Unparseable input is returned as-is only when it is not JSON at all — that file cannot hold a
+    /// key in a field we would recognise anyway, and its shape is itself the bug being reported.
+    /// </remarks>
+    public static string RedactSettings(string json)
+    {
+        JsonNode? root;
+        try
+        {
+            root = JsonNode.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return json;
+        }
+
+        if (root is not JsonObject obj)
+            return json;
+
+        RedactInPlace(obj);
+        return obj.ToJsonString(ReadableJson);
+    }
+
+    /// <summary>
+    /// Relaxed escaping, because this copy is written to be read by a person. The default encoder
+    /// escapes everything outside a conservative ASCII set, which writes a shortcut as
+    /// <c>Ctrl+Alt+A</c> and a Chinese prompt as an unbroken run of <c>\uXXXX</c> — in a
+    /// file whose whole purpose is being read by whoever is diagnosing the report. Safe here in a
+    /// way it would not be elsewhere: this string goes into a zip, never into a web page.
+    /// </summary>
+    private static readonly JsonSerializerOptions ReadableJson = new()
+    {
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private static void RedactInPlace(JsonObject obj)
+    {
+        // Materialised first: the loop reassigns properties, which cannot be done while enumerating
+        // the live collection.
+        foreach (var name in obj.Select(pair => pair.Key).ToList())
+        {
+            switch (obj[name])
+            {
+                // Realtime keeps its own copy of the provider settings, so the walk has to recurse
+                // rather than only look at the top level.
+                case JsonObject nested:
+                    RedactInPlace(nested);
+                    continue;
+
+                case JsonValue value when value.TryGetValue(out string? text):
+                    if (IsSecret(name))
+                        obj[name] = Mask(text);
+                    else if (name.EndsWith("BaseUrl", StringComparison.Ordinal))
+                        obj[name] = StripUrlCredentials(text);
+                    continue;
+            }
+        }
+    }
+
+    private static bool IsSecret(string name) =>
+        SecretSuffixes.Any(suffix => name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+
+    private static string Mask(string? value) =>
+        string.IsNullOrEmpty(value) ? "" : $"<redacted:{value.Length}>";
+
+    /// <summary>
+    /// Keeps the address but drops anything credential-shaped hanging off it.
+    /// </summary>
+    /// <remarks>
+    /// The address itself is kept on purpose: whether someone is pointed at api.openai.com, at
+    /// localhost:11434, or at a machine on their own network is most of the diagnosis when an
+    /// OpenAI-compatible provider misbehaves. What cannot be kept is a token someone put in the
+    /// user info or the query string, which some self-hosted front ends still ask for.
+    /// </remarks>
+    private static string StripUrlCredentials(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return value ?? "";
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)) return value;
+        if (string.IsNullOrEmpty(uri.UserInfo) && string.IsNullOrEmpty(uri.Query)) return value;
+
+        var builder = new UriBuilder(uri) { UserName = "", Password = "", Query = "" };
+        return builder.Uri.ToString();
+    }
+
+    private static string ReadRedactedSettings()
+    {
+        try
+        {
+            return RedactSettings(File.ReadAllText(SettingsService.FilePath));
+        }
+        catch (Exception ex)
+        {
+            // A bundle that is missing one of its three files is still worth having, and the reason
+            // it is missing belongs in the bundle rather than in a message box.
+            return $"Could not read {SettingsService.FilePath}: {ex.Message}";
+        }
+    }
+
+    private static void AddLogs(ZipArchive archive)
+    {
+        var directory = LogDirectory;
+        if (!Directory.Exists(directory)) return;
+
+        foreach (var file in Directory.GetFiles(directory, "*.log"))
+        {
+            try
+            {
+                // NLog holds app.log open for writing, so the ordinary ZipFile helpers — which ask
+                // for FileShare.Read — cannot read the one file the bundle exists for.
+                using var source = new FileStream(
+                    file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var entry = archive
+                    .CreateEntry($"logs/{Path.GetFileName(file)}", CompressionLevel.Optimal)
+                    .Open();
+                source.CopyTo(entry);
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex, "Could not add {0} to the diagnostic bundle", file);
+            }
+        }
+    }
+
+    private static void AddText(ZipArchive archive, string entryName, string content)
+    {
+        using var stream = archive.CreateEntry(entryName, CompressionLevel.Optimal).Open();
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false));
+        writer.Write(content);
+    }
+
+    /// <summary>
+    /// The facts about the machine that the log does not already carry. The display topology is not
+    /// repeated here — <see cref="Export"/> writes a fresh snapshot of it into the log itself, where
+    /// it sits in order beside whatever went wrong.
+    /// </summary>
+    private static string BuildEnvironmentReport()
+    {
+        var sb = new StringBuilder();
+        var process = Process.GetCurrentProcess();
+
+        sb.AppendLine("=== OverTranslate diagnostics ===");
+        sb.AppendLine($"generated : {DateTimeOffset.Now:yyyy-MM-dd HH:mm:ss zzz}");
+        sb.AppendLine($"app       : v{Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0"}");
+        sb.AppendLine($"install   : {AppContext.BaseDirectory}");
+        sb.AppendLine($"framework : {RuntimeInformation.FrameworkDescription}");
+        sb.AppendLine($"os        : {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
+        sb.AppendLine(
+            $"process   : {RuntimeInformation.ProcessArchitecture} " +
+            $"uptime={DateTime.Now - process.StartTime:hh\\:mm\\:ss} " +
+            $"workingSet={process.WorkingSet64 / (1024 * 1024)}MB");
+        sb.AppendLine(
+            $"culture   : {CultureInfo.CurrentCulture.Name} " +
+            $"ui={CultureInfo.CurrentUICulture.Name} " +
+            $"app={LocalizationService.Current}");
+        sb.AppendLine(
+            $"logging   : verbose={SettingsService.Instance.Current.VerboseLogging} " +
+            $"envOverride={LogLevelService.IsOverriddenByEnvironment}");
+        sb.AppendLine($"settings  : {SettingsService.FilePath}");
+        sb.AppendLine($"logs      : {LogDirectory}");
+        sb.AppendLine();
+        sb.AppendLine("=== What is in this file ===");
+        sb.AppendLine("environment.txt            this file");
+        sb.AppendLine("appsettings.redacted.json  your settings, with API keys replaced by their length");
+        sb.AppendLine("logs/app.log               the current log; the numbered ones are older");
+        sb.AppendLine();
+        sb.AppendLine("Nothing here was sent anywhere — this file was written to your disk and is");
+        sb.AppendLine("yours to read before you attach it. The log can contain text that was on your");
+        sb.AppendLine("screen while 記錄詳細資訊 was switched on.");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The desktop, or the next writable thing if this account has no desktop folder — a bundle in
+    /// the temp folder is recoverable, a failed export is not.
+    /// </summary>
+    private static string ResolveDestination(string? requested)
+    {
+        if (!string.IsNullOrWhiteSpace(requested)) return requested;
+
+        var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+        if (!string.IsNullOrWhiteSpace(desktop)) return desktop;
+
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        return string.IsNullOrWhiteSpace(documents) ? Path.GetTempPath() : documents;
+    }
+}

--- a/src/OverTranslate/Services/DiagnosticBundleService.cs
+++ b/src/OverTranslate/Services/DiagnosticBundleService.cs
@@ -14,8 +14,8 @@ using NLog.Targets;
 namespace OverTranslate.Services;
 
 /// <summary>
-/// Packs the log files and a description of the machine into one zip on the desktop, so reporting a
-/// problem is a drag and a drop instead of being talked through where %AppData% is.
+/// Packs the log files and a description of the machine into one zip, so reporting a problem is a
+/// drag and a drop instead of being talked through where %AppData% is.
 /// </summary>
 /// <remarks>
 /// Everything here stays on the user's disk: nothing is sent anywhere, and the file is left
@@ -93,9 +93,7 @@ public static class DiagnosticBundleService
     /// Writes the bundle and returns its full path. Blocking — call it off the UI thread.
     /// </summary>
     /// <param name="destinationDirectory">
-    /// Where to put the zip, or null for the desktop. The desktop is the default because the file
-    /// exists to be dragged into a forum post, and a folder the user has to go and find is the
-    /// problem this feature is trying to remove.
+    /// Where to put the zip, or null for <see cref="DefaultExportDirectory"/>.
     /// </param>
     public static string Export(string? destinationDirectory = null)
     {
@@ -304,6 +302,7 @@ public static class DiagnosticBundleService
             $"envOverride={LogLevelService.IsOverriddenByEnvironment}");
         sb.AppendLine($"settings  : {SettingsService.FilePath}");
         sb.AppendLine($"logs      : {LogDirectory}");
+        sb.AppendLine($"exports   : {DefaultExportDirectory}");
         sb.AppendLine();
         sb.AppendLine("=== What is in this file ===");
         sb.AppendLine("environment.txt            this file");
@@ -318,17 +317,19 @@ public static class DiagnosticBundleService
     }
 
     /// <summary>
-    /// The desktop, or the next writable thing if this account has no desktop folder — a bundle in
-    /// the temp folder is recoverable, a failed export is not.
+    /// Beside the settings and the logs, in the folder this application already owns.
     /// </summary>
-    private static string ResolveDestination(string? requested)
-    {
-        if (!string.IsNullOrWhiteSpace(requested)) return requested;
+    /// <remarks>
+    /// Not the desktop, which is the user's space rather than ours: exports accumulate — the point
+    /// of the timestamp in the name is that a second attempt does not overwrite the first — and a
+    /// feature that drops another file onto someone's desktop every time they are asked for one is
+    /// a feature they end up tidying up after. Here they sit beside the logs they were made from,
+    /// and Explorer opens with the file already selected either way, so nothing is harder to find.
+    /// </remarks>
+    private static string DefaultExportDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "OverTranslate", "diagnostics");
 
-        var desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
-        if (!string.IsNullOrWhiteSpace(desktop)) return desktop;
-
-        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        return string.IsNullOrWhiteSpace(documents) ? Path.GetTempPath() : documents;
-    }
+    private static string ResolveDestination(string? requested) =>
+        string.IsNullOrWhiteSpace(requested) ? DefaultExportDirectory : requested;
 }

--- a/src/OverTranslate/Services/SettingsService.cs
+++ b/src/OverTranslate/Services/SettingsService.cs
@@ -18,6 +18,12 @@ public class SettingsService
 
     private static readonly string SettingsPath = Path.Combine(SettingsDirectory, "appsettings.json");
 
+    /// <summary>
+    /// Where the settings actually are, for the one caller that needs the file rather than the
+    /// values in it: <see cref="DiagnosticBundleService"/> copies it into a problem report.
+    /// </summary>
+    public static string FilePath => SettingsPath;
+
     // Where 1.7.0 and earlier kept the file. Velopack has usually deleted it by the time an updated
     // build runs, but when it survives — a build relaunched in place, a dev run — those are still the
     // user's settings, so read them once on the way to the new location.

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -703,98 +703,167 @@
                     </StackPanel>
                 </Border>
 
-                <!-- ══════════ 外觀 ══════════ -->
-                <Border Grid.Column="0" Grid.Row="2"
-                        Style="{StaticResource CardBorder}"
-                        Margin="0,0,12,12">
-                    <StackPanel>
-                        <StackPanel Style="{StaticResource CardHeaderRow}">
-                            <TextBlock Text="&#xE790;" Style="{StaticResource CardHeaderIcon}"/>
-                            <TextBlock Text="{DynamicResource S.Settings.Appearance}"
-                                       Style="{StaticResource CardTitle}"/>
-                        </StackPanel>
-
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.Theme}"
-                                       Style="{StaticResource FieldLabel}"/>
-                            <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                <RadioButton x:Name="LightThemeRadio"
-                                             Content="{DynamicResource S.Settings.ThemeLight}"
-                                             GroupName="ThemeGroup"
-                                             Style="{StaticResource ThemeRadioButton}"
-                                             Checked="ThemeRadio_Checked"/>
-                                <RadioButton x:Name="DarkThemeRadio"
-                                             Content="{DynamicResource S.Settings.ThemeDark}"
-                                             GroupName="ThemeGroup"
-                                             Style="{StaticResource ThemeRadioButton}"
-                                             Margin="0"
-                                             Checked="ThemeRadio_Checked"/>
+                <!-- The bottom row splits evenly, unlike the 1.6*/* the rows above it use.
+                     Those columns are sized by what is in them — four shortcut rows against one
+                     checkbox and a path. These two are a theme picker and a logging card, and
+                     neither has a claim on the extra width, so a shared row of their own keeps the
+                     split off the columns the rows above depend on. -->
+                <Grid Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <!-- ══════════ 外觀 ══════════ -->
+                    <Border Grid.Column="0"
+                            Style="{StaticResource CardBorder}"
+                            Margin="0,0,12,12">
+                        <StackPanel>
+                            <StackPanel Style="{StaticResource CardHeaderRow}">
+                                <TextBlock Text="&#xE790;" Style="{StaticResource CardHeaderIcon}"/>
+                                <TextBlock Text="{DynamicResource S.Settings.Appearance}"
+                                           Style="{StaticResource CardTitle}"/>
                             </StackPanel>
-                        </Grid>
-                    </StackPanel>
-                </Border>
 
-                <!-- ══════════ 進階設定 ══════════
-                     Nothing here is part of translating, and a user who never has a problem to
-                     report never needs to read it. -->
-                <Border Grid.Column="1" Grid.Row="2" Style="{StaticResource CardBorder}">
-                    <StackPanel>
-                        <StackPanel Style="{StaticResource CardHeaderRow}">
-                            <TextBlock Text="&#xE7BA;" Style="{StaticResource CardHeaderIcon}"/>
-                            <TextBlock Text="{DynamicResource S.Settings.Advanced}"
-                                       Style="{StaticResource CardTitle}"/>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsLabel"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{DynamicResource S.Settings.Theme}"
+                                           Style="{StaticResource FieldLabel}"/>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                    <RadioButton x:Name="LightThemeRadio"
+                                                 Content="{DynamicResource S.Settings.ThemeLight}"
+                                                 GroupName="ThemeGroup"
+                                                 Style="{StaticResource ThemeRadioButton}"
+                                                 Checked="ThemeRadio_Checked"/>
+                                    <RadioButton x:Name="DarkThemeRadio"
+                                                 Content="{DynamicResource S.Settings.ThemeDark}"
+                                                 GroupName="ThemeGroup"
+                                                 Style="{StaticResource ThemeRadioButton}"
+                                                 Margin="0"
+                                                 Checked="ThemeRadio_Checked"/>
+                                </StackPanel>
+                            </Grid>
                         </StackPanel>
+                    </Border>
 
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            <CheckBox  Grid.Column="0" x:Name="VerboseLoggingCheckBox"
-                                       Style="{StaticResource ModernCheckBox}"
-                                       VerticalAlignment="Top"
-                                       ToolTip="{DynamicResource S.Settings.Logging}"
-                                       Checked="VerboseLogging_Toggled"
-                                       Unchecked="VerboseLogging_Toggled"/>
-                            <TextBlock Grid.Column="1" Text="&#xE9D9;" Style="{StaticResource OptionGlyph}"/>
-                            <StackPanel Grid.Column="2">
-                                <TextBlock Text="{DynamicResource S.Settings.LoggingCheck}"
-                                           Style="{StaticResource OptionTitle}"/>
-                                <TextBlock x:Name="VerboseLoggingHint"
-                                           Text="{DynamicResource S.Settings.LoggingHint}"
-                                           Style="{StaticResource OptionDescription}"/>
+                    <!-- ══════════ 進階設定 ══════════
+                         Nothing here is part of translating, and a user who never has a problem to
+                         report never needs to read it. -->
+                    <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                        <StackPanel>
+                            <StackPanel Style="{StaticResource CardHeaderRow}">
+                                <TextBlock Text="&#xE7BA;" Style="{StaticResource CardHeaderIcon}"/>
+                                <TextBlock Text="{DynamicResource S.Settings.Advanced}"
+                                           Style="{StaticResource CardTitle}"/>
+
+                                <!-- What the export actually collects, on the heading for the same
+                                     reason the shortcut card's does: it is read once, before the first
+                                     export, and never again — while a paragraph spelling it out sits
+                                     above the buttons for good, taking more room than the two controls
+                                     it describes. Background and Padding as there: a bare TextBlock is
+                                     only hit-testable across the glyph's own strokes. -->
+                                <TextBlock Text="&#xE946;"
+                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                           FontSize="14"
+                                           Foreground="{DynamicResource AppTextSecondary}"
+                                           Background="Transparent"
+                                           Padding="4,2"
+                                           Margin="7,1,0,0"
+                                           VerticalAlignment="Center"
+                                           Cursor="Help">
+                                    <controls:HoverToolTip.Content>
+                                        <TextBlock Text="{DynamicResource S.Settings.DiagnosticsHint}"
+                                                   MaxWidth="420"
+                                                   FontFamily="{StaticResource AppFont}"
+                                                   FontSize="{StaticResource AppFontSize}"
+                                                   TextWrapping="Wrap"
+                                                   LineHeight="18"/>
+                                    </controls:HoverToolTip.Content>
+                                </TextBlock>
                             </StackPanel>
-                        </Grid>
 
-                        <!-- Below the checkbox rather than beside it: the box decides what gets
-                             written, these two decide what happens to what was written, and the
-                             usual order of that conversation is tick, reproduce, then hand over. -->
-                        <StackPanel Margin="0,16,0,0">
-                            <TextBlock Text="{DynamicResource S.Settings.DiagnosticsHint}"
-                                       Style="{StaticResource OptionDescription}"
-                                       Margin="0,0,0,10"/>
-                            <StackPanel Orientation="Horizontal">
-                                <Button x:Name="ExportDiagnosticsBtn"
-                                        Content="{DynamicResource S.Settings.ExportDiagnostics}"
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <CheckBox  Grid.Column="0" x:Name="VerboseLoggingCheckBox"
+                                           Style="{StaticResource ModernCheckBox}"
+                                           VerticalAlignment="Top"
+                                           ToolTip="{DynamicResource S.Settings.Logging}"
+                                           Checked="VerboseLogging_Toggled"
+                                           Unchecked="VerboseLogging_Toggled"/>
+                                <TextBlock Grid.Column="1" Text="&#xE9D9;" Style="{StaticResource OptionGlyph}"/>
+                                <StackPanel Grid.Column="2">
+                                    <TextBlock Text="{DynamicResource S.Settings.LoggingCheck}"
+                                               Style="{StaticResource OptionTitle}"/>
+                                    <TextBlock x:Name="VerboseLoggingHint"
+                                               Text="{DynamicResource S.Settings.LoggingHint}"
+                                               Style="{StaticResource OptionDescription}"/>
+                                </StackPanel>
+                            </Grid>
+
+                            <!-- Below the checkbox rather than beside it: the box decides what gets
+                                 written, these two decide what happens to what was written, and the
+                                 usual order of that conversation is tick, reproduce, then hand over.
+
+                                 Two equal columns filling the card rather than two buttons sized to
+                                 their own labels. The labels are different lengths in both languages,
+                                 so left-packed buttons leave a ragged edge against a card whose every
+                                 other row runs the full width.
+
+                                 Accent on the export and not on the folder: one of these is what the
+                                 card is for and the other is the way out for someone who wants to look
+                                 before they hand anything over. -->
+                            <Grid Margin="0,16,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <Button Grid.Column="0" x:Name="ExportDiagnosticsBtn"
+                                        Style="{StaticResource AccentButton}"
+                                        Height="34"
+                                        Margin="0,0,4,0"
+                                        Click="ExportDiagnosticsBtn_Click">
+                                    <StackPanel Orientation="Horizontal">
+                                        <!-- Upload, the pair of the Download glyph 更新 already uses
+                                             on this same shape of control. No Foreground on
+                                             either block: both inherit the button's, which is
+                                             the one thing that differs between these two styles
+                                             and the one thing that must keep differing. -->
+                                        <TextBlock Text="&#xE898;"
+                                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="13"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,6,0"/>
+                                        <TextBlock Text="{DynamicResource S.Settings.ExportDiagnostics}"
+                                                   VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+
+                                <Button Grid.Column="1" x:Name="OpenLogFolderBtn"
                                         Style="{StaticResource FlatButton}"
                                         Height="34"
-                                        Margin="0,0,8,0"
-                                        ToolTip="{DynamicResource S.Settings.ExportDiagnosticsTip}"
-                                        Click="ExportDiagnosticsBtn_Click"/>
-                                <Button x:Name="OpenLogFolderBtn"
-                                        Content="{DynamicResource S.Settings.OpenLogFolder}"
-                                        Style="{StaticResource FlatButton}"
-                                        Height="34"
-                                        Click="OpenLogFolderBtn_Click"/>
-                            </StackPanel>
+                                        Margin="4,0,0,0"
+                                        Click="OpenLogFolderBtn_Click">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="&#xE838;"
+                                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="13"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,6,0"/>
+                                        <TextBlock Text="{DynamicResource S.Settings.OpenLogFolder}"
+                                                   VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                            </Grid>
                         </StackPanel>
-                    </StackPanel>
-                </Border>
+                    </Border>
+                </Grid>
             </Grid>
         </ScrollViewer>
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -770,6 +770,29 @@
                                            Style="{StaticResource OptionDescription}"/>
                             </StackPanel>
                         </Grid>
+
+                        <!-- Below the checkbox rather than beside it: the box decides what gets
+                             written, these two decide what happens to what was written, and the
+                             usual order of that conversation is tick, reproduce, then hand over. -->
+                        <StackPanel Margin="0,16,0,0">
+                            <TextBlock Text="{DynamicResource S.Settings.DiagnosticsHint}"
+                                       Style="{StaticResource OptionDescription}"
+                                       Margin="0,0,0,10"/>
+                            <StackPanel Orientation="Horizontal">
+                                <Button x:Name="ExportDiagnosticsBtn"
+                                        Content="{DynamicResource S.Settings.ExportDiagnostics}"
+                                        Style="{StaticResource FlatButton}"
+                                        Height="34"
+                                        Margin="0,0,8,0"
+                                        ToolTip="{DynamicResource S.Settings.ExportDiagnosticsTip}"
+                                        Click="ExportDiagnosticsBtn_Click"/>
+                                <Button x:Name="OpenLogFolderBtn"
+                                        Content="{DynamicResource S.Settings.OpenLogFolder}"
+                                        Style="{StaticResource FlatButton}"
+                                        Height="34"
+                                        Click="OpenLogFolderBtn_Click"/>
+                            </StackPanel>
+                        </StackPanel>
                     </StackPanel>
                 </Border>
             </Grid>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -221,9 +221,15 @@ public partial class SettingsPage : UserControl
         FlashSaved();
     }
 
-    private void FlashSaved()
+    private void FlashSaved() => FlashSuccess(LocalizationService.Get("S.Settings.Saved"));
+
+    /// <summary>
+    /// The same line the auto-save confirmation uses, for the handful of actions that finish with
+    /// something to say other than 已儲存 — an export naming the file it wrote, so far.
+    /// </summary>
+    private void FlashSuccess(string message)
     {
-        StatusText.Text       = LocalizationService.Get("S.Settings.Saved");
+        StatusText.Text       = message;
         StatusText.Foreground = (Brush)FindResource("AppSuccess");
 
         StatusText.BeginAnimation(OpacityProperty, null);
@@ -442,6 +448,48 @@ public partial class SettingsPage : UserControl
         catch (Exception ex)
         {
             ShowError(LocalizationService.Format("S.Settings.OpenFolderFailed", ex.Message));
+        }
+    }
+
+    private void OpenLogFolderBtn_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            DiagnosticBundleService.OpenLogFolder();
+        }
+        catch (Exception ex)
+        {
+            ShowError(LocalizationService.Format("S.Settings.OpenFolderFailed", ex.Message));
+        }
+    }
+
+    /// <remarks>
+    /// Off the UI thread because the bundle copies and compresses every log file there is, which on
+    /// a machine that has filled its five archives is a dozen megabytes — not long, but long enough
+    /// to freeze the window on a slow disk, and freezing while collecting a bug report is its own
+    /// bug report. The button is disabled meanwhile so the same zip cannot be started twice.
+    /// </remarks>
+    private async void ExportDiagnosticsBtn_Click(object sender, RoutedEventArgs e)
+    {
+        ExportDiagnosticsBtn.IsEnabled = false;
+        try
+        {
+            var path = await Task.Run(() => DiagnosticBundleService.Export());
+
+            FlashSuccess(LocalizationService.Get("S.Settings.DiagnosticsExported"));
+
+            // The real confirmation: the status line fades after a moment and cannot show a path
+            // worth reading anyway, whereas Explorer opens with the file already selected and ready
+            // to be dragged into a forum post — which is the entire point of the feature.
+            DiagnosticBundleService.Reveal(path);
+        }
+        catch (Exception ex)
+        {
+            ShowError(LocalizationService.Format("S.Settings.DiagnosticsFailed", ex.Message));
+        }
+        finally
+        {
+            ExportDiagnosticsBtn.IsEnabled = true;
         }
     }
 

--- a/tests/OverTranslate.Tests/DiagnosticRedactionTests.cs
+++ b/tests/OverTranslate.Tests/DiagnosticRedactionTests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json.Nodes;
+using OverTranslate.Services;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+// The settings file goes into a zip the user is expected to hand to a stranger — a forum thread, an
+// issue, eventually an upload. A credential that survives that trip is the one mistake this feature
+// can make that the user cannot undo, so the rule that decides what gets hidden is pinned here
+// rather than left to be re-read out of the implementation.
+public class DiagnosticRedactionTests
+{
+    [Fact]
+    public void ApiKeys_AreReplacedByTheirLength()
+    {
+        var json = DiagnosticBundleService.RedactSettings(
+            """{"ApiKey":"secret-value","OpenAiApiKey":"sk-0123456789"}""");
+
+        var obj = JsonNode.Parse(json)!.AsObject();
+
+        // The length rather than a blank: whether a key is set at all, and whether it is the length
+        // a key of that kind should be, answers a good share of the reports this file is collected
+        // for — and neither question can be asked of an empty string.
+        Assert.Equal("<redacted:12>", (string?)obj["ApiKey"]);
+        Assert.Equal("<redacted:13>", (string?)obj["OpenAiApiKey"]);
+    }
+
+    [Fact]
+    public void UnsetKey_StaysEmptyRatherThanLookingSet()
+    {
+        var json = DiagnosticBundleService.RedactSettings("""{"ApiKey":""}""");
+
+        // "<redacted:0>" would say a key was hidden when there was none, and send whoever reads the
+        // bundle looking for an authentication problem that cannot exist.
+        Assert.Equal("", (string?)JsonNode.Parse(json)!.AsObject()["ApiKey"]);
+    }
+
+    [Fact]
+    public void HotkeyFields_SurviveRedaction()
+    {
+        var json = DiagnosticBundleService.RedactSettings(
+            """{"HotkeyVirtualKey":65,"HotkeyDisplay":"Ctrl+Alt+A"}""");
+
+        var obj = JsonNode.Parse(json)!.AsObject();
+
+        // The reason the rule matches "ApiKey" and not "Key". Which key a shortcut is bound to is
+        // one of the more useful things in this file, and every hotkey field ends in Key.
+        Assert.Equal(65, (int?)obj["HotkeyVirtualKey"]);
+        Assert.Equal("Ctrl+Alt+A", (string?)obj["HotkeyDisplay"]);
+    }
+
+    [Fact]
+    public void NestedRealtimeSettings_AreRedactedToo()
+    {
+        var json = DiagnosticBundleService.RedactSettings(
+            """{"Realtime":{"OpenAiApiKey":"sk-abcdef","TargetLanguage":"JA"}}""");
+
+        var realtime = JsonNode.Parse(json)!.AsObject()["Realtime"]!.AsObject();
+
+        // Realtime keeps its own copy of the provider settings, so a walk that only looked at the
+        // top level would leak the key from the half of the app that has two of them.
+        Assert.Equal("<redacted:9>", (string?)realtime["OpenAiApiKey"]);
+        Assert.Equal("JA", (string?)realtime["TargetLanguage"]);
+    }
+
+    [Fact]
+    public void BaseUrl_KeepsTheAddressAndDropsTheCredentials()
+    {
+        var json = DiagnosticBundleService.RedactSettings(
+            """{"OpenAiBaseUrl":"https://user:pw@example.com/v1?token=abc"}""");
+
+        var url = (string?)JsonNode.Parse(json)!.AsObject()["OpenAiBaseUrl"];
+
+        // The host is most of the diagnosis when an OpenAI-compatible provider misbehaves, so it
+        // stays; the user info and query string are where self-hosted front ends put tokens.
+        Assert.NotNull(url);
+        Assert.Contains("example.com/v1", url);
+        Assert.DoesNotContain("pw", url);
+        Assert.DoesNotContain("abc", url);
+    }
+
+    [Fact]
+    public void PlainBaseUrl_IsLeftAlone()
+    {
+        var json = DiagnosticBundleService.RedactSettings(
+            """{"OpenAiBaseUrl":"http://localhost:11434/v1"}""");
+
+        // Pointed at a local model or at a hosted one is the first thing to establish, and rewriting
+        // an address that had nothing to hide only invites doubt about what else was rewritten.
+        Assert.Equal(
+            "http://localhost:11434/v1",
+            (string?)JsonNode.Parse(json)!.AsObject()["OpenAiBaseUrl"]);
+    }
+
+    [Fact]
+    public void FileThatIsNotJson_IsReturnedUnchanged()
+    {
+        const string broken = "{ this was truncated by a power cut";
+
+        // A file in this shape cannot hold a key in a field we would recognise, and its shape is
+        // itself the bug being reported — so it goes into the bundle exactly as found.
+        Assert.Equal(broken, DiagnosticBundleService.RedactSettings(broken));
+    }
+}


### PR DESCRIPTION
Closes #126

回報問題以前只有「記錄詳細資訊」這個勾選框，勾完就沒有然後了——使用者得自己知道 `%AppData%` 在哪、自己找檔案、自己判斷該給哪一份。設定頁上連一顆開啟資料夾的按鈕都沒有。

這個 PR 讓它變成按一下：診斷檔打包好，Explorer 直接開著並選取那個檔。**完全在本機，沒有任何東西被送出去**（上傳是 #127，且必須是手動觸發）。

## 內容

`Services/DiagnosticBundleService.cs`（新）打包成 `%AppData%\OverTranslate\diagnostics\OverTranslate-diagnostics-<時間戳>.zip`：

| 檔案 | 內容 |
|---|---|
| `environment.txt` | 版本、OS、framework、DPI／文化、記錄等級、各路徑 |
| `appsettings.redacted.json` | 目前設定，金鑰已遮蔽 |
| `logs/*.log` | 全部記錄檔，含 NLog 正佔用中的 `app.log` |

存在 `logs` 旁邊而不是桌面：檔名帶時間戳記代表匯出會累積，每回報一次就往桌面丟一個檔，最後是使用者在收拾。

## 遮蔽規則

打包出去的設定檔不能原封不動——把 zip 貼到公開討論串的人不會想到裡面有金鑰。

- 屬性名結尾為 `ApiKey` / `Token` / `Secret` / `Password` → 換成 `<redacted:長度>`
- **不能用 `Key` 結尾當規則**：`HotkeyVirtualKey` 那一整排會全中，而快捷鍵綁在哪個鍵是這份檔案裡最有用的資訊之一。有一條測試專門釘住這件事
- 留長度而非留空白：「有沒有填、長度像不像那家的金鑰」本身就能解掉一部分回報
- `OpenAiBaseUrl` 保留位址（指到 api.openai.com、localhost:11434 還是自家網段是主要線索），但拿掉 user info 與 query string
- `Realtime` 底下有自己一份供應商設定，遮蔽會遞迴走下去

## 三個實作上的坑

- `keepFileOpen="true"`，最新幾行還在 NLog 緩衝裡。打包前 `LogManager.Flush()`，否則收到的 log 缺的正是剛出事那幾行
- 同樣因為 NLog 佔著 `app.log`，`ZipFile.CreateFromDirectory` 這類 helper 用 `FileShare.Read` 會直接爆掉——爆的還是整包裡最重要的那個檔。改自己用 `FileShare.ReadWrite`
- `System.Text.Json` 預設編碼器把 `Ctrl+Alt+A` 寫成 `Ctrl\u002BAlt\u002BA`，中文 prompt 會整段變 `\uXXXX`。這份檔案的用途就是給人讀，改用 `UnsafeRelaxedJsonEscaping`（進 zip、不進網頁）

## 影響分析

- `DisplayDiagnostics.LogSnapshot` 判為 HIGH（2 個直接呼叫者、3 條執行流程）。**因此不改它**：改由 `Export()` 在打包前以 Info 呼叫一次，新鮮的顯示拓撲落進 log 一起被打包——比抽成回傳字串更好，快照會按時序排在出事那幾行旁邊
- `SettingsPage.FlashSaved` 判為 HIGH，但那是「每個 handler 都走它」的中樞效應。抽成帶參數的 `FlashSuccess`，簽章與行為不變

## 版面

- 說明文字收進「進階設定」標題列的 `` 提示圖示，比照快捷鍵卡的做法——它讀一次就不再讀，不值得長駐一整段
- 兩顆按鈕在卡片內平分滿版；匯出用 accent，開啟資料夾用 flat
- 匯出圖示 `E898`（Upload），是更新視窗下載按鈕 `E896` 的另一半，同一種形狀的控制項。字級與間距對齊它
- 最後一排包成一個橫跨兩欄、內部各半的 Grid，讓外觀與進階設定平分。外層欄寬 `1.6*`/`*` 是上面兩排撐出來的，不能動。`SettingsPage.xaml` 的 diff 偏大，絕大部分是這兩張卡多一層巢狀後整段內縮四格

## 驗證

- `dotnet build` 成功（唯一警告是 `RealtimeSessionController` 既有的 CA1416，不在改動範圍）
- `dotnet test` 560 通過 / 0 失敗
- 另用拋棄式 probe 實跑 `Export()`，確認落點正確、`app.log` 讀得到、JSON 可讀：4.5 MB 記錄檔壓成 412 KB。probe 跑完已刪除
- 候選圖示字符渲染成圖檢查過——原本挑的 `EDE1` 其實是登出箭頭

`PRIVACY.md` 補上 Logs and Diagnostics 一節（log 不會自動送出、詳細記錄會含螢幕文字、診斷檔裡金鑰只留長度）。#127 以它為前提。

**尚未人工檢查**：按鈕實際觀感、tooltip 觸發手感、兩張卡平分後的高度差，需要實際開起來看。
