### PR TITLE
fix: 修正取詞翻譯閃退與啟動競態

### DIFF
--- a/src/OverTranslate/Services/SelectedTextReader.cs
+++ b/src/OverTranslate/Services/SelectedTextReader.cs
@@ -26,6 +26,11 @@ internal static class SelectedTextReader
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
     /// <summary>
+    /// Keeps the managed data object alive while this process owns the restored clipboard.
+    /// </summary>
+    private static System.Windows.DataObject? _restoredClipboardOwner;
+
+    /// <summary>
     /// How long the foreground application is given to answer the copy.
     /// </summary>
     /// <remarks>
@@ -165,8 +170,21 @@ internal static class SelectedTextReader
     {
         try
         {
-            if (snapshot is System.Windows.DataObject data) Clipboard.SetDataObject(data, copy: true);
-            else Clipboard.Clear();
+            if (snapshot is System.Windows.DataObject data)
+            {
+                // copy:true calls OleFlushClipboard after publishing every format. Some third-party
+                // clipboard data providers make that native call access-violate inside ole32.dll;
+                // a corrupted-state exception cannot be caught here and terminates the process.
+                // Keep the data object alive instead so OLE can request its formats lazily without
+                // taking that unsafe flush path.
+                Clipboard.SetDataObject(data, copy: false);
+                _restoredClipboardOwner = data;
+            }
+            else
+            {
+                Clipboard.Clear();
+                _restoredClipboardOwner = null;
+            }
         }
         catch (Exception ex)
         {

--- a/src/OverTranslate/Services/SelectedTextReader.cs
+++ b/src/OverTranslate/Services/SelectedTextReader.cs
@@ -87,13 +87,14 @@ internal static class SelectedTextReader
         {
             SendCopy();
 
-            var deadline = DateTime.UtcNow + CopyTimeout;
-            while (GetClipboardSequenceNumber() == before && DateTime.UtcNow < deadline)
-                await Task.Delay(PollInterval);
-
-            if (GetClipboardSequenceNumber() == before) return "";
-
-            return Sanitize(Clipboard.ContainsText() ? Clipboard.GetText() : "");
+            var maxPolls = (int)Math.Ceiling(
+                CopyTimeout.TotalMilliseconds / PollInterval.TotalMilliseconds);
+            return await PollForCopiedTextAsync(
+                before,
+                GetClipboardSequenceNumber,
+                ReadClipboardTextIfAvailable,
+                () => Task.Delay(PollInterval),
+                maxPolls);
         }
         catch (Exception ex)
         {
@@ -103,6 +104,54 @@ internal static class SelectedTextReader
         finally
         {
             Restore(snapshot);
+        }
+    }
+
+    /// <summary>
+    /// Waits for a copy operation to publish readable text after changing the clipboard.
+    /// </summary>
+    /// <remarks>
+    /// A clipboard sequence change means that an update started, not that every format is ready.
+    /// Applications commonly empty the clipboard before publishing text, and another process can
+    /// briefly hold it between those steps. Returning on that first change mistakes an in-progress
+    /// copy for an empty selection and restores the old clipboard over the result that is still
+    /// arriving.
+    /// </remarks>
+    internal static async Task<string> PollForCopiedTextAsync(
+        uint before,
+        Func<uint> getSequenceNumber,
+        Func<string?> readText,
+        Func<Task> delay,
+        int maxPolls)
+    {
+        var changed = false;
+
+        for (var poll = 0; poll <= maxPolls; poll++)
+        {
+            changed |= getSequenceNumber() != before;
+
+            if (changed && readText() is { } text)
+                return Sanitize(text);
+
+            if (poll < maxPolls) await delay();
+        }
+
+        return "";
+    }
+
+    /// <summary>Returns null while copied text is not published or cannot be read yet.</summary>
+    private static string? ReadClipboardTextIfAvailable()
+    {
+        try
+        {
+            return Clipboard.ContainsText() ? Clipboard.GetText() : null;
+        }
+        catch (Exception ex)
+        {
+            // Clipboard ownership changes asynchronously. A lock here is a state to poll through,
+            // not the final answer to the user's copy request.
+            Log.Trace(ex, "Copied text is not readable yet");
+            return null;
         }
     }
 

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -691,15 +691,17 @@ public partial class QuickLookupWindow : Window
     /// It also means the popup never closes while it is the window being used — typing in it, waiting
     /// for a translation, listening to one — so none of those needs a rule of its own.
     ///
-    /// Two exceptions. A pinned popup is one the user has said to keep regardless, which is what
-    /// pinning is for. And a picker with its list down has not lost anybody's attention: the list is
-    /// its own window, and answering that deactivation would close the popup out from under the
-    /// language someone is in the middle of choosing.
+    /// Three exceptions. A popup that has not yet been confirmed as the foreground window is still
+    /// in the activation handoff started by <see cref="ReacquireForeground"/>; treating that transient
+    /// deactivation as departure closes it before the retry can run. A pinned popup is one the user
+    /// has said to keep regardless, which is what pinning is for. And a picker with its list down has
+    /// not lost anybody's attention: the list is its own window, and answering that deactivation
+    /// would close the popup out from under the language someone is in the middle of choosing.
     /// </remarks>
     protected override void OnDeactivated(EventArgs e)
     {
         base.OnDeactivated(e);
-        if (_pinned || _dropDownOpen) return;
+        if (!_hadForeground || _pinned || _dropDownOpen) return;
         BeginClose();
     }
 

--- a/tests/OverTranslate.Tests/SelectedTextReaderTests.cs
+++ b/tests/OverTranslate.Tests/SelectedTextReaderTests.cs
@@ -14,6 +14,40 @@ namespace OverTranslate.Tests;
 public class SelectedTextReaderTests
 {
     [Fact]
+    public async Task A_clipboard_change_before_text_is_ready_is_not_mistaken_for_no_selection()
+    {
+        var sequences = new Queue<uint>(new uint[] { 10, 11, 11 });
+        var reads = new Queue<string?>(new string?[] { null, "selected text" });
+
+        var text = await SelectedTextReader.PollForCopiedTextAsync(
+            before: 10,
+            sequences.Dequeue,
+            reads.Dequeue,
+            () => Task.CompletedTask,
+            maxPolls: 2);
+
+        Assert.Equal("selected text", text);
+        Assert.Empty(sequences);
+        Assert.Empty(reads);
+    }
+
+    [Fact]
+    public async Task An_unchanged_clipboard_never_reuses_the_text_that_was_already_there()
+    {
+        var readCalls = 0;
+
+        var text = await SelectedTextReader.PollForCopiedTextAsync(
+            before: 10,
+            () => 10,
+            () => { readCalls++; return "old text"; },
+            () => Task.CompletedTask,
+            maxPolls: 2);
+
+        Assert.Equal("", text);
+        Assert.Equal(0, readCalls);
+    }
+
+    [Fact]
     public void A_selection_dragged_across_wrapped_lines_arrives_as_one_sentence()
     {
         // Line breaks in a selection belong to the page's layout, not to the sentence, and reach the


### PR DESCRIPTION
## 摘要

- 避免取詞翻譯還原第三方剪貼簿格式時，在 `OleFlushClipboard` 發生 native access violation 而閃退
- 避免視窗啟動交接前景焦點期間，因短暫 `Deactivated` 事件而立即關閉
- 在剪貼簿 sequence 已變更但文字尚未就緒時持續輪詢，避免偶發漏帶選取文字

## 原因

- WPF 使用持久化剪貼簿還原時會呼叫 `OleFlushClipboard`，特定剪貼簿資料提供者可能讓 `ole32.dll` 發生無法攔截的存取違規
- 前景視窗 latch 原先只保護輪詢檢查，沒有保護 WPF 的 `OnDeactivated` 事件
- Clipboard sequence 的第一次變動可能只是清空或鎖定剪貼簿，不代表文字格式已經可以讀取

## 驗證

- `SelectedTextReaderTests`：6/6 通過
- 取詞視窗、定位與剪貼簿相關測試：17/17 通過
- STA 剪貼簿還原 probe 通過，Windows Event Log 無新增 `ole32.dll` crash
- STA 視窗生命週期 probe 通過，啟動短暫失焦不關閉、正常失焦仍會關閉
- 完整測試：617 passed、2 skipped、2 failed

完整測試的兩個失敗皆為既有的 `LocalizedLineBreakTests.TheDiagnosticsHints_KeepTheirLineBreak` 中英文資源換行檢查，與本次修改無關。
