### PR TITLE
fix: 修正小視窗詞典版面與繁體來源查詢

### DIFF
--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -100,7 +100,7 @@
     <sys:String x:Key="S.Translation.SpeakFailed">朗讀失敗：{0}</sys:String>
 
     <!-- ── Rich dictionary ── -->
-    <sys:String x:Key="S.Dictionary.Alternatives">其他譯法</sys:String>
+    <sys:String x:Key="S.Dictionary.Alternatives">其他翻譯</sys:String>
     <sys:String x:Key="S.Dictionary.NoResult">該詞查無對應的詞典資料。</sys:String>
     <sys:String x:Key="S.Dictionary.Unavailable">該詞查無對應的詞典資料。</sys:String>
     <sys:String x:Key="S.Dictionary.PartOfSpeech.Adjective">形容詞</sys:String>

--- a/src/OverTranslate/Services/DictionaryLookupPlan.cs
+++ b/src/OverTranslate/Services/DictionaryLookupPlan.cs
@@ -4,89 +4,110 @@ namespace OverTranslate.Services;
 
 internal sealed record DictionaryLookupStep(
     TranslationProvider Provider,
+    string SourceLanguage,
     string TargetLanguage,
+    bool ConvertSourceToSimplified,
     bool ConvertToTraditional);
 
 internal static class DictionaryLookupPlan
 {
     internal static IReadOnlyList<DictionaryLookupStep> Build(
-        TranslationProvider selectedProvider, string targetLanguage)
+        TranslationProvider selectedProvider, string sourceLanguage, string targetLanguage)
     {
         if (targetLanguage.Equals("ZH-HANT", StringComparison.OrdinalIgnoreCase))
-            return BuildTraditionalChinese(selectedProvider, targetLanguage);
+            return BuildTraditionalChinese(selectedProvider, sourceLanguage, targetLanguage);
 
         return selectedProvider switch
         {
             TranslationProvider.Google =>
             [
-                Native(TranslationProvider.Google, targetLanguage),
-                Native(TranslationProvider.Microsoft, targetLanguage),
-                Native(TranslationProvider.Bing, targetLanguage),
+                Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Microsoft, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Bing, sourceLanguage, targetLanguage),
             ],
             TranslationProvider.Google2 =>
             [
-                Native(TranslationProvider.Google, targetLanguage),
-                Native(TranslationProvider.Microsoft, targetLanguage),
+                Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Microsoft, sourceLanguage, targetLanguage),
             ],
             TranslationProvider.Microsoft =>
             [
-                Native(TranslationProvider.Microsoft, targetLanguage),
-                Native(TranslationProvider.Google, targetLanguage),
-                Native(TranslationProvider.Bing, targetLanguage),
+                Native(TranslationProvider.Microsoft, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Bing, sourceLanguage, targetLanguage),
             ],
             TranslationProvider.Bing =>
             [
-                Native(TranslationProvider.Bing, targetLanguage),
-                Native(TranslationProvider.Google, targetLanguage),
-                Native(TranslationProvider.Microsoft, targetLanguage),
+                Native(TranslationProvider.Bing, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Microsoft, sourceLanguage, targetLanguage),
             ],
             TranslationProvider.DeepL =>
             [
-                Native(TranslationProvider.Google, targetLanguage),
-                Native(TranslationProvider.Microsoft, targetLanguage),
+                Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+                Native(TranslationProvider.Microsoft, sourceLanguage, targetLanguage),
             ],
             _ => [],
         };
     }
 
     private static IReadOnlyList<DictionaryLookupStep> BuildTraditionalChinese(
-        TranslationProvider selectedProvider, string targetLanguage) => selectedProvider switch
+        TranslationProvider selectedProvider, string sourceLanguage, string targetLanguage) => selectedProvider switch
     {
         TranslationProvider.Google =>
         [
-            Native(TranslationProvider.Google, targetLanguage),
-            Converted(TranslationProvider.Microsoft),
-            Converted(TranslationProvider.Bing),
+            Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+            Converted(TranslationProvider.Microsoft, sourceLanguage),
+            Converted(TranslationProvider.Bing, sourceLanguage),
         ],
         TranslationProvider.Google2 =>
         [
-            Native(TranslationProvider.Google, targetLanguage),
-            Converted(TranslationProvider.Microsoft),
+            Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+            Converted(TranslationProvider.Microsoft, sourceLanguage),
         ],
         TranslationProvider.Microsoft =>
         [
-            Converted(TranslationProvider.Microsoft),
-            Native(TranslationProvider.Google, targetLanguage),
-            Converted(TranslationProvider.Bing),
+            Converted(TranslationProvider.Microsoft, sourceLanguage),
+            Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+            Converted(TranslationProvider.Bing, sourceLanguage),
         ],
         TranslationProvider.Bing =>
         [
-            Converted(TranslationProvider.Bing),
-            Native(TranslationProvider.Google, targetLanguage),
-            Converted(TranslationProvider.Microsoft),
+            Converted(TranslationProvider.Bing, sourceLanguage),
+            Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+            Converted(TranslationProvider.Microsoft, sourceLanguage),
         ],
         TranslationProvider.DeepL =>
         [
-            Native(TranslationProvider.Google, targetLanguage),
-            Converted(TranslationProvider.Microsoft),
+            Native(TranslationProvider.Google, sourceLanguage, targetLanguage),
+            Converted(TranslationProvider.Microsoft, sourceLanguage),
         ],
         _ => [],
     };
 
     private static DictionaryLookupStep Native(
-        TranslationProvider provider, string targetLanguage) =>
-        new(provider, targetLanguage, ConvertToTraditional: false);
+        TranslationProvider provider, string sourceLanguage, string targetLanguage) =>
+        Create(provider, sourceLanguage, targetLanguage, convertTargetToTraditional: false);
 
-    private static DictionaryLookupStep Converted(TranslationProvider provider) =>
-        new(provider, "ZH-HANS", ConvertToTraditional: true);
+    private static DictionaryLookupStep Converted(
+        TranslationProvider provider, string sourceLanguage) =>
+        Create(provider, sourceLanguage, "ZH-HANS", convertTargetToTraditional: true);
+
+    private static DictionaryLookupStep Create(
+        TranslationProvider provider,
+        string sourceLanguage,
+        string targetLanguage,
+        bool convertTargetToTraditional)
+    {
+        var convertSourceToSimplified =
+            sourceLanguage.Equals("ZH-HANT", StringComparison.OrdinalIgnoreCase) &&
+            provider is TranslationProvider.Microsoft or TranslationProvider.Bing;
+
+        return new DictionaryLookupStep(
+            provider,
+            convertSourceToSimplified ? "ZH-HANS" : sourceLanguage,
+            targetLanguage,
+            convertSourceToSimplified,
+            convertTargetToTraditional || convertSourceToSimplified);
+    }
 }

--- a/src/OverTranslate/Services/DictionarySimplifiedChineseConverter.cs
+++ b/src/OverTranslate/Services/DictionarySimplifiedChineseConverter.cs
@@ -1,0 +1,11 @@
+using OpenccNetLib;
+
+namespace OverTranslate.Services;
+
+internal static class DictionarySimplifiedChineseConverter
+{
+    private static readonly Opencc Converter = new(OpenccConfig.Tw2Sp);
+
+    internal static string Convert(string source) =>
+        source.Length == 0 ? source : Converter.Convert(source, punctuation: false);
+}

--- a/src/OverTranslate/Services/TranslationService.cs
+++ b/src/OverTranslate/Services/TranslationService.cs
@@ -121,15 +121,19 @@ public class TranslationService
         if (!DictionaryLookupEligibility.IsEligible(text))
             return Task.FromResult<DictionaryLookupData?>(null);
 
-        var attempts = DictionaryLookupPlan.Build(engine ?? Saved, targetLang)
+        var lookupText = text.Trim();
+        var attempts = DictionaryLookupPlan.Build(engine ?? Saved, sourceLang, targetLang)
             .Select<DictionaryLookupStep, Func<CancellationToken, Task<DictionaryLookupData?>>>(step =>
                 async token =>
                 {
                     var provider = DictionaryProvider(step.Provider);
                     if (provider is null) return null;
 
+                    var requestText = step.ConvertSourceToSimplified
+                        ? DictionarySimplifiedChineseConverter.Convert(lookupText)
+                        : lookupText;
                     var result = await provider.LookupDictionaryAsync(
-                        text.Trim(), sourceLang, step.TargetLanguage, token);
+                        requestText, step.SourceLanguage, step.TargetLanguage, token);
                     if (result is null || !step.ConvertToTraditional) return result;
 
                     return DictionaryTraditionalChineseConverter.Convert(result);

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml
@@ -197,9 +197,11 @@
                                  Background="Transparent"
                                  Foreground="{DynamicResource AppAccent}"/>
 
-                    <Grid Grid.Row="2">
+                    <Grid x:Name="TranslationResultLayout"
+                          Grid.Row="2"
+                          SizeChanged="TranslationResultLayout_SizeChanged">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="*" MinHeight="96"/>
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
@@ -209,7 +211,8 @@
                                  IsReadOnly="True"
                                  Background="Transparent"/>
 
-                        <ScrollViewer Grid.Row="1"
+                        <ScrollViewer x:Name="DictionaryScroller"
+                                      Grid.Row="1"
                                       MaxHeight="290"
                                       VerticalScrollBarVisibility="Auto"
                                       HorizontalScrollBarVisibility="Disabled">

--- a/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
+++ b/src/OverTranslate/Views/Translation/TranslationPage.xaml.cs
@@ -12,6 +12,8 @@ namespace OverTranslate.Views.Translation;
 
 public partial class TranslationPage : UserControl
 {
+    private const double PreferredDictionaryHeight = 290;
+    private const double MinimumTranslatedResultHeight = 96;
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
     private readonly TranslationService _translationService = new();
     private readonly TtsService _tts = new();
@@ -428,6 +430,14 @@ public partial class TranslationPage : UserControl
         DictionaryView.Clear();
         DictionaryHost.Visibility = Visibility.Collapsed;
     }
+
+    private void TranslationResultLayout_SizeChanged(object sender, SizeChangedEventArgs e)
+        => DictionaryScroller.MaxHeight = CalculateDictionaryMaxHeight(e.NewSize.Height);
+
+    internal static double CalculateDictionaryMaxHeight(double availableHeight)
+        => Math.Min(
+            PreferredDictionaryHeight,
+            Math.Max(0, availableHeight - MinimumTranslatedResultHeight));
 
     // Toggles the in-flight indicator: an indeterminate bar over the output plus an accent status line,
     // so "translating" is obvious where the user is looking (the 譯文 panel), not just a grey footer note.

--- a/tests/OverTranslate.Tests/DictionaryLookupTests.cs
+++ b/tests/OverTranslate.Tests/DictionaryLookupTests.cs
@@ -117,6 +117,41 @@ public class DictionaryLookupTests
     }
 
     [Fact]
+    public void Text_translation_dictionary_height_is_bound_to_the_available_result_space()
+    {
+        XNamespace presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+        XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+        var document = XDocument.Load(Path.Combine(
+            StringsParityTests.ProjectDirectory(),
+            "Views", "Translation", "TranslationPage.xaml"));
+
+        var translatedTextBox = document.Descendants(presentation + "TextBox")
+            .Single(element => element.Attribute(x + "Name")?.Value == "TranslatedTextBox");
+        var resultGrid = translatedTextBox.Parent!;
+        var resultRows = resultGrid.Element(presentation + "Grid.RowDefinitions")!
+            .Elements(presentation + "RowDefinition")
+            .ToList();
+        var dictionaryScroller = resultGrid.Elements(presentation + "ScrollViewer").Single();
+
+        Assert.Equal("96", resultRows[0].Attribute("MinHeight")?.Value);
+        Assert.Equal("TranslationResultLayout_SizeChanged", resultGrid.Attribute("SizeChanged")?.Value);
+        Assert.Equal("290", dictionaryScroller.Attribute("MaxHeight")?.Value);
+    }
+
+    [Theory]
+    [InlineData(500, 290)]
+    [InlineData(386, 290)]
+    [InlineData(300, 204)]
+    [InlineData(80, 0)]
+    public void Text_translation_dictionary_height_preserves_the_primary_result(
+        double availableHeight, double expectedDictionaryHeight)
+    {
+        Assert.Equal(
+            expectedDictionaryHeight,
+            Views.Translation.TranslationPage.CalculateDictionaryMaxHeight(availableHeight));
+    }
+
+    [Fact]
     public async Task Dictionary_lookup_falls_back_when_the_selected_provider_rejects_the_language_pair()
     {
         var expected = new DictionaryLookupData(

--- a/tests/OverTranslate.Tests/DictionaryLookupTests.cs
+++ b/tests/OverTranslate.Tests/DictionaryLookupTests.cs
@@ -25,10 +25,49 @@ public class DictionaryLookupTests
     public void Dictionary_fallback_plan_matches_the_selected_provider_and_target(
         TranslationProvider provider, string targetLanguage, string expected)
     {
-        var actual = string.Join(",", DictionaryLookupPlan.Build(provider, targetLanguage)
+        var actual = string.Join(",", DictionaryLookupPlan.Build(provider, "EN-US", targetLanguage)
             .Select(step => $"{step.Provider}:{step.TargetLanguage}:{step.ConvertToTraditional}"));
 
         Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(TranslationProvider.Google)]
+    [InlineData(TranslationProvider.Google2)]
+    [InlineData(TranslationProvider.Microsoft)]
+    [InlineData(TranslationProvider.Bing)]
+    [InlineData(TranslationProvider.DeepL)]
+    public void Traditional_Chinese_source_is_simplified_only_for_Microsoft_and_Bing(
+        TranslationProvider provider)
+    {
+        var steps = DictionaryLookupPlan.Build(provider, "ZH-HANT", "EN-US");
+
+        Assert.All(steps, step =>
+        {
+            var requiresSimplifiedSource =
+                step.Provider is TranslationProvider.Microsoft or TranslationProvider.Bing;
+            Assert.Equal(requiresSimplifiedSource ? "ZH-HANS" : "ZH-HANT", step.SourceLanguage);
+            Assert.Equal(requiresSimplifiedSource, step.ConvertSourceToSimplified);
+            Assert.Equal(requiresSimplifiedSource, step.ConvertToTraditional);
+        });
+    }
+
+    [Fact]
+    public void Traditional_Chinese_source_and_target_conversions_are_independent()
+    {
+        var steps = DictionaryLookupPlan.Build(
+            TranslationProvider.Microsoft, "ZH-HANT", "ZH-HANT");
+
+        Assert.True(steps[0].ConvertSourceToSimplified);
+        Assert.True(steps[0].ConvertToTraditional);
+        Assert.False(steps[1].ConvertSourceToSimplified);
+        Assert.False(steps[1].ConvertToTraditional);
+    }
+
+    [Fact]
+    public void Traditional_dictionary_query_is_converted_with_Taiwan_phrases()
+    {
+        Assert.Equal("软件", DictionarySimplifiedChineseConverter.Convert("軟體"));
     }
 
     [Fact]


### PR DESCRIPTION
## 變更內容

- 小視窗下自適應限制詞典區高度，保留主譯文的顯示空間，最大高度維持 290px。
- 繁體中文來源送往 Microsoft／Bing 詞典前，透過 OpenCC `tw2sp` 轉為簡體並於回傳後轉回繁體。
- 將詞典區標題「其他譯法」調整為「其他翻譯」。

## 詞典 fallback 規則

以下皆為詞典 API 的 fallback，不影響主翻譯功能。

### 英文 → 其他語言（不含繁體中文）

| 使用中的翻譯服務 | 詞典查詢順序 |
|---|---|
| Google Web | Google Web → Microsoft → Bing |
| Google RPC | Google Web → Microsoft |
| Microsoft | Microsoft → Google Web → Bing |
| Bing | Bing → Google Web → Microsoft |
| DeepL | Google Web → Microsoft |
| OpenAI | 不查詢詞典 |

來源文字不經過 OpenCC。

### 英文 → 繁體中文

| 使用中的翻譯服務 | 詞典查詢順序 |
|---|---|
| Google Web | Google Web → Microsoft（結果轉繁體）→ Bing（結果轉繁體） |
| Google RPC | Google Web → Microsoft（結果轉繁體） |
| Microsoft | Microsoft（結果轉繁體）→ Google Web → Bing（結果轉繁體） |
| Bing | Bing（結果轉繁體）→ Google Web → Microsoft（結果轉繁體） |
| DeepL | Google Web → Microsoft（結果轉繁體） |
| OpenAI | 不查詢詞典 |

Google Web 直接查詢 `ZH-HANT`；Microsoft／Bing 改查 `ZH-HANS`，結果再以 OpenCC `s2twp` 轉為繁體。

### 其他語言 → 英文（不含繁體中文來源）

| 使用中的翻譯服務 | 詞典查詢順序 |
|---|---|
| Google Web | Google Web → Microsoft → Bing |
| Google RPC | Google Web → Microsoft |
| Microsoft | Microsoft → Google Web → Bing |
| Bing | Bing → Google Web → Microsoft |
| DeepL | Google Web → Microsoft |
| OpenAI | 不查詢詞典 |

來源文字與來源語言代碼直接送往各詞典 API，不經過 OpenCC。

### 繁體中文 → 英文

| 使用中的翻譯服務 | 詞典查詢順序 |
|---|---|
| Google Web | Google Web → Microsoft（輸入轉簡體）→ Bing（輸入轉簡體） |
| Google RPC | Google Web → Microsoft（輸入轉簡體） |
| Microsoft | Microsoft（輸入轉簡體）→ Google Web → Bing（輸入轉簡體） |
| Bing | Bing（輸入轉簡體）→ Google Web → Microsoft（輸入轉簡體） |
| DeepL | Google Web → Microsoft（輸入轉簡體） |
| OpenAI | 不查詢詞典 |

Google Web 保留繁體原文與 `ZH-HANT`。Microsoft／Bing 的輸入先以 OpenCC `tw2sp` 轉為簡體，來源代碼改為 `ZH-HANS`；回傳詞條再以 `s2twp` 轉回繁體，英文譯文不受影響。

## 測試

- 詞典專項測試：47 passed
- 完整測試：664 passed, 2 skipped