### PR TITLE
feat: 開啟翻譯視窗時重新翻譯，並調整診斷資訊文案

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -382,7 +382,7 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open folder</sys:String>
-    <sys:String x:Key="S.Settings.UploadDiagnostics">Export and upload diagnostics</sys:String>
+    <sys:String x:Key="S.Settings.UploadDiagnostics">Upload diagnostics</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">The diagnostics contain the log files, system information and your current settings, with sensitive data replaced.&#x0a;The diagnostic file is kept on your device and deleted automatically after 30 days.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Diagnostics exported</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -386,8 +386,8 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">The diagnostics contain the log files, system information and your current settings, with sensitive data replaced.&#x0a;The diagnostic file is kept on your device and deleted automatically after 30 days.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Diagnostics exported</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully.&#x0a;Open file to see what was exported this time.</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file.&#x0a;Open file to get what was exported this time.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully. Open file to see what was exported this time.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file. Open file to get what was exported this time.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsRetention">Files are deleted automatically after 30 days</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">Copy</sys:String>
     <sys:String x:Key="S.Settings.OpenBundle">Open file</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -410,8 +410,8 @@
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">診斷資訊包含記錄檔、系統資訊與目前設定，敏感資料會被替換。&#x0a;診斷檔會保留在本機，並於 30 天後自動刪除。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">診斷資訊已匯出</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。&#x0a;按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">診斷資訊已成功匯出，但無法上傳。請透過 GitHub 或論壇回報問題並附上檔案。&#x0a;按「開啟檔案」可取得本次匯出的診斷資訊。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">診斷資訊已成功匯出，但無法上傳。請透過 GitHub 或論壇回報問題並附上檔案。按「開啟檔案」可取得本次匯出的診斷資訊。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsRetention">檔案將於 30 天後自動刪除</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">複製</sys:String>
     <sys:String x:Key="S.Settings.OpenBundle">開啟檔案</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -406,7 +406,7 @@
     <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟資料夾</sys:String>
-    <sys:String x:Key="S.Settings.UploadDiagnostics">匯出並上傳診斷資訊</sys:String>
+    <sys:String x:Key="S.Settings.UploadDiagnostics">上傳診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">診斷資訊包含記錄檔、系統資訊與目前設定，敏感資料會被替換。&#x0a;診斷檔會保留在本機，並於 30 天後自動刪除。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">診斷資訊已匯出</sys:String>

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -251,8 +251,9 @@ public partial class TranslationPage : UserControl
     }
 
     /// <summary>
-    /// Schedules a debounced auto-translation. Programmatic edits are ignored (so opening from a
-    /// screenshot doesn't re-translate), and an empty source instantly clears the output.
+    /// Schedules a debounced auto-translation. Programmatic edits are ignored — the screenshot flow
+    /// fills both panes itself and then asks for the one translation it wants, see
+    /// <see cref="SetContent"/> — and an empty source instantly clears the output.
     /// </summary>
     private void RequestTranslate()
     {
@@ -438,9 +439,23 @@ public partial class TranslationPage : UserControl
         TgtTtsBtn.Content = ReferenceEquals(_ttsActiveBtn, TgtTtsBtn) ? StopGlyph : SpeakerGlyph;
     }
 
+    /// <summary>
+    /// Carries a screenshot result into the page and re-translates it once.
+    /// </summary>
+    /// <remarks>
+    /// <para>Both panes are filled from the capture before anything is sent, so the window never
+    /// opens empty: the translation that came with the result is what there is to read while the new
+    /// one is on its way, and it is replaced in place when the answer arrives.</para>
+    ///
+    /// <para>Re-translated rather than shown as-is, because the two flows are not asking the same
+    /// question. The overlay translates each OCR block on its own — it has to, since every answer is
+    /// painted back over the box it came from — and what arrives here is those per-block answers
+    /// glued together: sentences cut in half at a line end, and mixed-language lines each judged with
+    /// only their own fragment for context. Sending the joined text as one request is the whole
+    /// reason somebody opens the window after reading the overlay.</para>
+    /// </remarks>
     public void SetContent(string sourceText, string translatedText, string srcLang, string tgtLang)
     {
-        // Content arrives already translated (from the screenshot flow) — show it as-is, don't re-call.
         _suppressAuto = true;
         _debounce.Stop();
         _seq++;
@@ -454,12 +469,16 @@ public partial class TranslationPage : UserControl
         SrcLangBox.SelectedValue = LanguageData.GetValidSourceCode(srcLang);
         TgtLangBox.SelectedValue = LanguageData.GetValidTargetCode(tgtLang);
 
-        // Treat the supplied translation as the current state so a later identical input won't re-call.
-        _lastDone = (sourceText, LanguageData.GetValidSourceCode(srcLang),
-                     LanguageData.GetValidTargetCode(tgtLang), SettingsService.Instance.Current.Provider);
+        // The carried translation is not one this page produced, so it does not count as one:
+        // leaving it here would make the request below the "identical input" case and skip it.
+        _lastDone = null;
         _suppressAuto = false;
 
         RenderSourceActions();
+
+        // Straight to the request rather than through the debounce: nobody is typing, and the wait
+        // would only hold back the answer the window was opened for.
+        _ = TranslateNowAsync();
     }
 
     private void ShowRetry(bool visible)


### PR DESCRIPTION
## 摘要

- 截圖翻譯的「開啟翻譯視窗」帶入結果後，額外觸發一次翻譯
- 診斷資訊結果小卡的說明文字移除硬換行
- 「匯出並上傳診斷資訊」按鈕改名為「上傳診斷資訊」

## 開啟翻譯視窗時重新翻譯

原本 `TranslationPage.SetContent` 把截圖流程的原文與譯文直接填進左右欄位就結束，並把該譯文記成 `_lastDone`，因此不會再送翻譯。

疊圖流程是每個 OCR 區塊各自翻譯（要畫回原本的位置），視窗收到的是那些碎片黏起來的結果 —— 斷句被切在行尾、混語的行各自只用自己的片段判斷。把合併後的整段文字當成單一請求重送，正是使用者看完疊圖後開視窗的目的。

- 兩邊欄位仍先填入帶過來的內容，視窗不會空著開；舊譯文留在畫面上直到新結果覆蓋
- `_lastDone` 改為 `null`，否則新請求會被判定為相同輸入而跳過
- 直接呼叫 `TranslateNowAsync()` 而不走 debounce（沒人在打字）
- 翻譯中沿用既有的進度條；失敗則保留舊譯文並顯示錯誤與重試

## 診斷資訊文案

- `DiagnosticsUploadedHint` / `DiagnosticsNotUploadedHint` 移除句中的 `&#x0a;`，文字內容未改。該 TextBlock 已套 `TextWrapping=Wrap`，會依寬度自然折行
- `UploadDiagnostics` 按鈕文字改為「上傳診斷資訊」；未設定上傳端點時使用的 `ExportDiagnostics` 維持不變
- 英文資源一併對齊

## 測試

- `dotnet build` 通過（僅剩既有的 CA1416 警告）
- 需實機確認：截圖後按「開啟翻譯視窗」確實跑一次翻譯、診斷小卡排版與按鈕文字