### PR TITLE
feat: #127 診斷包一鍵上傳，以 Cloudflare Worker + KV 當收件口

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -102,7 +102,7 @@ Uploaded files are held by Cloudflare (Workers KV) in an account operated by the
 
 
 
-The source code of the receiving endpoint is public and can be read at https://github.com/asd880921/overtranslate-diag-worker
+The source code of the receiving endpoint is public and can be read at https://github.com/asd880921/OverTranslate-Diag-Worker
 
 
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 
 
-_Last updated: 2026-05-22_
+_Last updated: 2026-08-21_
 
 
 
@@ -19,6 +19,10 @@ OverTranslate does not collect, store, track, or sell any personal information.
 
 
 This application does not provide user accounts, analytics tracking, advertising tracking, or telemetry collection.
+
+
+
+The one thing that is ever sent to the developer is the diagnostic file described under "Logs and Diagnostics" below, and only when the user presses the button that sends it.
 
 
 
@@ -86,7 +90,19 @@ When "Record detailed information" is switched on in Settings, the log also reco
 
 
 
-Settings offers "Export diagnostics", which packs the log files, information about the device, and the current settings into a single zip file stored with the application's own data on the user's device. API keys are replaced by a note giving only their length. Nothing is uploaded; the user decides whether to share the file and with whom.
+Settings offers "Export and upload diagnostics", which packs the log files, information about the device, and the current settings into a single zip file stored with the application's own data on the user's device. API keys are replaced by a note giving only their length.
+
+
+
+Pressing that button also uploads the file and returns a short code the user can quote in a problem report. This happens only when that button is pressed. There is no automatic upload, no background upload, and no crash reporting. Whether the upload succeeds or fails, the file remains on the user's device, and a user who does not want to upload anything can still attach it by hand.
+
+
+
+Uploaded files are held by Cloudflare (Workers KV) in an account operated by the project maintainer, under a name that cannot be worked out from the code shown to the user, and are deleted automatically 30 days after upload. No IP address or other identifier is stored with them: the only information kept alongside the file is the time of upload, the application version, and the operating system it reported. The code identifies an upload to the maintainer only — the application offers no way to browse or download uploaded files.
+
+
+
+The source code of the receiving endpoint is public and can be read at https://github.com/asd880921/overtranslate-diag-worker
 
 
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -90,7 +90,7 @@ When "Record detailed information" is switched on in Settings, the log also reco
 
 
 
-Settings offers "Export and upload diagnostics", which packs the log files, information about the device, and the current settings into a single zip file stored with the application's own data on the user's device. API keys are replaced by a note giving only their length.
+Settings offers "Export and upload diagnostics", which packs the log files, information about the device, and the current settings into a single zip file stored with the application's own data on the user's device. API keys are replaced by a note giving only their length. That local copy is deleted automatically 30 days after it is created, whether or not it was uploaded.
 
 
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -381,11 +381,14 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.LoggingHint">Records more information about the app; only recommended while troubleshooting.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
-    <sys:String x:Key="S.Settings.OpenLogFolder">Open log folder</sys:String>
+    <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open diagnostics folder</sys:String>
     <sys:String x:Key="S.Settings.UploadDiagnostics">Export and upload diagnostics</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint">This collects the log files, system information and your current settings into one file — with API keys replaced by a note giving only their length — uploads it, and gives you back a short code to quote in your problem report. Nothing is ever sent unless you press this button, and the upload is deleted after 30 days. If the upload fails the file is still kept on your device.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsCodeHint">Quote this code in your problem report — there is no file to attach. Open file shows exactly what was sent. The upload is deleted after 30 days.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Upload failed</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully.&#x0a;Open file to see what was exported this time.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file.&#x0a;Open file to get what was exported this time.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsRetention">The uploaded file is deleted after 30 days</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">Copy</sys:String>
     <sys:String x:Key="S.Settings.OpenBundle">Open file</sys:String>
 
@@ -408,10 +411,7 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ Uploaded — code {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ Code copied</sys:String>
     <sys:String x:Key="S.Settings.CopyFailed">✗ Could not copy — read the code from the box above.</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedUnreachable">✗ Could not reach the upload service. The diagnostic file was kept on your device — attach it to your report instead.</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedTooLarge">✗ The diagnostic file is too large to upload. It was kept on your device — attach it to your report instead.</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedRateLimited">✗ Too many uploads just now. Try again in a minute, or attach the file kept on your device.</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedRejected">✗ The upload was refused. The diagnostic file was kept on your device — attach it to your report instead.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">✗ Could not upload the diagnostics</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} is already assigned to "{1}"</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -382,6 +382,12 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
     <sys:String x:Key="S.Settings.OpenLogFolder">Open log folder</sys:String>
+    <sys:String x:Key="S.Settings.UploadDiagnostics">Export and upload diagnostics</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">This collects the log files, system information and your current settings into one file — with API keys replaced by a note giving only their length — uploads it, and gives you back a short code to quote in your problem report. Nothing is ever sent unless you press this button, and the upload is deleted after 30 days. If the upload fails the file is still kept on your device.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsCodeHint">Quote this code in your problem report — there is no file to attach. Open file shows exactly what was sent. The upload is deleted after 30 days.</sys:String>
+    <sys:String x:Key="S.Settings.CopyCode">Copy</sys:String>
+    <sys:String x:Key="S.Settings.OpenBundle">Open file</sys:String>
 
     <sys:String x:Key="S.Settings.AutoSaveHint">Changes are saved automatically</sys:String>
 
@@ -398,6 +404,14 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ Could not open the folder: {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsExported">✓ Diagnostics exported</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ Could not export diagnostics: {0}</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploading">Collecting and uploading…</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ Uploaded — code {0}</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ Code copied</sys:String>
+    <sys:String x:Key="S.Settings.CopyFailed">✗ Could not copy — read the code from the box above.</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedUnreachable">✗ Could not reach the upload service. The diagnostic file was kept on your device — attach it to your report instead.</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedTooLarge">✗ The diagnostic file is too large to upload. It was kept on your device — attach it to your report instead.</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedRateLimited">✗ Too many uploads just now. Try again in a minute, or attach the file kept on your device.</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedRejected">✗ The upload was refused. The diagnostic file was kept on your device — attach it to your report instead.</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} is already assigned to "{1}"</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -381,14 +381,14 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.LoggingHint">Records more information about the app; only recommended while troubleshooting.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
-    <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open diagnostics folder</sys:String>
+    <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open folder</sys:String>
     <sys:String x:Key="S.Settings.UploadDiagnostics">Export and upload diagnostics</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">This collects the log files, system information and your current settings into one file — with API keys replaced by a note giving only their length — uploads it, and gives you back a short code to quote in your problem report. Nothing is ever sent unless you press this button, and the upload is deleted after 30 days. If the upload fails the file is still kept on your device.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">The diagnostics contain the log files, system information and your current settings, with sensitive data replaced.&#x0a;The diagnostic file is kept on your device and deleted automatically after 30 days.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Upload failed</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully.&#x0a;Open file to see what was exported this time.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file.&#x0a;Open file to get what was exported this time.</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsRetention">The uploaded file is deleted after 30 days</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsRetention">Files are deleted automatically after 30 days</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">Copy</sys:String>
     <sys:String x:Key="S.Settings.OpenBundle">Open file</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -383,11 +383,11 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open folder</sys:String>
     <sys:String x:Key="S.Settings.UploadDiagnostics">Export and upload diagnostics</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">The diagnostics contain the log files, system information and your current settings, with sensitive data replaced.&#x0a;The diagnostic file is kept on your device and deleted automatically after 30 days.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">The diagnostics contain the log files, system information and your current settings, with sensitive data replaced.&#x0a;The diagnostic file is kept on your device and deleted automatically after 30 days.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Upload failed</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully.&#x0a;Open file to see what was exported this time.</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file.&#x0a;Open file to get what was exported this time.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Diagnostics exported</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully.&#x0a;Open file to see what was exported this time.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file.&#x0a;Open file to get what was exported this time.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsRetention">Files are deleted automatically after 30 days</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">Copy</sys:String>
     <sys:String x:Key="S.Settings.OpenBundle">Open file</sys:String>
@@ -411,7 +411,7 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ Uploaded — code {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ Code copied</sys:String>
     <sys:String x:Key="S.Settings.CopyFailed">✗ Could not copy — read the code from the box above.</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">✗ Could not upload the diagnostics</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">⚠ The diagnostics were exported but could not be uploaded</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} is already assigned to "{1}"</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -405,9 +405,9 @@
     <sys:String x:Key="S.Settings.LoggingHint">啟用後會記錄更多應用程式資訊，僅建議於問題排查時開啟。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
-    <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟診斷資料夾</sys:String>
+    <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟資料夾</sys:String>
     <sys:String x:Key="S.Settings.UploadDiagnostics">匯出並上傳診斷資訊</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">按下後會把記錄檔、系統資訊與目前設定整理成一個檔案（API 金鑰只會保留長度，不會包含內容），上傳後回傳一組代碼，讓你貼在問題回報中。只有你按下這顆按鈕時才會送出，上傳的檔案 30 天後自動刪除；若上傳失敗，檔案仍會保留在你的電腦上。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">診斷資訊包含記錄檔、系統資訊與目前設定，敏感資料會被替換。&#x0a;診斷檔會保留在本機，並於 30 天後自動刪除。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">上傳失敗</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。&#x0a;按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -407,11 +407,11 @@
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟資料夾</sys:String>
     <sys:String x:Key="S.Settings.UploadDiagnostics">匯出並上傳診斷資訊</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">診斷資訊包含記錄檔、系統資訊與目前設定，敏感資料會被替換。&#x0a;診斷檔會保留在本機，並於 30 天後自動刪除。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">診斷資訊包含記錄檔、系統資訊與目前設定，敏感資料會被替換。&#x0a;診斷檔會保留在本機，並於 30 天後自動刪除。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">上傳失敗</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。&#x0a;按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint">診斷資訊已成功匯出，但無法上傳。請透過 GitHub 或論壇回報問題並附上檔案。&#x0a;按「開啟檔案」可取得本次匯出的診斷資訊。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">診斷資訊已匯出</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。&#x0a;按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">診斷資訊已成功匯出，但無法上傳。請透過 GitHub 或論壇回報問題並附上檔案。&#x0a;按「開啟檔案」可取得本次匯出的診斷資訊。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsRetention">檔案將於 30 天後自動刪除</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">複製</sys:String>
     <sys:String x:Key="S.Settings.OpenBundle">開啟檔案</sys:String>
@@ -435,7 +435,7 @@
     <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ 已上傳，代碼 {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ 已複製代碼</sys:String>
     <sys:String x:Key="S.Settings.CopyFailed">✗ 無法複製，請直接看上方顯示的代碼。</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">✗ 無法上傳診斷資訊</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">⚠ 診斷資訊已成功匯出，但無法進行上傳</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} 已指派給「{1}」</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -406,6 +406,12 @@
     <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.OpenLogFolder">開啟記錄資料夾</sys:String>
+    <sys:String x:Key="S.Settings.UploadDiagnostics">匯出並上傳診斷資訊</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadHint">按下後會把記錄檔、系統資訊與目前設定整理成一個檔案（API 金鑰只會保留長度，不會包含內容），上傳後回傳一組代碼，讓你貼在問題回報中。只有你按下這顆按鈕時才會送出，上傳的檔案 30 天後自動刪除；若上傳失敗，檔案仍會保留在你的電腦上。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsCodeHint">把這組代碼貼在問題回報中即可，不需要附加檔案。按「開啟檔案」可以看到剛才送出的完整內容。上傳的檔案 30 天後自動刪除。</sys:String>
+    <sys:String x:Key="S.Settings.CopyCode">複製</sys:String>
+    <sys:String x:Key="S.Settings.OpenBundle">開啟檔案</sys:String>
 
     <sys:String x:Key="S.Settings.AutoSaveHint">設定變更後會自動儲存</sys:String>
 
@@ -422,6 +428,14 @@
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ 無法開啟資料夾：{0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsExported">✓ 已匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ 無法匯出診斷資訊：{0}</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploading">正在整理並上傳…</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ 已上傳，代碼 {0}</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ 已複製代碼</sys:String>
+    <sys:String x:Key="S.Settings.CopyFailed">✗ 無法複製，請直接看上方顯示的代碼。</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedUnreachable">✗ 無法連線到上傳服務，診斷檔已保留在你的電腦，請改為手動附加。</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedTooLarge">✗ 診斷檔過大無法上傳，已保留在你的電腦，請改為手動附加。</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedRateLimited">✗ 短時間內上傳次數過多，請稍後再試，或改為手動附加已保留在電腦上的診斷檔。</sys:String>
+    <sys:String x:Key="S.Settings.UploadFailedRejected">✗ 上傳被拒絕，診斷檔已保留在你的電腦，請改為手動附加。</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} 已指派給「{1}」</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -405,11 +405,14 @@
     <sys:String x:Key="S.Settings.LoggingHint">啟用後會記錄更多應用程式資訊，僅建議於問題排查時開啟。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
-    <sys:String x:Key="S.Settings.OpenLogFolder">開啟記錄資料夾</sys:String>
+    <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟診斷資料夾</sys:String>
     <sys:String x:Key="S.Settings.UploadDiagnostics">匯出並上傳診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint">按下後會把記錄檔、系統資訊與目前設定整理成一個檔案（API 金鑰只會保留長度，不會包含內容），上傳後回傳一組代碼，讓你貼在問題回報中。只有你按下這顆按鈕時才會送出，上傳的檔案 30 天後自動刪除；若上傳失敗，檔案仍會保留在你的電腦上。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsCodeHint">把這組代碼貼在問題回報中即可，不需要附加檔案。按「開啟檔案」可以看到剛才送出的完整內容。上傳的檔案 30 天後自動刪除。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">上傳失敗</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。&#x0a;按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint">診斷資訊已成功匯出，但無法上傳。請透過 GitHub 或論壇回報問題並附上檔案。&#x0a;按「開啟檔案」可取得本次匯出的診斷資訊。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsRetention">檔案將於 30 天後自動刪除</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">複製</sys:String>
     <sys:String x:Key="S.Settings.OpenBundle">開啟檔案</sys:String>
 
@@ -432,10 +435,7 @@
     <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ 已上傳，代碼 {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ 已複製代碼</sys:String>
     <sys:String x:Key="S.Settings.CopyFailed">✗ 無法複製，請直接看上方顯示的代碼。</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedUnreachable">✗ 無法連線到上傳服務，診斷檔已保留在你的電腦，請改為手動附加。</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedTooLarge">✗ 診斷檔過大無法上傳，已保留在你的電腦，請改為手動附加。</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedRateLimited">✗ 短時間內上傳次數過多，請稍後再試，或改為手動附加已保留在電腦上的診斷檔。</sys:String>
-    <sys:String x:Key="S.Settings.UploadFailedRejected">✗ 上傳被拒絕，診斷檔已保留在你的電腦，請改為手動附加。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">✗ 無法上傳診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} 已指派給「{1}」</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Services/DiagnosticBundleService.cs
+++ b/src/OverTranslate/Services/DiagnosticBundleService.cs
@@ -79,12 +79,16 @@ public static class DiagnosticBundleService
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "OverTranslate", "logs");
 
     /// <summary>
-    /// Opens the log folder in Explorer, creating it first so the button works on a machine that has
-    /// not written a line yet.
+    /// Opens the folder the exports are written to, creating it first so the button works on a
+    /// machine that has never made one.
     /// </summary>
-    public static void OpenLogFolder()
+    /// <remarks>
+    /// The exports rather than the logs: this is the folder someone is sent to when they have to
+    /// hand a file over by themselves, and the logs are inside every zip in it anyway.
+    /// </remarks>
+    public static void OpenExportFolder()
     {
-        var directory = LogDirectory;
+        var directory = DefaultExportDirectory;
         Directory.CreateDirectory(directory);
         Process.Start(new ProcessStartInfo(directory) { UseShellExecute = true });
     }
@@ -120,7 +124,7 @@ public static class DiagnosticBundleService
             AddLogs(archive);
         }
 
-        Log.Info("Diagnostic bundle written to {0}", path);
+        Log.Info("Diagnostic bundle written to {0}", CollapseUserPaths(path));
         return path;
     }
 
@@ -135,6 +139,48 @@ public static class DiagnosticBundleService
     public static void Open(string path)
     {
         Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+    }
+
+    /// <summary>
+    /// The folders a path sits under, written as the variables that name them rather than as where
+    /// they expanded to.
+    /// </summary>
+    /// <remarks>
+    /// Longest root first: LocalApplicationData and ApplicationData both sit under UserProfile, and
+    /// matching the shortest would turn every path into %USERPROFILE%\AppData\....
+    /// </remarks>
+    private static readonly (string Variable, string Root)[] ProfileRoots =
+    {
+        ("%LOCALAPPDATA%", Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)),
+        ("%APPDATA%",      Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)),
+        ("%USERPROFILE%",  Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)),
+    };
+
+    /// <summary>
+    /// Rewrites the user's own folders back into the variables that name them, so a bundle does not
+    /// carry the Windows account name out with it.
+    /// </summary>
+    /// <remarks>
+    /// The account name is on a great many machines the person's real name, and it appeared four
+    /// times in a file whose four path lines were only ever interesting for their shape: is the log
+    /// where it is expected, is this a Velopack install or something run loose from a folder. That
+    /// shape survives this; the name does not.
+    ///
+    /// A path that is not under any of those roots is returned untouched, which is deliberate. Being
+    /// somewhere unexpected is precisely the condition worth seeing, and there is no account name to
+    /// hide in a path that was never under the account's own folder.
+    /// </remarks>
+    public static string CollapseUserPaths(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return path;
+
+        foreach (var (variable, root) in ProfileRoots)
+        {
+            if (!string.IsNullOrEmpty(root) && path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+                return variable + path[root.Length..];
+        }
+
+        return path;
     }
 
     /// <summary>Opens Explorer with the file already selected.</summary>
@@ -250,7 +296,7 @@ public static class DiagnosticBundleService
         {
             // A bundle that is missing one of its three files is still worth having, and the reason
             // it is missing belongs in the bundle rather than in a message box.
-            return $"Could not read {SettingsService.FilePath}: {ex.Message}";
+            return $"Could not read {CollapseUserPaths(SettingsService.FilePath)}: {ex.Message}";
         }
     }
 
@@ -274,7 +320,7 @@ public static class DiagnosticBundleService
             }
             catch (Exception ex)
             {
-                Log.Warn(ex, "Could not add {0} to the diagnostic bundle", file);
+                Log.Warn(ex, "Could not add {0} to the diagnostic bundle", CollapseUserPaths(file));
             }
         }
     }
@@ -299,7 +345,7 @@ public static class DiagnosticBundleService
         sb.AppendLine("=== OverTranslate diagnostics ===");
         sb.AppendLine($"generated : {DateTimeOffset.Now:yyyy-MM-dd HH:mm:ss zzz}");
         sb.AppendLine($"app       : v{Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0"}");
-        sb.AppendLine($"install   : {AppContext.BaseDirectory}");
+        sb.AppendLine($"install   : {CollapseUserPaths(AppContext.BaseDirectory)}");
         sb.AppendLine($"framework : {RuntimeInformation.FrameworkDescription}");
         sb.AppendLine($"os        : {RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})");
         sb.AppendLine(
@@ -313,9 +359,9 @@ public static class DiagnosticBundleService
         sb.AppendLine(
             $"logging   : verbose={SettingsService.Instance.Current.VerboseLogging} " +
             $"envOverride={LogLevelService.IsOverriddenByEnvironment}");
-        sb.AppendLine($"settings  : {SettingsService.FilePath}");
-        sb.AppendLine($"logs      : {LogDirectory}");
-        sb.AppendLine($"exports   : {DefaultExportDirectory}");
+        sb.AppendLine($"settings  : {CollapseUserPaths(SettingsService.FilePath)}");
+        sb.AppendLine($"logs      : {CollapseUserPaths(LogDirectory)}");
+        sb.AppendLine($"exports   : {CollapseUserPaths(DefaultExportDirectory)}");
         // Written before any upload is attempted, so this says where it would go rather than where
         // it went — which is the line worth having when the upload is what failed.
         sb.AppendLine($"upload    : {(DiagnosticUploadService.IsConfigured ? DiagnosticUploadService.Endpoint : "(disabled)")}");

--- a/src/OverTranslate/Services/DiagnosticBundleService.cs
+++ b/src/OverTranslate/Services/DiagnosticBundleService.cs
@@ -124,6 +124,19 @@ public static class DiagnosticBundleService
         return path;
     }
 
+    /// <summary>
+    /// Opens the bundle itself, which on Windows means Explorer showing what is inside it.
+    /// </summary>
+    /// <remarks>
+    /// The pair of <see cref="Reveal"/>, and the difference matters: Reveal answers "where is it",
+    /// which is what someone about to attach a file needs, while this answers "what is in it", which
+    /// is what someone who has just uploaded one needs.
+    /// </remarks>
+    public static void Open(string path)
+    {
+        Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+    }
+
     /// <summary>Opens Explorer with the file already selected.</summary>
     public static void Reveal(string path)
     {
@@ -303,15 +316,18 @@ public static class DiagnosticBundleService
         sb.AppendLine($"settings  : {SettingsService.FilePath}");
         sb.AppendLine($"logs      : {LogDirectory}");
         sb.AppendLine($"exports   : {DefaultExportDirectory}");
+        // Written before any upload is attempted, so this says where it would go rather than where
+        // it went — which is the line worth having when the upload is what failed.
+        sb.AppendLine($"upload    : {(DiagnosticUploadService.IsConfigured ? DiagnosticUploadService.Endpoint : "(disabled)")}");
         sb.AppendLine();
         sb.AppendLine("=== What is in this file ===");
         sb.AppendLine("environment.txt            this file");
         sb.AppendLine("appsettings.redacted.json  your settings, with API keys replaced by their length");
         sb.AppendLine("logs/app.log               the current log; the numbered ones are older");
         sb.AppendLine();
-        sb.AppendLine("Nothing here was sent anywhere — this file was written to your disk and is");
-        sb.AppendLine("yours to read before you attach it. The log can contain text that was on your");
-        sb.AppendLine("screen while 記錄詳細資訊 was switched on.");
+        sb.AppendLine("This file was written to your disk and is yours to read. It leaves this machine");
+        sb.AppendLine("only if you pressed the button that uploads it, and never on its own. The log can");
+        sb.AppendLine("contain text that was on your screen while 記錄詳細資訊 was switched on.");
 
         return sb.ToString();
     }

--- a/src/OverTranslate/Services/DiagnosticBundleService.cs
+++ b/src/OverTranslate/Services/DiagnosticBundleService.cs
@@ -112,6 +112,7 @@ public static class DiagnosticBundleService
 
         var directory = ResolveDestination(destinationDirectory);
         Directory.CreateDirectory(directory);
+        PruneOldExports(directory, DateTime.UtcNow);
 
         var path = Path.Combine(
             directory,
@@ -139,6 +140,56 @@ public static class DiagnosticBundleService
     public static void Open(string path)
     {
         Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+    }
+
+    /// <summary>
+    /// How long an export stays on disk, matching what the uploaded copy gets. One number for both,
+    /// so the interface can state it once without having to say which copy it means.
+    /// </summary>
+    public static readonly TimeSpan ExportRetention = TimeSpan.FromDays(30);
+
+    /// <summary>The names <see cref="Export"/> writes, and the only ones this will delete.</summary>
+    private const string ExportPattern = "OverTranslate-diagnostics-*.zip";
+
+    /// <summary>
+    /// Deletes the exports older than <see cref="ExportRetention"/>, and returns how many went.
+    /// </summary>
+    /// <remarks>
+    /// Done on the way to writing a new one rather than on a timer: the folder only grows when this
+    /// runs, so that is the only moment it can have grown, and a background sweep would be a thread
+    /// kept for a folder that is empty on most machines.
+    ///
+    /// The pattern is what keeps this honest. It is a folder inside the application own data, but a
+    /// user who has put something in there — a renamed copy they kept, a note to themselves — put it
+    /// there deliberately, and a cleanup that takes files it did not write is a bug that destroys
+    /// data. Nothing outside the shape <see cref="Export"/> produces is touched.
+    ///
+    /// A file that cannot be deleted is left rather than reported: one open in a zip viewer will go
+    /// on the next export, and there is nothing the user would do about being told.
+    /// </remarks>
+    public static int PruneOldExports(string directory, DateTime nowUtc)
+    {
+        var deleted = 0;
+        if (!Directory.Exists(directory)) return deleted;
+
+        foreach (var file in Directory.GetFiles(directory, ExportPattern))
+        {
+            try
+            {
+                if (nowUtc - File.GetLastWriteTimeUtc(file) <= ExportRetention) continue;
+
+                File.Delete(file);
+                deleted++;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex, "Could not delete the expired diagnostic bundle {0}",
+                    CollapseUserPaths(file));
+            }
+        }
+
+        if (deleted > 0) Log.Info("Deleted {0} expired diagnostic bundle(s)", deleted);
+        return deleted;
     }
 
     /// <summary>

--- a/src/OverTranslate/Services/DiagnosticUploadService.cs
+++ b/src/OverTranslate/Services/DiagnosticUploadService.cs
@@ -66,18 +66,24 @@ public static class DiagnosticUploadService
     /// upload down with it.
     /// </summary>
     /// <remarks>
-    /// Empty is still a working state rather than a broken one — <see cref="IsConfigured"/> goes
-    /// false, the button says "export" and only exports, and the #126 path is what remains. That is
-    /// what a build gets by having this cleared, and what every build was before the worker existed.
+    /// Having none is still a working state rather than a broken one — <see cref="IsConfigured"/>
+    /// goes false, the button says "export" and only exports, and the #126 path is what remains.
+    /// That is what every build was before the worker existed.
     /// </remarks>
     private const string DefaultEndpoint =
         "https://overtranslate-diag.overtranslate.workers.dev/v1/bundle";
 
     /// <summary>
-    /// Overrides <see cref="DefaultEndpoint"/>, for pointing a local build at `wrangler dev`.
-    /// Setting it to an empty string switches uploading off, which is the only supported way to opt
-    /// out of a feature that already requires a deliberate press.
+    /// Overrides <see cref="DefaultEndpoint"/>, for pointing a local build at a `wrangler dev`
+    /// instance. Setting it to anything that is not an http(s) address — "off" does nicely — turns
+    /// uploading off, which is the supported way to opt out of a feature that already requires a
+    /// deliberate press.
     /// </summary>
+    /// <remarks>
+    /// Not "set it to an empty string", which is what this used to say and does not work: on Windows
+    /// setting a variable to "" deletes it, and a deleted variable falls through to the endpoint
+    /// compiled in — the exact opposite of what someone typing that would be trying to achieve.
+    /// </remarks>
     private const string EndpointVariable = "OVERTRANSLATE_DIAG_ENDPOINT";
 
     /// <summary>Matches the worker's own limit. Checked here so an oversized bundle costs no upload.</summary>
@@ -97,7 +103,16 @@ public static class DiagnosticUploadService
     public static string Endpoint =>
         Environment.GetEnvironmentVariable(EndpointVariable) ?? DefaultEndpoint;
 
-    public static bool IsConfigured => !string.IsNullOrWhiteSpace(Endpoint);
+    /// <summary>
+    /// Whether there is somewhere to upload to. Tested by parsing rather than by checking for a
+    /// non-empty string, which also settles what happens to a mistyped address: it turns the feature
+    /// off, rather than sending a log full of someone's screen to whatever that address resolves to.
+    /// </summary>
+    public static bool IsConfigured => IsUsableEndpoint(Endpoint);
+
+    private static bool IsUsableEndpoint(string value) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+        (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
 
     /// <summary>
     /// Uploads a bundle and returns its code. Throws <see cref="DiagnosticUploadException"/> for
@@ -106,7 +121,7 @@ public static class DiagnosticUploadService
     public static async Task<string> UploadAsync(string bundlePath, CancellationToken token = default)
     {
         var endpoint = Endpoint;
-        if (string.IsNullOrWhiteSpace(endpoint))
+        if (!IsUsableEndpoint(endpoint))
             throw new DiagnosticUploadException(DiagnosticUploadFailure.NotConfigured, "No endpoint");
 
         var info = new FileInfo(bundlePath);

--- a/src/OverTranslate/Services/DiagnosticUploadService.cs
+++ b/src/OverTranslate/Services/DiagnosticUploadService.cs
@@ -53,7 +53,7 @@ public sealed class DiagnosticUploadException(DiagnosticUploadFailure reason, st
 ///
 /// The receiving end is a Cloudflare Worker in front of an R2 bucket, kept in its own public
 /// repository so that what happens to the upload can be read rather than promised:
-/// https://github.com/asd880921/overtranslate-diag-worker
+/// https://github.com/asd880921/OverTranslate-Diag-Worker
 /// </remarks>
 public static class DiagnosticUploadService
 {

--- a/src/OverTranslate/Services/DiagnosticUploadService.cs
+++ b/src/OverTranslate/Services/DiagnosticUploadService.cs
@@ -66,11 +66,12 @@ public static class DiagnosticUploadService
     /// upload down with it.
     /// </summary>
     /// <remarks>
-    /// Empty until the worker is deployed and its address is known; see DEPLOY.md in that
-    /// repository. Empty is a working state rather than a broken one — <see cref="IsConfigured"/>
-    /// is false, the button says "export" and only exports, and the #126 path is what remains.
+    /// Empty is still a working state rather than a broken one — <see cref="IsConfigured"/> goes
+    /// false, the button says "export" and only exports, and the #126 path is what remains. That is
+    /// what a build gets by having this cleared, and what every build was before the worker existed.
     /// </remarks>
-    private const string DefaultEndpoint = "";
+    private const string DefaultEndpoint =
+        "https://overtranslate-diag.overtranslate.workers.dev/v1/bundle";
 
     /// <summary>
     /// Overrides <see cref="DefaultEndpoint"/>, for pointing a local build at `wrangler dev`.

--- a/src/OverTranslate/Services/DiagnosticUploadService.cs
+++ b/src/OverTranslate/Services/DiagnosticUploadService.cs
@@ -1,0 +1,206 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using NLog;
+
+namespace OverTranslate.Services;
+
+/// <summary>Why an upload did not happen, in the terms the user needs to hear it.</summary>
+public enum DiagnosticUploadFailure
+{
+    /// <summary>No endpoint is configured, so nothing was attempted.</summary>
+    NotConfigured,
+
+    /// <summary>Nothing answered: offline, a corporate proxy, a firewall, a timeout.</summary>
+    Unreachable,
+
+    /// <summary>The bundle is over the endpoint's size limit.</summary>
+    TooLarge,
+
+    /// <summary>Too many uploads from this address too quickly.</summary>
+    RateLimited,
+
+    /// <summary>The endpoint answered, but not with a code we can show.</summary>
+    Rejected,
+}
+
+/// <summary>An upload that did not produce a code. Always recoverable — see the remarks.</summary>
+/// <remarks>
+/// Every one of these is met the same way by the caller: say what happened and open Explorer on the
+/// zip that is still sitting on the disk. The bundle is written before the upload is attempted
+/// precisely so that this is always possible, and so that the offline path from #126 stays whole.
+/// </remarks>
+public sealed class DiagnosticUploadException(DiagnosticUploadFailure reason, string detail)
+    : Exception(detail)
+{
+    public DiagnosticUploadFailure Reason { get; } = reason;
+}
+
+/// <summary>
+/// Hands a diagnostic bundle to the collection endpoint and returns the short code the user pastes
+/// into their problem report.
+/// </summary>
+/// <remarks>
+/// The design constraint that shapes everything here: this runs because a person pressed a button,
+/// and only then. There is no retry loop, no background queue, no crash handler that calls it. The
+/// bundle contains the log, and with 記錄詳細資訊 switched on the log contains text that was on the
+/// user's screen — which is exactly the log worth sending, and exactly why sending it can never be
+/// something that happens on its own.
+///
+/// The receiving end is a Cloudflare Worker in front of an R2 bucket, kept in its own public
+/// repository so that what happens to the upload can be read rather than promised:
+/// https://github.com/asd880921/overtranslate-diag-worker
+/// </remarks>
+public static class DiagnosticUploadService
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    /// <summary>
+    /// Where bundles go. Baked into the build rather than fetched from anywhere: it is one string,
+    /// and standing up a remote configuration mechanism to hold one string costs more than it saves
+    /// — including in the failure mode, where a broken config endpoint would take the diagnostic
+    /// upload down with it.
+    /// </summary>
+    /// <remarks>
+    /// Empty until the worker is deployed and its address is known; see DEPLOY.md in that
+    /// repository. Empty is a working state rather than a broken one — <see cref="IsConfigured"/>
+    /// is false, the button says "export" and only exports, and the #126 path is what remains.
+    /// </remarks>
+    private const string DefaultEndpoint = "";
+
+    /// <summary>
+    /// Overrides <see cref="DefaultEndpoint"/>, for pointing a local build at `wrangler dev`.
+    /// Setting it to an empty string switches uploading off, which is the only supported way to opt
+    /// out of a feature that already requires a deliberate press.
+    /// </summary>
+    private const string EndpointVariable = "OVERTRANSLATE_DIAG_ENDPOINT";
+
+    /// <summary>Matches the worker's own limit. Checked here so an oversized bundle costs no upload.</summary>
+    public const long MaxUploadBytes = 5 * 1024 * 1024;
+
+    /// <summary>
+    /// Generous, because the upload happens over a connection we know nothing about and the user is
+    /// watching a button that says it is working. Short enough that a black-holed connection gives
+    /// up while they are still in the room.
+    /// </summary>
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(60) };
+
+    /// <summary>What the worker returns, and the only shape this accepts back.</summary>
+    private static readonly Regex CodePattern = new(
+        @"^[0-9A-HJKMNP-TV-Z]{3}-[0-9A-HJKMNP-TV-Z]{3}$", RegexOptions.Compiled);
+
+    public static string Endpoint =>
+        Environment.GetEnvironmentVariable(EndpointVariable) ?? DefaultEndpoint;
+
+    public static bool IsConfigured => !string.IsNullOrWhiteSpace(Endpoint);
+
+    /// <summary>
+    /// Uploads a bundle and returns its code. Throws <see cref="DiagnosticUploadException"/> for
+    /// every failure, so callers have exactly one thing to catch and one thing to do about it.
+    /// </summary>
+    public static async Task<string> UploadAsync(string bundlePath, CancellationToken token = default)
+    {
+        var endpoint = Endpoint;
+        if (string.IsNullOrWhiteSpace(endpoint))
+            throw new DiagnosticUploadException(DiagnosticUploadFailure.NotConfigured, "No endpoint");
+
+        var info = new FileInfo(bundlePath);
+        if (info.Length > MaxUploadBytes)
+        {
+            // Refused here rather than by the server: the same answer, minus the several megabytes
+            // spent on someone's metered connection to hear it.
+            throw new DiagnosticUploadException(
+                DiagnosticUploadFailure.TooLarge, $"{info.Length} bytes exceeds {MaxUploadBytes}");
+        }
+
+        using var stream = File.OpenRead(bundlePath);
+        using var content = new StreamContent(stream);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
+        // Metadata, not identity. Which build and which Windows answers most of the "why does this
+        // only happen to them" questions; neither is anything the receiving end trusts.
+        request.Headers.TryAddWithoutValidation("x-overtranslate-version", AppVersion);
+        request.Headers.TryAddWithoutValidation("x-overtranslate-os", RuntimeInformation.OSDescription);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await Http.SendAsync(request, token).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // The expected failure, not the exceptional one: the people most likely to press this
+            // button are behind a network that is part of what they are reporting.
+            Log.Warn(ex, "Diagnostic upload could not reach {0}", endpoint);
+            throw new DiagnosticUploadException(DiagnosticUploadFailure.Unreachable, ex.Message);
+        }
+
+        using (response)
+        {
+            var body = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Warn("Diagnostic upload refused with {0}: {1}", (int)response.StatusCode, body);
+                throw new DiagnosticUploadException(
+                    Classify(response.StatusCode), $"HTTP {(int)response.StatusCode}");
+            }
+
+            var code = ParseCode(body);
+            if (code is null)
+            {
+                Log.Warn("Diagnostic upload returned no usable code: {0}", body);
+                throw new DiagnosticUploadException(DiagnosticUploadFailure.Rejected, "No code in response");
+            }
+
+            Log.Info("Diagnostic bundle uploaded as {0}", code);
+            return code;
+        }
+    }
+
+    /// <summary>
+    /// Which of the things the user can be told happened. Everything that is not specifically "too
+    /// big" or "too often" collapses into <see cref="DiagnosticUploadFailure.Rejected"/>: the
+    /// difference between a 500 and a 503 changes nothing they can do, and the fallback is the same
+    /// either way.
+    /// </summary>
+    public static DiagnosticUploadFailure Classify(HttpStatusCode status) => status switch
+    {
+        HttpStatusCode.RequestEntityTooLarge => DiagnosticUploadFailure.TooLarge,
+        HttpStatusCode.TooManyRequests       => DiagnosticUploadFailure.RateLimited,
+        _                                    => DiagnosticUploadFailure.Rejected,
+    };
+
+    /// <summary>
+    /// The code from a response body, or null if there is not one in the shape we expect.
+    /// </summary>
+    /// <remarks>
+    /// Validated against <see cref="CodePattern"/> rather than shown as received. This string goes
+    /// into a box the user is told to copy into a public forum post, and the endpoint it comes from
+    /// is reachable by anything on the internet — including a captive portal answering 200 with its
+    /// own login page. A code that does not look like a code is a failure, not a code.
+    /// </remarks>
+    public static string? ParseCode(string body)
+    {
+        try
+        {
+            var code = JsonDocument.Parse(body).RootElement.TryGetProperty("code", out var value)
+                ? value.GetString()
+                : null;
+
+            return code is not null && CodePattern.IsMatch(code) ? code : null;
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static string AppVersion =>
+        Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+}

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -774,7 +774,8 @@
                                            VerticalAlignment="Center"
                                            Cursor="Help">
                                     <controls:HoverToolTip.Content>
-                                        <TextBlock Text="{DynamicResource S.Settings.DiagnosticsHint}"
+                                        <TextBlock x:Name="DiagnosticsHintText"
+                                                   Text="{DynamicResource S.Settings.DiagnosticsHint}"
                                                    MaxWidth="420"
                                                    FontFamily="{StaticResource AppFont}"
                                                    FontSize="{StaticResource AppFontSize}"
@@ -840,7 +841,8 @@
                                                    FontSize="13"
                                                    VerticalAlignment="Center"
                                                    Margin="0,0,6,0"/>
-                                        <TextBlock Text="{DynamicResource S.Settings.ExportDiagnostics}"
+                                        <TextBlock x:Name="ExportDiagnosticsLabel"
+                                                   Text="{DynamicResource S.Settings.ExportDiagnostics}"
                                                    VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -861,6 +863,72 @@
                                     </StackPanel>
                                 </Button>
                             </Grid>
+
+                            <!-- The one thing the user has to leave with. It appears only after an
+                                 upload has succeeded, and it stays until the page is left: the status
+                                 line above fades after a moment, and a code that faded before it was
+                                 copied could only be got back by uploading the bundle a second time.
+
+                                 Open file belongs here rather than in the row above. One press now
+                                 packs and sends, so "what did I just send" is a question this row has
+                                 to be able to answer after the fact. -->
+                            <Border x:Name="DiagnosticsCodePanel"
+                                    Visibility="Collapsed"
+                                    Margin="0,10,0,0"
+                                    Background="{DynamicResource AppInputBg}"
+                                    BorderBrush="{DynamicResource AppBorder}"
+                                    BorderThickness="1"
+                                    CornerRadius="6"
+                                    Padding="12,10">
+                                <StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{DynamicResource S.Settings.DiagnosticsCodeLabel}"
+                                                   Style="{StaticResource OptionTitle}"
+                                                   VerticalAlignment="Center"/>
+
+                                        <!-- A monospaced face, because these characters get read back
+                                             one at a time against whatever the user typed into a forum
+                                             post, and a proportional face is where 0/O and 1/I go
+                                             wrong. The worker's alphabet already excludes that pair;
+                                             the face is what makes the exclusion visible. -->
+                                        <TextBlock Grid.Column="1" x:Name="DiagnosticsCodeText"
+                                                   FontFamily="Consolas, Cascadia Mono, Courier New"
+                                                   FontSize="18"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AppAccent}"
+                                                   Margin="10,0,0,0"
+                                                   VerticalAlignment="Center"/>
+
+                                        <Button Grid.Column="3" x:Name="CopyDiagnosticsCodeBtn"
+                                                Style="{StaticResource FlatButton}"
+                                                Height="28"
+                                                Padding="10,0"
+                                                Content="{DynamicResource S.Settings.CopyCode}"
+                                                Click="CopyDiagnosticsCodeBtn_Click"/>
+
+                                        <Button Grid.Column="4" x:Name="OpenDiagnosticsBundleBtn"
+                                                Style="{StaticResource FlatButton}"
+                                                Height="28"
+                                                Padding="10,0"
+                                                Margin="6,0,0,0"
+                                                Content="{DynamicResource S.Settings.OpenBundle}"
+                                                Click="OpenDiagnosticsBundleBtn_Click"/>
+                                    </Grid>
+
+                                    <TextBlock Text="{DynamicResource S.Settings.DiagnosticsCodeHint}"
+                                               Style="{StaticResource OptionDescription}"
+                                               Margin="2,8,0,0"/>
+                                </StackPanel>
+                            </Border>
                         </StackPanel>
                     </Border>
                 </Grid>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -847,18 +847,18 @@
                                     </StackPanel>
                                 </Button>
 
-                                <Button Grid.Column="1" x:Name="OpenLogFolderBtn"
+                                <Button Grid.Column="1" x:Name="OpenDiagnosticsFolderBtn"
                                         Style="{StaticResource FlatButton}"
                                         Height="34"
                                         Margin="4,0,0,0"
-                                        Click="OpenLogFolderBtn_Click">
+                                        Click="OpenDiagnosticsFolderBtn_Click">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="&#xE838;"
                                                    FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                                    FontSize="13"
                                                    VerticalAlignment="Center"
                                                    Margin="0,0,6,0"/>
-                                        <TextBlock Text="{DynamicResource S.Settings.OpenLogFolder}"
+                                        <TextBlock Text="{DynamicResource S.Settings.OpenDiagnosticsFolder}"
                                                    VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </Button>
@@ -872,7 +872,7 @@
                                  Open file belongs here rather than in the row above. One press now
                                  packs and sends, so "what did I just send" is a question this row has
                                  to be able to answer after the fact. -->
-                            <Border x:Name="DiagnosticsCodePanel"
+                            <Border x:Name="DiagnosticsResultPanel"
                                     Visibility="Collapsed"
                                     Margin="0,10,0,0"
                                     Background="{DynamicResource AppInputBg}"
@@ -885,22 +885,34 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="*"/>
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
 
-                                        <TextBlock Grid.Column="0"
-                                                   Text="{DynamicResource S.Settings.DiagnosticsCodeLabel}"
+                                        <!-- The glyph carries the state, because the rest of the row
+                                             changes shape between the two: on failure there is no
+                                             code and no Copy, and a heading that differs only in its
+                                             wording is one a reader has to actually read before they
+                                             know which of the two happened. -->
+                                        <TextBlock Grid.Column="0" x:Name="DiagnosticsResultGlyph"
+                                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="15"
+                                                   Foreground="{DynamicResource AppTextSecondary}"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,8,0"/>
+
+                                        <TextBlock Grid.Column="1" x:Name="DiagnosticsResultTitle"
                                                    Style="{StaticResource OptionTitle}"
                                                    VerticalAlignment="Center"/>
 
                                         <!-- A monospaced face, because these characters get read back
                                              one at a time against whatever the user typed into a forum
                                              post, and a proportional face is where 0/O and 1/I go
-                                             wrong. The worker's alphabet already excludes that pair;
-                                             the face is what makes the exclusion visible. -->
-                                        <TextBlock Grid.Column="1" x:Name="DiagnosticsCodeText"
+                                             wrong. The alphabet the worker draws from already excludes
+                                             that pair; the face makes the exclusion visible. -->
+                                        <TextBlock Grid.Column="2" x:Name="DiagnosticsCodeText"
                                                    FontFamily="Consolas, Cascadia Mono, Courier New"
                                                    FontSize="18"
                                                    FontWeight="SemiBold"
@@ -908,25 +920,62 @@
                                                    Margin="10,0,0,0"
                                                    VerticalAlignment="Center"/>
 
-                                        <Button Grid.Column="3" x:Name="CopyDiagnosticsCodeBtn"
+                                        <Button Grid.Column="4" x:Name="CopyDiagnosticsCodeBtn"
                                                 Style="{StaticResource FlatButton}"
-                                                Height="28"
-                                                Padding="10,0"
-                                                Content="{DynamicResource S.Settings.CopyCode}"
-                                                Click="CopyDiagnosticsCodeBtn_Click"/>
+                                                Height="30"
+                                                Padding="12,0"
+                                                Click="CopyDiagnosticsCodeBtn_Click">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#xE8C8;"
+                                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                           FontSize="13"
+                                                           VerticalAlignment="Center"
+                                                           Margin="0,0,6,0"/>
+                                                <TextBlock Text="{DynamicResource S.Settings.CopyCode}"
+                                                           VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Button>
 
-                                        <Button Grid.Column="4" x:Name="OpenDiagnosticsBundleBtn"
+                                        <Button Grid.Column="5" x:Name="OpenDiagnosticsBundleBtn"
                                                 Style="{StaticResource FlatButton}"
-                                                Height="28"
-                                                Padding="10,0"
+                                                Height="30"
+                                                Padding="12,0"
                                                 Margin="6,0,0,0"
-                                                Content="{DynamicResource S.Settings.OpenBundle}"
-                                                Click="OpenDiagnosticsBundleBtn_Click"/>
+                                                Click="OpenDiagnosticsBundleBtn_Click">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#xE8E5;"
+                                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                           FontSize="13"
+                                                           VerticalAlignment="Center"
+                                                           Margin="0,0,6,0"/>
+                                                <TextBlock Text="{DynamicResource S.Settings.OpenBundle}"
+                                                           VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Button>
                                     </Grid>
 
-                                    <TextBlock Text="{DynamicResource S.Settings.DiagnosticsCodeHint}"
+                                    <TextBlock x:Name="DiagnosticsResultHint"
                                                Style="{StaticResource OptionDescription}"
                                                Margin="2,8,0,0"/>
+
+                                    <!-- Only shown when something was actually uploaded. On the
+                                         failure path nothing left the machine, and promising that it
+                                         will be deleted in thirty days would be describing a file
+                                         that is not there. -->
+                                    <StackPanel x:Name="DiagnosticsRetentionRow"
+                                                Orientation="Horizontal"
+                                                Margin="2,10,0,0">
+                                        <TextBlock Text="&#xE823;"
+                                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="12"
+                                                   Foreground="{DynamicResource AppTextSecondary}"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,6,0"/>
+                                        <TextBlock Text="{DynamicResource S.Settings.DiagnosticsRetention}"
+                                                   Style="{StaticResource OptionDescription}"
+                                                   Margin="0"
+                                                   VerticalAlignment="Center"/>
+                                    </StackPanel>
                                 </StackPanel>
                             </Border>
                         </StackPanel>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -958,10 +958,10 @@
                                                Style="{StaticResource OptionDescription}"
                                                Margin="2,8,0,0"/>
 
-                                    <!-- Only shown when something was actually uploaded. On the
-                                         failure path nothing left the machine, and promising that it
-                                         will be deleted in thirty days would be describing a file
-                                         that is not there. -->
+                                    <!-- Shown in both states. The copy on disk is kept for thirty
+                                         days whether or not the upload went through, so this is one
+                                         line that does not have to be read against which of the two
+                                         happened. -->
                                     <StackPanel x:Name="DiagnosticsRetentionRow"
                                                 Orientation="Horizontal"
                                                 Margin="2,10,0,0">

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -275,6 +275,21 @@ public partial class SettingsPage : UserControl
         AutoSaveHint.Opacity  = 0;
     }
 
+    /// <summary>
+    /// For an outcome that is neither. Red would say the press failed when the file it produced is
+    /// sitting on the disk and is the whole point; green would say it went through when it did not.
+    /// Held rather than faded, for the same reason the error line is: there is something left to do.
+    /// </summary>
+    private void ShowWarning(string message)
+    {
+        _statusHold.Stop();
+        StatusText.BeginAnimation(OpacityProperty, null);
+        StatusText.Text       = message;
+        StatusText.Foreground = (Brush)FindResource("AppWarning");
+        StatusText.Opacity    = 1;
+        AutoSaveHint.Opacity  = 0;
+    }
+
     private void ShowError(string message)
     {
         _statusHold.Stop();
@@ -553,7 +568,7 @@ public partial class SettingsPage : UserControl
                 // appears says to press Open file, and a window opening by itself at the same moment
                 // is a second instruction contradicting the first.
                 ShowNotUploaded();
-                ShowError(LocalizationService.Get("S.Settings.DiagnosticsUploadFailed"));
+                ShowWarning(LocalizationService.Get("S.Settings.DiagnosticsUploadFailed"));
             }
         }
         catch (Exception ex)

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -475,11 +475,17 @@ public partial class SettingsPage : UserControl
         }
     }
 
-    private void OpenLogFolderBtn_Click(object sender, RoutedEventArgs e)
+    /// <remarks>
+    /// The diagnostics folder rather than the log folder, because the export is what a person coming
+    /// off this card is looking for — the raw logs are inside the zip anyway, and this is where the
+    /// zips accumulate. That is also why the button no longer says "log folder": a button that opens
+    /// one folder while naming another is worse than either name on its own.
+    /// </remarks>
+    private void OpenDiagnosticsFolderBtn_Click(object sender, RoutedEventArgs e)
     {
         try
         {
-            DiagnosticBundleService.OpenLogFolder();
+            DiagnosticBundleService.OpenExportFolder();
         }
         catch (Exception ex)
         {
@@ -513,7 +519,7 @@ public partial class SettingsPage : UserControl
 
         // A code from an earlier press describes an earlier upload. Leaving it on screen through
         // the next one invites it to be copied as though it were the new one.
-        DiagnosticsCodePanel.Visibility = Visibility.Collapsed;
+        DiagnosticsResultPanel.Visibility = Visibility.Collapsed;
 
         var uploading = DiagnosticUploadService.IsConfigured;
         try
@@ -538,14 +544,16 @@ public partial class SettingsPage : UserControl
             {
                 var code = await DiagnosticUploadService.UploadAsync(path);
 
-                DiagnosticsCodeText.Text = code;
-                DiagnosticsCodePanel.Visibility = Visibility.Visible;
+                ShowUploaded(code);
                 FlashSuccess(LocalizationService.Format("S.Settings.DiagnosticsUploaded", code));
             }
-            catch (DiagnosticUploadException ex)
+            catch (DiagnosticUploadException)
             {
-                ShowError(LocalizationService.Get(FailureMessageKey(ex.Reason)));
-                DiagnosticBundleService.Reveal(path);
+                // No Explorer window here, unlike the path with no endpoint at all. The panel that
+                // appears says to press Open file, and a window opening by itself at the same moment
+                // is a second instruction contradicting the first.
+                ShowNotUploaded();
+                ShowError(LocalizationService.Get("S.Settings.DiagnosticsUploadFailed"));
             }
         }
         catch (Exception ex)
@@ -560,17 +568,56 @@ public partial class SettingsPage : UserControl
         }
     }
 
-    /// <summary>
-    /// Every one of these lines ends by pointing at the file still on the user's disk, because that
-    /// is what they are to do next in every case.
-    /// </summary>
-    private static string FailureMessageKey(DiagnosticUploadFailure reason) => reason switch
+    /// <summary>The panel as it looks when a bundle went up and came back with a code.</summary>
+    private void ShowUploaded(string code)
     {
-        DiagnosticUploadFailure.Unreachable => "S.Settings.UploadFailedUnreachable",
-        DiagnosticUploadFailure.TooLarge    => "S.Settings.UploadFailedTooLarge",
-        DiagnosticUploadFailure.RateLimited => "S.Settings.UploadFailedRateLimited",
-        _                                   => "S.Settings.UploadFailedRejected",
-    };
+        DiagnosticsResultGlyph.Text = CompletedGlyph;
+        DiagnosticsResultTitle.SetResourceReference(
+            TextBlock.TextProperty, "S.Settings.DiagnosticsCodeLabel");
+        DiagnosticsResultHint.SetResourceReference(
+            TextBlock.TextProperty, "S.Settings.DiagnosticsUploadedHint");
+
+        DiagnosticsCodeText.Text = code;
+        DiagnosticsCodeText.Visibility = Visibility.Visible;
+        CopyDiagnosticsCodeBtn.Visibility = Visibility.Visible;
+        DiagnosticsRetentionRow.Visibility = Visibility.Visible;
+
+        DiagnosticsResultPanel.Visibility = Visibility.Visible;
+    }
+
+    /// <summary>
+    /// The panel as it looks when the bundle was written but did not leave the machine.
+    /// </summary>
+    /// <remarks>
+    /// The same panel rather than a different one, because the thing it is built around — Open file,
+    /// pointing at the zip that exists either way — is what the user needs in both cases. What goes
+    /// away is everything that would be a lie here: there is no code to copy, and nothing was
+    /// uploaded for the thirty-day line to be about.
+    ///
+    /// One wording for every reason an upload can fail. Whether it was the network, the size or a
+    /// refusal, the next move is the same: report it by hand and attach the file. Telling the four
+    /// apart would offer a distinction the user cannot act on.
+    /// </remarks>
+    private void ShowNotUploaded()
+    {
+        DiagnosticsResultGlyph.Text = FailedGlyph;
+        DiagnosticsResultTitle.SetResourceReference(
+            TextBlock.TextProperty, "S.Settings.DiagnosticsUploadFailedTitle");
+        DiagnosticsResultHint.SetResourceReference(
+            TextBlock.TextProperty, "S.Settings.DiagnosticsNotUploadedHint");
+
+        DiagnosticsCodeText.Visibility = Visibility.Collapsed;
+        CopyDiagnosticsCodeBtn.Visibility = Visibility.Collapsed;
+        DiagnosticsRetentionRow.Visibility = Visibility.Collapsed;
+
+        DiagnosticsResultPanel.Visibility = Visibility.Visible;
+    }
+
+    /// <summary>Segoe MDL2 Completed, the tick in a circle.</summary>
+    private const string CompletedGlyph = "\uE930";
+
+    /// <summary>Segoe MDL2 Important, the exclamation mark in a circle.</summary>
+    private const string FailedGlyph = "\uE7BA";
 
     /// <summary>
     /// Points the export button and its explanation at whichever of the two stories is true for this
@@ -581,9 +628,9 @@ public partial class SettingsPage : UserControl
     /// Resource references rather than assignments, so both survive a language change — the page
     /// rebuilds itself on one, and a plain Text assignment would come back in the old language.
     ///
-    /// A build with no endpoint is a supported state, not a broken one: it is what every build is
-    /// until the worker is deployed, and what a user gets by setting OVERTRANSLATE_DIAG_ENDPOINT to
-    /// nothing.
+    /// A build with no endpoint is a supported state, not a broken one: it is what every build was
+    /// until the worker was deployed, and what a user gets by pointing OVERTRANSLATE_DIAG_ENDPOINT
+    /// at something that is not an address.
     /// </remarks>
     private void ApplyDiagnosticUploadAvailability()
     {

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -15,6 +15,7 @@ using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using TextBox = System.Windows.Controls.TextBox;
 using Brush = System.Windows.Media.Brush;
 using Button = System.Windows.Controls.Button;
+using Clipboard = System.Windows.Clipboard;
 
 namespace OverTranslate.Views.Settings;
 
@@ -30,6 +31,12 @@ namespace OverTranslate.Views.Settings;
 public partial class SettingsPage : UserControl
 {
     private readonly DispatcherTimer _statusHold;
+
+    /// <summary>
+    /// The bundle written by the last press, so the row that appears afterwards can open the
+    /// thing that was just sent. Null until the first export of this session.
+    /// </summary>
+    private string? _lastBundlePath;
     private readonly DispatcherTimer _hotkeyGamepadRecordTimer;
     private readonly ushort[] _recordGamepadButtons = new ushort[4];
 
@@ -156,6 +163,7 @@ public partial class SettingsPage : UserControl
             StopRecording();
         };
 
+        ApplyDiagnosticUploadAvailability();
         LoadSettings();
     }
 
@@ -249,6 +257,22 @@ public partial class SettingsPage : UserControl
         };
         fade.Completed += (_, _) => AutoSaveHint.Opacity = 1;
         StatusText.BeginAnimation(OpacityProperty, fade);
+    }
+
+    /// <summary>
+    /// The status line for something that has started and has not finished. Neither colour fits:
+    /// green would be a claim, red an accusation, and the fade the success path uses would take the
+    /// line away while the thing it describes is still running — so this one holds until whoever
+    /// started it replaces it.
+    /// </summary>
+    private void ShowProgress(string message)
+    {
+        _statusHold.Stop();
+        StatusText.BeginAnimation(OpacityProperty, null);
+        StatusText.Text       = message;
+        StatusText.Foreground = (Brush)FindResource("AppTextSecondary");
+        StatusText.Opacity    = 1;
+        AutoSaveHint.Opacity  = 0;
     }
 
     private void ShowError(string message)
@@ -463,7 +487,21 @@ public partial class SettingsPage : UserControl
         }
     }
 
+    /// <summary>
+    /// Collects the bundle and, where an endpoint is compiled in, sends it and shows the code that
+    /// comes back.
+    /// </summary>
     /// <remarks>
+    /// One button for both halves, because the two halves are one intention: nobody collects a
+    /// diagnostic bundle for its own sake. What that costs is the chance to open the zip before it
+    /// goes — paid for by the explanation on the heading, by a label that says it uploads, and by
+    /// the row afterwards that opens what was sent.
+    ///
+    /// The upload is nested inside its own try on purpose. A failure there is not a failure of the
+    /// press: the bundle is already written, and every one of those paths ends by opening Explorer
+    /// on it — which is the whole of #126, still there for the offline machine, the blocked network
+    /// and the person who would simply rather attach it themselves.
+    ///
     /// Off the UI thread because the bundle copies and compresses every log file there is, which on
     /// a machine that has filled its five archives is a dozen megabytes — not long, but long enough
     /// to freeze the window on a slow disk, and freezing while collecting a bug report is its own
@@ -472,24 +510,130 @@ public partial class SettingsPage : UserControl
     private async void ExportDiagnosticsBtn_Click(object sender, RoutedEventArgs e)
     {
         ExportDiagnosticsBtn.IsEnabled = false;
+
+        // A code from an earlier press describes an earlier upload. Leaving it on screen through
+        // the next one invites it to be copied as though it were the new one.
+        DiagnosticsCodePanel.Visibility = Visibility.Collapsed;
+
+        var uploading = DiagnosticUploadService.IsConfigured;
         try
         {
+            if (uploading) ShowProgress(LocalizationService.Get("S.Settings.DiagnosticsUploading"));
+
             var path = await Task.Run(() => DiagnosticBundleService.Export());
+            _lastBundlePath = path;
 
-            FlashSuccess(LocalizationService.Get("S.Settings.DiagnosticsExported"));
+            if (!uploading)
+            {
+                FlashSuccess(LocalizationService.Get("S.Settings.DiagnosticsExported"));
 
-            // The real confirmation: the status line fades after a moment and cannot show a path
-            // worth reading anyway, whereas Explorer opens with the file already selected and ready
-            // to be dragged into a forum post — which is the entire point of the feature.
-            DiagnosticBundleService.Reveal(path);
+                // The real confirmation: the status line fades after a moment and cannot show a path
+                // worth reading anyway, whereas Explorer opens with the file already selected and
+                // ready to be dragged into a forum post — which is the entire point of the feature.
+                DiagnosticBundleService.Reveal(path);
+                return;
+            }
+
+            try
+            {
+                var code = await DiagnosticUploadService.UploadAsync(path);
+
+                DiagnosticsCodeText.Text = code;
+                DiagnosticsCodePanel.Visibility = Visibility.Visible;
+                FlashSuccess(LocalizationService.Format("S.Settings.DiagnosticsUploaded", code));
+            }
+            catch (DiagnosticUploadException ex)
+            {
+                ShowError(LocalizationService.Get(FailureMessageKey(ex.Reason)));
+                DiagnosticBundleService.Reveal(path);
+            }
         }
         catch (Exception ex)
         {
+            // Only the collection can land here now, and if that failed there is no file to fall
+            // back to — which is why this one still names the error.
             ShowError(LocalizationService.Format("S.Settings.DiagnosticsFailed", ex.Message));
         }
         finally
         {
             ExportDiagnosticsBtn.IsEnabled = true;
+        }
+    }
+
+    /// <summary>
+    /// Every one of these lines ends by pointing at the file still on the user's disk, because that
+    /// is what they are to do next in every case.
+    /// </summary>
+    private static string FailureMessageKey(DiagnosticUploadFailure reason) => reason switch
+    {
+        DiagnosticUploadFailure.Unreachable => "S.Settings.UploadFailedUnreachable",
+        DiagnosticUploadFailure.TooLarge    => "S.Settings.UploadFailedTooLarge",
+        DiagnosticUploadFailure.RateLimited => "S.Settings.UploadFailedRateLimited",
+        _                                   => "S.Settings.UploadFailedRejected",
+    };
+
+    /// <summary>
+    /// Points the export button and its explanation at whichever of the two stories is true for this
+    /// build: with an endpoint compiled in, one press collects and sends; without one, it collects
+    /// and nothing leaves the machine.
+    /// </summary>
+    /// <remarks>
+    /// Resource references rather than assignments, so both survive a language change — the page
+    /// rebuilds itself on one, and a plain Text assignment would come back in the old language.
+    ///
+    /// A build with no endpoint is a supported state, not a broken one: it is what every build is
+    /// until the worker is deployed, and what a user gets by setting OVERTRANSLATE_DIAG_ENDPOINT to
+    /// nothing.
+    /// </remarks>
+    private void ApplyDiagnosticUploadAvailability()
+    {
+        var configured = DiagnosticUploadService.IsConfigured;
+
+        ExportDiagnosticsLabel.SetResourceReference(
+            TextBlock.TextProperty,
+            configured ? "S.Settings.UploadDiagnostics" : "S.Settings.ExportDiagnostics");
+
+        DiagnosticsHintText.SetResourceReference(
+            TextBlock.TextProperty,
+            configured ? "S.Settings.DiagnosticsUploadHint" : "S.Settings.DiagnosticsHint");
+    }
+
+    /// <remarks>
+    /// The clipboard is a shared, lockable resource, and the one thing that must not happen is the
+    /// user walking away believing they have the code. On failure the code stays on screen and the
+    /// line says to read it from there.
+    /// </remarks>
+    private void CopyDiagnosticsCodeBtn_Click(object sender, RoutedEventArgs e)
+    {
+        var code = DiagnosticsCodeText.Text;
+        if (string.IsNullOrEmpty(code)) return;
+
+        try
+        {
+            Clipboard.SetText(code);
+            FlashSuccess(LocalizationService.Get("S.Settings.DiagnosticsCodeCopied"));
+        }
+        catch (Exception)
+        {
+            ShowError(LocalizationService.Get("S.Settings.CopyFailed"));
+        }
+    }
+
+    /// <remarks>
+    /// Opens the zip rather than selecting it, because the question this button answers is "what did
+    /// I just send" — and Explorer shows the three files inside a zip it opens.
+    /// </remarks>
+    private void OpenDiagnosticsBundleBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_lastBundlePath is null) return;
+
+        try
+        {
+            DiagnosticBundleService.Open(_lastBundlePath);
+        }
+        catch (Exception ex)
+        {
+            ShowError(LocalizationService.Format("S.Settings.OpenFolderFailed", ex.Message));
         }
     }
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -580,7 +580,6 @@ public partial class SettingsPage : UserControl
         DiagnosticsCodeText.Text = code;
         DiagnosticsCodeText.Visibility = Visibility.Visible;
         CopyDiagnosticsCodeBtn.Visibility = Visibility.Visible;
-        DiagnosticsRetentionRow.Visibility = Visibility.Visible;
 
         DiagnosticsResultPanel.Visibility = Visibility.Visible;
     }
@@ -597,6 +596,9 @@ public partial class SettingsPage : UserControl
     /// One wording for every reason an upload can fail. Whether it was the network, the size or a
     /// refusal, the next move is the same: report it by hand and attach the file. Telling the four
     /// apart would offer a distinction the user cannot act on.
+    ///
+    /// The thirty-day line stays, unlike everything else that goes: it is about the copy on disk,
+    /// which is kept for the same thirty days either way.
     /// </remarks>
     private void ShowNotUploaded()
     {
@@ -608,7 +610,6 @@ public partial class SettingsPage : UserControl
 
         DiagnosticsCodeText.Visibility = Visibility.Collapsed;
         CopyDiagnosticsCodeBtn.Visibility = Visibility.Collapsed;
-        DiagnosticsRetentionRow.Visibility = Visibility.Collapsed;
 
         DiagnosticsResultPanel.Visibility = Visibility.Visible;
     }

--- a/tests/OverTranslate.Tests/DiagnosticRedactionTests.cs
+++ b/tests/OverTranslate.Tests/DiagnosticRedactionTests.cs
@@ -141,4 +141,76 @@ public class DiagnosticRedactionTests
 
         Assert.Equal(elsewhere, DiagnosticBundleService.CollapseUserPaths(elsewhere));
     }
+
+    // The exported zips are kept for the same thirty days the uploaded copy gets, so that the
+    // interface can say "30 days" once without having to explain which copy it means. That makes
+    // this a deletion loop running inside the user's own data folder, which is worth pinning down.
+    [Fact]
+    public void ExportsPastTheirThirtyDays_AreDeleted()
+    {
+        var directory = NewTempFolder();
+        try
+        {
+            var old = WriteBundle(directory, "OverTranslate-diagnostics-20250101-120000.zip",
+                DateTime.UtcNow - TimeSpan.FromDays(31));
+            var fresh = WriteBundle(directory, "OverTranslate-diagnostics-20260101-120000.zip",
+                DateTime.UtcNow - TimeSpan.FromDays(29));
+
+            Assert.Equal(1, DiagnosticBundleService.PruneOldExports(directory, DateTime.UtcNow));
+
+            Assert.False(File.Exists(old));
+            Assert.True(File.Exists(fresh));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FilesTheExportDidNotWrite_AreLeftAloneHoweverOld()
+    {
+        var directory = NewTempFolder();
+        try
+        {
+            // Someone who renamed a bundle to remember which one it was, and someone who kept a note
+            // beside it, both put those there on purpose. A cleanup that takes files it did not
+            // write is a bug that destroys data, so the name it wrote is the only licence it has.
+            var renamed = WriteBundle(directory, "the one with the crash.zip", DateTime.UtcNow.AddYears(-2));
+            var note = WriteBundle(directory, "notes.txt", DateTime.UtcNow.AddYears(-2));
+
+            Assert.Equal(0, DiagnosticBundleService.PruneOldExports(directory, DateTime.UtcNow));
+
+            Assert.True(File.Exists(renamed));
+            Assert.True(File.Exists(note));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void AFolderThatWasNeverExportedTo_IsNotAnError()
+    {
+        // The first press on a fresh machine prunes before it writes, so this runs against a folder
+        // that does not exist yet every single time.
+        Assert.Equal(0, DiagnosticBundleService.PruneOldExports(
+            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), DateTime.UtcNow));
+    }
+
+    private static string NewTempFolder()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "ot-prune-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static string WriteBundle(string directory, string name, DateTime writtenUtc)
+    {
+        var path = Path.Combine(directory, name);
+        File.WriteAllText(path, "not really a zip");
+        File.SetLastWriteTimeUtc(path, writtenUtc);
+        return path;
+    }
 }

--- a/tests/OverTranslate.Tests/DiagnosticRedactionTests.cs
+++ b/tests/OverTranslate.Tests/DiagnosticRedactionTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text.Json.Nodes;
 using OverTranslate.Services;
 using Xunit;
@@ -100,5 +101,44 @@ public class DiagnosticRedactionTests
         // A file in this shape cannot hold a key in a field we would recognise, and its shape is
         // itself the bug being reported — so it goes into the bundle exactly as found.
         Assert.Equal(broken, DiagnosticBundleService.RedactSettings(broken));
+    }
+
+    // The settings file is not the only thing in the bundle that carried something the user did not
+    // mean to hand over. environment.txt named four folders, and on most machines the account those
+    // folders belong to is the person's actual name.
+    [Fact]
+    public void UserFolders_AreNamedByTheirVariableRatherThanTheAccount()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
+        var collapsed = DiagnosticBundleService.CollapseUserPaths(
+            Path.Combine(appData, "OverTranslate", "logs"));
+
+        Assert.StartsWith("%APPDATA%", collapsed);
+        Assert.EndsWith(Path.Combine("OverTranslate", "logs"), collapsed);
+        Assert.DoesNotContain(Environment.UserName, collapsed, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LocalAppData_IsNotMistakenForTheProfileRoot()
+    {
+        // Both roots are under the profile. Matching the shortest one first would turn every path
+        // into %USERPROFILE%\AppData\..., which puts the folder layout back in the wrong terms.
+        var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        Assert.StartsWith(
+            "%LOCALAPPDATA%",
+            DiagnosticBundleService.CollapseUserPaths(Path.Combine(local, "OverTranslate")));
+    }
+
+    [Fact]
+    public void PathOutsideTheProfile_IsLeftAlone()
+    {
+        // Being somewhere unexpected is the condition worth seeing — a log redirected onto another
+        // drive is exactly the environment whose log we would otherwise fail to explain. And a path
+        // that was never under the account's folder has no account name in it to hide.
+        const string elsewhere = @"D:	ools\OverTranslate\logs";
+
+        Assert.Equal(elsewhere, DiagnosticBundleService.CollapseUserPaths(elsewhere));
     }
 }

--- a/tests/OverTranslate.Tests/DiagnosticUploadTests.cs
+++ b/tests/OverTranslate.Tests/DiagnosticUploadTests.cs
@@ -58,11 +58,18 @@ public class DiagnosticUploadTests
         Assert.Equal(expected, DiagnosticUploadService.Classify(status));
     }
 
-    [Fact]
-    public async Task WithNoEndpoint_NothingIsSentAndTheCallerIsToldWhy()
+    [Theory]
+    // "off" is the documented way to switch uploading off. The other two are what a mistyped or
+    // half-edited endpoint looks like, and they have to fail the same way: an address that is not an
+    // address must turn the feature off, never send a log full of someone's screen to whatever it
+    // resolves to.
+    [InlineData("off")]
+    [InlineData("overtranslate-diag.example.workers.dev/v1/bundle")]
+    [InlineData("ftp://example.com/v1/bundle")]
+    public async Task WithNoUsableEndpoint_NothingIsSentAndTheCallerIsToldWhy(string endpoint)
     {
         var saved = Environment.GetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT");
-        Environment.SetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT", "");
+        Environment.SetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT", endpoint);
         try
         {
             Assert.False(DiagnosticUploadService.IsConfigured);
@@ -74,6 +81,24 @@ public class DiagnosticUploadTests
                 () => DiagnosticUploadService.UploadAsync("C:/nowhere/no-such-bundle.zip"));
 
             Assert.Equal(DiagnosticUploadFailure.NotConfigured, ex.Reason);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT", saved);
+        }
+    }
+
+    [Fact]
+    public void TheEndpointCompiledIn_IsAnAddressThatCanBeUploadedTo()
+    {
+        var saved = Environment.GetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT");
+        Environment.SetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT", null);
+        try
+        {
+            // Not that it answers — that needs a network and belongs in a manual pass — but that a
+            // shipped build would try. A typo here turns the whole feature off silently.
+            Assert.True(DiagnosticUploadService.IsConfigured);
+            Assert.StartsWith("https://", DiagnosticUploadService.Endpoint);
         }
         finally
         {

--- a/tests/OverTranslate.Tests/DiagnosticUploadTests.cs
+++ b/tests/OverTranslate.Tests/DiagnosticUploadTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using OverTranslate.Services;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+// The upload endpoint is open to anything on the internet, so the response it returns cannot be
+// trusted to be the response the worker would have returned. What is pinned here is the pair of
+// decisions that follow from that: what counts as a code worth showing the user, and which failures
+// they get told apart. Everything else about the upload needs a network and belongs in a manual
+// pass.
+public class DiagnosticUploadTests
+{
+    [Fact]
+    public void WellFormedCode_IsAccepted()
+    {
+        Assert.Equal("A3F-7K2", DiagnosticUploadService.ParseCode("""{"code":"A3F-7K2"}"""));
+    }
+
+    [Theory]
+    // A captive portal answering 200 with its own page, and a proxy answering with an error object:
+    // both are "success" as far as HTTP is concerned, and neither carries a code.
+    [InlineData("<html><body>Sign in to continue</body></html>")]
+    [InlineData("""{"error":"rate_limited"}""")]
+    [InlineData("")]
+    public void ResponseWithoutACode_IsRejectedRatherThanShown(string body)
+    {
+        Assert.Null(DiagnosticUploadService.ParseCode(body));
+    }
+
+    [Theory]
+    // The shape is fixed on purpose: six characters, a dash in the middle, and only from the
+    // alphabet the worker draws on. A user is told to copy this into a public post, so a string
+    // that is not a code has to fail here rather than be pasted somewhere as though it were one.
+    [InlineData("A3F7K2")]            // no separator
+    [InlineData("A3F-7K")]            // too short
+    [InlineData("A3F-7K2X")]          // too long
+    [InlineData("a3f-7k2")]           // lower case
+    [InlineData("A3I-7K2")]           // I, L, O and U are excluded to keep it readable aloud
+    [InlineData("A3F-7K2 or click here")]
+    public void MisshapenCode_IsRejected(string code)
+    {
+        Assert.Null(DiagnosticUploadService.ParseCode($$"""{"code":"{{code}}"}"""));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, DiagnosticUploadFailure.TooLarge)]
+    [InlineData(HttpStatusCode.TooManyRequests, DiagnosticUploadFailure.RateLimited)]
+    // Everything else collapses into one line, because the difference between a 500 and a 415
+    // changes nothing the user can do — and what they are told to do next, attach the file that is
+    // still on their disk, is the same either way.
+    [InlineData(HttpStatusCode.InternalServerError, DiagnosticUploadFailure.Rejected)]
+    [InlineData(HttpStatusCode.UnsupportedMediaType, DiagnosticUploadFailure.Rejected)]
+    [InlineData(HttpStatusCode.NotFound, DiagnosticUploadFailure.Rejected)]
+    public void RefusalIsTranslatedIntoSomethingTheUserCanActOn(
+        HttpStatusCode status, DiagnosticUploadFailure expected)
+    {
+        Assert.Equal(expected, DiagnosticUploadService.Classify(status));
+    }
+
+    [Fact]
+    public async Task WithNoEndpoint_NothingIsSentAndTheCallerIsToldWhy()
+    {
+        var saved = Environment.GetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT");
+        Environment.SetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT", "");
+        try
+        {
+            Assert.False(DiagnosticUploadService.IsConfigured);
+
+            // A path that does not exist: reaching a FileNotFoundException would mean the endpoint
+            // check happens after the file is opened, and by then a build with no endpoint would be
+            // one line away from posting to an empty address.
+            var ex = await Assert.ThrowsAsync<DiagnosticUploadException>(
+                () => DiagnosticUploadService.UploadAsync("C:/nowhere/no-such-bundle.zip"));
+
+            Assert.Equal(DiagnosticUploadFailure.NotConfigured, ex.Reason);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OVERTRANSLATE_DIAG_ENDPOINT", saved);
+        }
+    }
+}

--- a/tests/OverTranslate.Tests/LocalizedLineBreakTests.cs
+++ b/tests/OverTranslate.Tests/LocalizedLineBreakTests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+// XAML collapses whitespace in element content, and a character reference is resolved by the XML
+// reader before XAML ever looks at it — so a &#x0a; written into a string arrives as a line feed and
+// leaves as a space. It shipped that way once: two sentences meant to sit on their own lines ran
+// together in the settings card, and nothing failed to say so. xml:space="preserve" is what keeps
+// the break, and it is easy to drop while editing the wording around it.
+//
+// Read as XML rather than through XamlReader, which would want an STA thread for what is really a
+// question about the source file: a string that asks for a line break has to be marked to keep one.
+//
+// Only the strings the diagnostics card composes. Four older strings elsewhere have the same problem
+// and are deliberately not covered — fixing them changes screens this had no business touching, and
+// a test that fails for something nobody is fixing is a test people learn to ignore.
+public class LocalizedLineBreakTests
+{
+    private static readonly string[] TwoLineKeys =
+    {
+        "S.Settings.DiagnosticsUploadHint",
+        "S.Settings.DiagnosticsUploadedHint",
+        "S.Settings.DiagnosticsNotUploadedHint",
+    };
+
+    [Theory]
+    [InlineData("Strings.en.xaml")]
+    [InlineData("Strings.zh-Hant.xaml")]
+    public void TheDiagnosticsHints_KeepTheirLineBreak(string file)
+    {
+        XNamespace xml = "http://www.w3.org/XML/1998/namespace";
+        XNamespace xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+        var strings = XDocument
+            .Load(Path.Combine(ResourcesDirectory, file))
+            .Descendants()
+            .Where(element => element.Name.LocalName == "String")
+            .ToDictionary(element => (string?)element.Attribute(xaml + "Key") ?? "", element => element);
+
+        foreach (var key in TwoLineKeys)
+        {
+            var element = Assert.Contains(key, strings);
+
+            // Two sentences, one break, and nothing hanging off either end — a stray space either
+            // side of the newline is the other way this goes wrong, and it looks fine in the source.
+            var lines = element.Value.Split('\n');
+            Assert.Equal(2, lines.Length);
+            Assert.All(lines, line => Assert.Equal(line.Trim(), line));
+
+            Assert.Equal("preserve", (string?)element.Attribute(xml + "space"));
+        }
+    }
+
+    /// <summary>
+    /// Walked up from the test binaries rather than hard-coded, so this keeps working from whichever
+    /// configuration and framework folder the run happens to be in.
+    /// </summary>
+    private static string ResourcesDirectory
+    {
+        get
+        {
+            var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (directory is not null &&
+                   !Directory.Exists(Path.Combine(directory.FullName, "src", "OverTranslate")))
+            {
+                directory = directory.Parent;
+            }
+
+            Assert.NotNull(directory);
+            return Path.Combine(directory!.FullName, "src", "OverTranslate", "Resources");
+        }
+    }
+}


### PR DESCRIPTION
Closes #127

#126 讓回報變成「按一下匯出、把 zip 拖進貼文」。這張票把最後那一段交接也拿掉：按一次，包好、送出、拿到一組代碼，貼一行字就結束。

## 形狀

**一顆按鈕。** 「匯出診斷資訊」改成「匯出並上傳診斷資訊」，沒有多一顆上傳鍵。沒有人是為了收集診斷檔而收集診斷檔的，拆成兩步只是把同一個意圖切成兩半。

**只有手動。** 沒有自動上傳、沒有背景佇列、沒有崩潰回報。記錄詳細資訊會把螢幕上的文字寫進 log，而那正是最值得送出的那份 log —— 所以送出這件事必須是刻意的。

**失敗一定退得回本機。** zip 在嘗試上傳之前就已經寫好，所以上傳失敗時面板換成另一種狀態，代碼與複製消失、只留「開啟檔案」。#126 那條路完整保留，離線、公司網路擋掉、或單純不想上傳的人不受影響。

## 收件端

Cloudflare Worker + Workers KV，程式碼在獨立的公開倉 [asd880921/OverTranslate-Diag-Worker](https://github.com/asd880921/OverTranslate-Diag-Worker)。公開是必要的：這顆按鈕會送出可能含有螢幕文字的 log，「相信我只留一個月」的份量遠不如讓人自己去讀那一百行。

用 KV 而不是 R2，是因為 **R2 即使在免費額度內也要求帳號綁定付款方式**，而這個端點的存在是為了讓回報問題不花任何人的錢。KV 的上限（單值 25 MiB、每日千次寫入）比實際需求高一個數量級，而且逐筆過期比 R2 的 lifecycle rule 更難忘記設。

端點位址寫死在建置裡，另認 `OVERTRANSLATE_DIAG_ENDPOINT` 覆寫。判定「是否啟用」用的是**能不能解析成 http(s) 網址**，不是字串非空 —— 順帶讓打錯字的端點變成關閉功能，而不是把 log 送到那串字碰巧解析到的地方。

## 隱私

- **API 金鑰**沿用 #126 的遮罩，只留長度
- **不再帶出 Windows 帳號名**：`environment.txt` 的四行路徑改用 `%APPDATA%` / `%LOCALAPPDATA%` / `%USERPROFILE%` 表示。非使用者資料夾的路徑原樣保留 —— 那正是要診斷的狀況，而且也沒有帳號名可藏。連同這個服務自己寫進 log 的三行一併處理，其中 `Diagnostic bundle written to …` 是會漏進**下一包**的側門
- **收件端不存 IP**，也沒有任何能把兩次上傳串成同一個人的識別碼。中繼資料只有時間、版本、OS、大小
- **30 天，兩邊一致**：上傳的那份由 KV 逐筆過期刪除，本機那份在下次匯出時順手清掉。所以介面上「30 天」只需要講一次，不必說明是哪一份
- `PRIVACY.md` 補上上傳什麼、傳到哪、留多久，以及本機副本同樣 30 天刪除

本機清理只刪自己寫出來的檔名（`OverTranslate-diagnostics-*.zip`）。使用者若把某一包改名留著，那是他刻意放的，清理程式動到不是自己寫的檔案是會毀資料的 bug。

## 已實測

端點：`GET /` 說明頁、405、411、415、404 全部正確；真實 zip 上傳回代碼；100 發連續請求擋掉 32 發（限流是洪水閘門而非精確門檻，這是 Cloudflare 限流器的設計，已寫進該倉的 README）；用代碼撈回的檔案位元組數與上傳一致；到期日正好是上傳時間 +30 天。

App：成功與失敗兩種面板狀態都在實機上看過。

## 順帶記下、但這次沒動的

- `SettingsService` 與 `RealtimeFrameDump` 有三處會把完整路徑寫進 log（存檔失敗、讀取設定失敗、畫面傾印）。都是失敗路徑或需另外開啟的除錯功能，改它們要動到與本票無關的檔案
- `S.Main.CopiedAndSavedBody`、`S.Main.TranslateFailedBody`、`S.Translation.ProviderUnavailable`、`S.Toolbar.BackupTooltip` 四個既有字串的換行同樣被 XAML 的空白收合吃成空格。修正方式與本票相同（`xml:space="preserve"`），但會改到截圖工具列與快顯通知的版面

## 測試

新增 20 個，全部 589 個測試通過。涵蓋：代碼格式驗證（含企業入口網頁回 200 卻不是代碼的情況）、狀態碼分類、沒有可用端點時不碰檔案就先拒絕、內建端點不能被打錯、路徑收斂的三種情形、本機清理只動自己的檔案、以及提示文案的換行不會被吃掉。
