### PR TITLE
feat: 為安裝加上識別碼，並隨診斷上傳送出

### DIFF
--- a/src/OverTranslate/App.xaml.cs
+++ b/src/OverTranslate/App.xaml.cs
@@ -75,6 +75,11 @@ public partial class App
         // 記錄詳細資訊 gets the detail from startup onwards rather than from their next toggle.
         LogLevelService.Apply(SettingsService.Instance.Current.VerboseLogging);
 
+        // Straight after the log level and before anything else runs, so the identity is on the
+        // first lines of every session's log rather than turning up partway down whichever of them
+        // happened to reach it first.
+        AppIdentityService.Initialize();
+
         ThemeService.Apply(SettingsService.Instance.Current.Theme);
 
         // Before any window is built, so nothing is ever constructed against the wrong dictionary.

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -7,6 +7,19 @@ public enum TranslationProvider { Google, Google2, Bing, Microsoft, DeepL, OpenA
 
 public class AppSettings
 {
+    /// <summary>
+    /// Identifies this installation across the diagnostic reports it sends.
+    /// </summary>
+    /// <remarks>
+    /// First in the file because it is what a maintainer opening a bundle looks for first, and
+    /// deliberately named for what it is rather than for the one thing it is used for today — it
+    /// identifies an install, and diagnostics is only the first thing that wants to know.
+    ///
+    /// Empty is a valid state and the one every existing install starts from. See
+    /// <see cref="Services.AppIdentityService"/> for what fills it and when.
+    /// </remarks>
+    public string ID { get; set; } = "";
+
     public uint HotkeyModifiers { get; set; } = 3;
     public uint HotkeyVirtualKey { get; set; } = 0x41;
     public string HotkeyDisplay { get; set; } = "Ctrl+Alt+A";

--- a/src/OverTranslate/Services/AppIdentityService.cs
+++ b/src/OverTranslate/Services/AppIdentityService.cs
@@ -1,0 +1,97 @@
+using System.Globalization;
+using NLog;
+using OverTranslate.Models;
+
+namespace OverTranslate.Services;
+
+/// <summary>
+/// The identifier that says two diagnostic reports came from the same installation.
+/// </summary>
+/// <remarks>
+/// <para>Uploads are anonymous and stay anonymous: this is issued here, from nothing but the clock
+/// and a random GUID. Nothing about the machine or the person goes into it, so it cannot be read
+/// backwards — the one and only question it answers is whether two reports are the same install
+/// talking twice, which is the question that cannot be answered at all without it.</para>
+///
+/// <para>It lives in appsettings.json under <see cref="AppSettings.ID"/> rather than in a file of
+/// its own, and it is deliberately not hidden. A user who deletes or edits it gets a new one on the
+/// next launch and nothing else happens; there is no attempt to make it stick, because anyone who
+/// wanted a fresh identity could reinstall for one anyway, and a value hidden from the person it
+/// describes would sit badly beside a diagnostic bundle whose whole promise is that they can read
+/// what they are handing over.</para>
+///
+/// <para>Read once, at startup, and held here. Not re-read afterwards: a value that changed
+/// underneath a running process would put two identities on one session's worth of log, and the
+/// only thing to gain would be honouring an edit made while the application was open.</para>
+/// </remarks>
+public static class AppIdentityService
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    /// <summary>The timestamp half, which says when this install first ran.</summary>
+    /// <remarks>
+    /// Local time, matching the timestamps this application already writes into export filenames.
+    /// Across time zones it is out by hours, which changes nothing about the only thing it is read
+    /// for: whether a report comes from an install of long standing or one that broke on day one.
+    /// </remarks>
+    private const string TimestampFormat = "yyyyMMddHHmmss";
+
+    private const int TimestampLength = 14;
+
+    /// <summary>A GUID in "D" format — 32 digits and four hyphens.</summary>
+    private const int GuidLength = 36;
+
+    /// <summary>The identifier for this run, or empty before <see cref="Initialize"/> has run.</summary>
+    public static string Current { get; private set; } = "";
+
+    /// <summary>
+    /// Settles the identifier for this run, issuing and saving a new one when what is on disk is
+    /// missing or malformed.
+    /// </summary>
+    /// <remarks>
+    /// Anything that does not parse is replaced rather than repaired or reported. There is nothing
+    /// in a broken value worth keeping and nothing the user would do about being told, and the
+    /// failure this covers is not sabotage but the ordinary sort: a hand-edited file, a half-written
+    /// one, a field this application has not written yet because the install predates it.
+    /// </remarks>
+    public static void Initialize()
+    {
+        var settings = SettingsService.Instance.Current;
+
+        if (IsWellFormed(settings.ID))
+        {
+            Current = settings.ID;
+            Log.Info("Install identity {0}", Current);
+            return;
+        }
+
+        Current = Generate(DateTime.Now);
+        settings.ID = Current;
+        SettingsService.Instance.Save();
+
+        Log.Info("Install identity issued: {0}", Current);
+    }
+
+    /// <summary>Builds an identifier from a moment and a fresh GUID.</summary>
+    public static string Generate(DateTime now) =>
+        $"{now.ToString(TimestampFormat, CultureInfo.InvariantCulture)}-{Guid.NewGuid():D}";
+
+    /// <summary>
+    /// Whether a stored value is one this class wrote.
+    /// </summary>
+    /// <remarks>
+    /// The date is parsed rather than pattern-matched, so a run of fourteen digits that is not a
+    /// date does not survive as one. Both halves have to hold: an identifier is only useful if
+    /// every part of it means what it claims to.
+    /// </remarks>
+    public static bool IsWellFormed(string? value)
+    {
+        if (value is null || value.Length != TimestampLength + 1 + GuidLength) return false;
+        if (value[TimestampLength] != '-') return false;
+
+        return DateTime.TryParseExact(
+                   value[..TimestampLength], TimestampFormat,
+                   CultureInfo.InvariantCulture, DateTimeStyles.None, out _)
+               && Guid.TryParseExact(value[(TimestampLength + 1)..], "D", out _);
+    }
+}

--- a/src/OverTranslate/Services/DiagnosticUploadService.cs
+++ b/src/OverTranslate/Services/DiagnosticUploadService.cs
@@ -138,10 +138,22 @@ public static class DiagnosticUploadService
         content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/zip");
 
         using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
-        // Metadata, not identity. Which build and which Windows answers most of the "why does this
-        // only happen to them" questions; neither is anything the receiving end trusts.
+        // Which build and which Windows answers most of the "why does this only happen to them"
+        // questions. Neither is anything the receiving end trusts — they are a client's word about
+        // itself, and any client can say anything.
         request.Headers.TryAddWithoutValidation("x-overtranslate-version", AppVersion);
         request.Headers.TryAddWithoutValidation("x-overtranslate-os", RuntimeInformation.OSDescription);
+
+        // Sent here as well as sitting inside the bundle, because the two are read at different
+        // moments: the copy in appsettings.redacted.json is found by someone who has already
+        // downloaded the zip, and by then they know which report they are reading. This one arrives
+        // with the upload itself, which is what lets a second report from an install announce itself
+        // as one rather than waiting to be recognised.
+        //
+        // Empty only if the upload somehow runs before startup settled it, and sent regardless:
+        // an absent header reads as "this client did not say", which is the truth, where an omitted
+        // one would be indistinguishable from an older build that could not.
+        request.Headers.TryAddWithoutValidation("x-overtranslate-id", AppIdentityService.Current);
 
         HttpResponseMessage response;
         try

--- a/tests/OverTranslate.Tests/AppIdentityTests.cs
+++ b/tests/OverTranslate.Tests/AppIdentityTests.cs
@@ -1,0 +1,58 @@
+using OverTranslate.Services;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+// The identifier is written once and then read for the rest of the install's life, so what is
+// pinned here is the shape agreed on and the judgement of what to do with a value that does not
+// match it — the file is hand-editable, and every rejection here costs the user their history
+// while every wrong acceptance puts a value that is not an identifier into a report.
+public class AppIdentityTests
+{
+    [Fact]
+    public void GeneratedIdentity_IsAcceptedBack()
+    {
+        Assert.True(AppIdentityService.IsWellFormed(AppIdentityService.Generate(DateTime.Now)));
+    }
+
+    [Fact]
+    public void GeneratedIdentity_CarriesTheMomentItWasIssued()
+    {
+        var issued = new DateTime(2026, 8, 22, 12, 41, 3);
+
+        Assert.StartsWith("20260822124103-", AppIdentityService.Generate(issued));
+    }
+
+    [Fact]
+    public void TwoIdentities_AreNotTheSame()
+    {
+        var now = DateTime.Now;
+
+        Assert.NotEqual(AppIdentityService.Generate(now), AppIdentityService.Generate(now));
+    }
+
+    [Theory]
+    // The state every install predating this field is in.
+    [InlineData("")]
+    // A GUID with no timestamp, and a timestamp with no GUID: each half alone is not the value.
+    [InlineData("3f2504e0-4f89-41d3-9a0c-0305e82c3301")]
+    [InlineData("20260822124103")]
+    // Fourteen digits that are not a date. Pattern-matching the shape would let this through.
+    [InlineData("20261332994103-3f2504e0-4f89-41d3-9a0c-0305e82c3301")]
+    // A GUID in the other formats .NET will happily parse, neither of which is what is written.
+    [InlineData("20260822124103-3f2504e04f8941d39a0c0305e82c3301")]
+    [InlineData("20260822124103-{3f2504e0-4f89-41d3-9a0c-0305e82c3301}")]
+    // Whatever a half-written file or a hand edit leaves behind.
+    [InlineData("not-an-identifier")]
+    [InlineData("20260822124103-3f2504e0-4f89-41d3-9a0c-0305e82c33")]
+    public void AnythingElse_IsReplacedRatherThanKept(string stored)
+    {
+        Assert.False(AppIdentityService.IsWellFormed(stored));
+    }
+
+    [Fact]
+    public void NoValueAtAll_IsReplacedRatherThanKept()
+    {
+        Assert.False(AppIdentityService.IsWellFormed(null));
+    }
+}


### PR DESCRIPTION
## 摘要

匿名上傳的設計沒有改變，改變的是「同一個安裝的兩份回報認得出彼此」。目前診斷資訊上傳完全無法區分來源，同一個人回報第二次時，跟陌生人的第一次是分不出來的。

- App 啟動時產生並保存安裝識別碼，欄位名為 `ID`
- 上傳診斷資訊時以 header 附帶該識別碼

收件端的對應改動在 `OverTranslate-Diag-Worker#<PR>`，需搭配部署才會生效。

## 識別碼是什麼

`yyyyMMddHHmmss-guid`，App 第一次啟動時自己產生。時間戳的部分說的是這個安裝第一次跑起來的時間——讀回報時「裝了三個月的老用戶」和「今天剛裝就炸了」是不同的兩件事。

不從機器或使用者身上取任何東西，所以反查不到任何人；重灌就是新的一組；使用者在自己診斷包裡的 `appsettings.redacted.json` 就讀得到它。它只回答一個問題：這兩份回報是不是同一個安裝。

## 產生與保存

- `AppSettings.ID`，放在 model 第一個位置，預設空字串
- `AppIdentityService.Initialize()` 在 `App.OnStartup` 中、設定完 log level 之後立即呼叫，讓識別碼落在每個 session 的 log 開頭
- 讀到的值格式不符就直接重新產生並回寫，不修復也不回報。這裡要擋的不是惡意竄改而是尋常狀況：手動編輯過的檔案、寫到一半的檔案、或這個欄位還不存在的舊安裝
- 之後只留在記憶體，不再重讀

格式驗證是解析而非比對長相：14 碼用 `TryParseExact` 當日期解，所以「十四個數字但不是日期」不會通過；GUID 只接受 `D` 格式。

## 上傳

`DiagnosticUploadService` 多送 `x-overtranslate-id`，和既有的 version / os 並列。

送 header 而不是只靠包內的設定檔，是因為兩者被讀到的時機不同：包裡那份要等有人下載了 zip 才看得到，而那時他已經知道自己在讀哪一份報告；header 這份跟著上傳當下抵達，這才讓第二份回報能自己表明身分，而不是等著被認出來。

## 測試

- `AppIdentityTests` 12 項通過，涵蓋格式往返、時間戳內容、兩次產生不相同，以及八種應被替換的壞值
- `dotnet build` 通過

`detect_changes` 標為 HIGH，原因是 `OnStartup` 本身是 hub、掛著 11 條 process；實際改動是插入一行呼叫，`AppSettings` 那幾個 property 是行號位移的誤判。

需要實機確認：首次啟動後 `appsettings.json` 出現 ID 欄位、重啟後不變、手動改壞後重啟會換新的。