### PR TITLE
chore: README 加入下載量統計卡片與 SVG 下載按鈕

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -25,7 +25,7 @@
   </p>
 
   <p>
-    <a href="https://github.com/asd880921/OverTranslate/releases"><img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.svg" alt="Total downloads and daily growth" /></a>
+    <a href="https://github.com/asd880921/OverTranslate/releases"><img src="https://raw.githubusercontent.com/asd880921/github-statcards/main/cards/overtranslate-downloads-history.svg" alt="Total downloads and daily growth" /></a>
   </p>
 
 </div>

--- a/README.en.md
+++ b/README.en.md
@@ -7,7 +7,7 @@
   </p>
 
   <h1>
-    <img src="src/OverTranslate/icons/icon.svg" width="150" alt="OverTranslate Icon"/>
+    <img src="src/OverTranslate/icons/icon.svg" width="180" alt="OverTranslate Icon"/>
     <br/>
     OverTranslate
   </h1>

--- a/README.en.md
+++ b/README.en.md
@@ -6,23 +6,31 @@
     <strong><a href="README.md">繁體中文</a></strong>
   </p>
 
-  <img src="src/OverTranslate/icons/icon.svg" width="250" alt="OverTranslate Icon"/>
-  <h1>OverTranslate</h1>
+  <h1>
+    <img src="src/OverTranslate/icons/icon.svg" width="150" alt="OverTranslate Icon"/>
+    <br/>
+    OverTranslate
+  </h1>
   <p>A Windows screen translator with screenshot, real-time, and quick lookup translation, showing the results right on the original screen.</p>
 
   <p>
     <img src="https://img.shields.io/github/v/release/asd880921/OverTranslate?style=for-the-badge&label=latest%20release" alt="Latest release" />
     <img src="https://img.shields.io/badge/license-GPL--3.0-22C55E?style=for-the-badge" alt="License GPL-3.0" />
-    <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads.json" alt="Total downloads" />
   </p>
 
   <p>
     <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Setup.exe">
-      <strong>➡️ Windows Installer (recommended)</strong>
+      <img src="docs/images/ui/btn-setup.en.svg" alt="Download the Windows installer (recommended)" />
     </a>
-    &nbsp;｜&nbsp;
+    &nbsp;
     <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Portable.zip">
-      <strong>➡️ Portable version</strong>
+      <img src="docs/images/ui/btn-portable.en.svg" alt="Download the portable version" />
+    </a>
+  </p>
+
+  <p>
+    <a href="https://github.com/asd880921/OverTranslate/releases">
+      <img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.svg" alt="Total downloads and daily growth" />
     </a>
   </p>
 

--- a/README.en.md
+++ b/README.en.md
@@ -19,19 +19,13 @@
   </p>
 
   <p>
-    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Setup.exe">
-      <img src="docs/images/ui/btn-setup.en.svg" alt="Download the Windows installer (recommended)" />
-    </a>
+    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Setup.exe"><img src="docs/images/ui/btn-setup.en.svg" alt="Download the Windows installer (recommended)" /></a>
     &nbsp;
-    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Portable.zip">
-      <img src="docs/images/ui/btn-portable.en.svg" alt="Download the portable version" />
-    </a>
+    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Portable.zip"><img src="docs/images/ui/btn-portable.en.svg" alt="Download the portable version" /></a>
   </p>
 
   <p>
-    <a href="https://github.com/asd880921/OverTranslate/releases">
-      <img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.svg" alt="Total downloads and daily growth" />
-    </a>
+    <a href="https://github.com/asd880921/OverTranslate/releases"><img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.svg" alt="Total downloads and daily growth" /></a>
   </p>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   </p>
 
   <p>
-    <a href="https://github.com/asd880921/OverTranslate/releases"><img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.zh-TW.svg" alt="累積下載次數與每日新增" /></a>
+    <a href="https://github.com/asd880921/OverTranslate/releases"><img src="https://raw.githubusercontent.com/asd880921/github-statcards/main/cards/overtranslate-downloads-history.zh-TW.svg" alt="累積下載次數與每日新增" /></a>
   </p>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </p>
 
   <h1>
-    <img src="src/OverTranslate/icons/icon.svg" width="150" alt="OverTranslate Icon"/>
+    <img src="src/OverTranslate/icons/icon.svg" width="180" alt="OverTranslate Icon"/>
     <br/>
     OverTranslate
   </h1>

--- a/README.md
+++ b/README.md
@@ -6,23 +6,31 @@
     <strong>繁體中文 ✓</strong>
   </p>
 
-  <img src="src/OverTranslate/icons/icon.svg" width="250" alt="OverTranslate Icon"/>
-  <h1>OverTranslate</h1>
+  <h1>
+    <img src="src/OverTranslate/icons/icon.svg" width="150" alt="OverTranslate Icon"/>
+    <br/>
+    OverTranslate
+  </h1>
   <p>一款 Windows 螢幕翻譯工具，支援截圖、即時與取詞翻譯，翻譯結果直接顯示在原畫面上。</p>
 
   <p>
     <img src="https://img.shields.io/github/v/release/asd880921/OverTranslate?style=for-the-badge&label=latest%20release" alt="Latest release" />
     <img src="https://img.shields.io/badge/license-GPL--3.0-22C55E?style=for-the-badge" alt="License GPL-3.0" />
-    <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads.json" alt="Total downloads" />
   </p>
 
   <p>
     <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Setup.exe">
-      <strong>➡️ Windows 安裝版（推薦）</strong>
+      <img src="docs/images/ui/btn-setup.svg" alt="下載 Windows 安裝版（推薦）" />
     </a>
-    &nbsp;｜&nbsp;
+    &nbsp;
     <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Portable.zip">
-      <strong>➡️ 免安裝版（Portable）</strong>
+      <img src="docs/images/ui/btn-portable.svg" alt="下載免安裝版（Portable）" />
+    </a>
+  </p>
+
+  <p>
+    <a href="https://github.com/asd880921/OverTranslate/releases">
+      <img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.zh-TW.svg" alt="累積下載次數與每日新增" />
     </a>
   </p>
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,13 @@
   </p>
 
   <p>
-    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Setup.exe">
-      <img src="docs/images/ui/btn-setup.svg" alt="下載 Windows 安裝版（推薦）" />
-    </a>
+    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Setup.exe"><img src="docs/images/ui/btn-setup.svg" alt="下載 Windows 安裝版（推薦）" /></a>
     &nbsp;
-    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Portable.zip">
-      <img src="docs/images/ui/btn-portable.svg" alt="下載免安裝版（Portable）" />
-    </a>
+    <a href="https://github.com/asd880921/OverTranslate/releases/latest/download/OverTranslate-win-Portable.zip"><img src="docs/images/ui/btn-portable.svg" alt="下載免安裝版（Portable）" /></a>
   </p>
 
   <p>
-    <a href="https://github.com/asd880921/OverTranslate/releases">
-      <img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.zh-TW.svg" alt="累積下載次數與每日新增" />
-    </a>
+    <a href="https://github.com/asd880921/OverTranslate/releases"><img src="https://raw.githubusercontent.com/asd880921/github-badges/main/badges/overtranslate-downloads-history.zh-TW.svg" alt="累積下載次數與每日新增" /></a>
   </p>
 
 </div>

--- a/docs/images/ui/btn-portable.en.svg
+++ b/docs/images/ui/btn-portable.en.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="189" height="44" viewBox="0 0 189 44" role="img" aria-label="Download the portable version">
   <style>
-    svg { --line:#d0d7de; --fg:#1f2328; }
-    @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
-    .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
+    svg { --bg:#ffffff; --line:#d0d7de; --fg:#1f2328; }
+    @media (prefers-color-scheme: dark) { svg { --bg:#0d1117; --line:#3d444d; --fg:#e6edf3; } }
+    .box { fill: var(--bg); stroke: var(--line); stroke-width: 1.5; }
     .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
     .dl { fill: none; stroke: var(--fg); stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;

--- a/docs/images/ui/btn-portable.en.svg
+++ b/docs/images/ui/btn-portable.en.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="170" height="44" viewBox="0 0 170 44" role="img" aria-label="Download the portable version">
+  <style>
+    svg { --line:#d0d7de; --fg:#1f2328; }
+    @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
+    .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
+    .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
+             font-size: 14px; font-weight: 600; fill: var(--fg); }
+  </style>
+  <rect x="0.75" y="0.75" width="168.5" height="42.5" rx="10" class="box"/>
+  <g transform="translate(18 13) scale(0.75)" class="icon">
+    <path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/>
+    <path d="M3.3 7 12 12l8.7-5"/>
+    <path d="M12 22V12"/>
+  </g>
+  <text x="46" y="27" class="label">Portable version</text>
+</svg>

--- a/docs/images/ui/btn-portable.en.svg
+++ b/docs/images/ui/btn-portable.en.svg
@@ -1,17 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="170" height="44" viewBox="0 0 170 44" role="img" aria-label="Download the portable version">
+<svg xmlns="http://www.w3.org/2000/svg" width="193" height="44" viewBox="0 0 193 44" role="img" aria-label="Download the portable version">
   <style>
     svg { --line:#d0d7de; --fg:#1f2328; }
     @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
     .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
-    .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .icon, .dl { fill: none; stroke: var(--fg); stroke-linecap: round; stroke-linejoin: round; }
+    .icon { stroke-width: 2; }
+    .dl { stroke-width: 1.8; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0.75" y="0.75" width="168.5" height="42.5" rx="10" class="box"/>
-  <g transform="translate(18 13) scale(0.75)" class="icon">
-    <path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/>
-    <path d="M3.3 7 12 12l8.7-5"/>
-    <path d="M12 22V12"/>
-  </g>
+  <rect x="0.75" y="0.75" width="191.5" height="42.5" rx="10" class="box"/>
+  <g transform="translate(18 13) scale(0.75)" class="icon"><path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/><path d="M3.3 7 12 12l8.7-5"/><path d="M12 22V12"/></g>
   <text x="46" y="27" class="label">Portable version</text>
+  <g transform="translate(160 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-portable.en.svg
+++ b/docs/images/ui/btn-portable.en.svg
@@ -1,16 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="193" height="44" viewBox="0 0 193 44" role="img" aria-label="Download the portable version">
+<svg xmlns="http://www.w3.org/2000/svg" width="189" height="44" viewBox="0 0 189 44" role="img" aria-label="Download the portable version">
   <style>
     svg { --line:#d0d7de; --fg:#1f2328; }
     @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
     .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
-    .icon, .dl { fill: none; stroke: var(--fg); stroke-linecap: round; stroke-linejoin: round; }
-    .icon { stroke-width: 2; }
-    .dl { stroke-width: 1.8; }
+    .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .dl { fill: none; stroke: var(--fg); stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0.75" y="0.75" width="191.5" height="42.5" rx="10" class="box"/>
+  <rect x="0.75" y="0.75" width="187.5" height="42.5" rx="10" class="box"/>
   <g transform="translate(18 13) scale(0.75)" class="icon"><path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/><path d="M3.3 7 12 12l8.7-5"/><path d="M12 22V12"/></g>
   <text x="46" y="27" class="label">Portable version</text>
-  <g transform="translate(160 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
+  <g transform="translate(158 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-portable.svg
+++ b/docs/images/ui/btn-portable.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="204" height="44" viewBox="0 0 204 44" role="img" aria-label="下載免安裝版（Portable）">
+  <style>
+    svg { --line:#d0d7de; --fg:#1f2328; }
+    @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
+    .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
+    .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
+             font-size: 14px; font-weight: 600; fill: var(--fg); }
+  </style>
+  <rect x="0.75" y="0.75" width="202.5" height="42.5" rx="10" class="box"/>
+  <g transform="translate(18 13) scale(0.75)" class="icon">
+    <path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/>
+    <path d="M3.3 7 12 12l8.7-5"/>
+    <path d="M12 22V12"/>
+  </g>
+  <text x="46" y="27" class="label">免安裝版（Portable）</text>
+</svg>

--- a/docs/images/ui/btn-portable.svg
+++ b/docs/images/ui/btn-portable.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="218" height="44" viewBox="0 0 218 44" role="img" aria-label="下載免安裝版（Portable）">
   <style>
-    svg { --line:#d0d7de; --fg:#1f2328; }
-    @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
-    .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
+    svg { --bg:#ffffff; --line:#d0d7de; --fg:#1f2328; }
+    @media (prefers-color-scheme: dark) { svg { --bg:#0d1117; --line:#3d444d; --fg:#e6edf3; } }
+    .box { fill: var(--bg); stroke: var(--line); stroke-width: 1.5; }
     .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
     .dl { fill: none; stroke: var(--fg); stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;

--- a/docs/images/ui/btn-portable.svg
+++ b/docs/images/ui/btn-portable.svg
@@ -1,17 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="204" height="44" viewBox="0 0 204 44" role="img" aria-label="下載免安裝版（Portable）">
+<svg xmlns="http://www.w3.org/2000/svg" width="227" height="44" viewBox="0 0 227 44" role="img" aria-label="下載免安裝版（Portable）">
   <style>
     svg { --line:#d0d7de; --fg:#1f2328; }
     @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
     .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
-    .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .icon, .dl { fill: none; stroke: var(--fg); stroke-linecap: round; stroke-linejoin: round; }
+    .icon { stroke-width: 2; }
+    .dl { stroke-width: 1.8; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0.75" y="0.75" width="202.5" height="42.5" rx="10" class="box"/>
-  <g transform="translate(18 13) scale(0.75)" class="icon">
-    <path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/>
-    <path d="M3.3 7 12 12l8.7-5"/>
-    <path d="M12 22V12"/>
-  </g>
+  <rect x="0.75" y="0.75" width="225.5" height="42.5" rx="10" class="box"/>
+  <g transform="translate(18 13) scale(0.75)" class="icon"><path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/><path d="M3.3 7 12 12l8.7-5"/><path d="M12 22V12"/></g>
   <text x="46" y="27" class="label">免安裝版（Portable）</text>
+  <g transform="translate(194 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-portable.svg
+++ b/docs/images/ui/btn-portable.svg
@@ -1,16 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="227" height="44" viewBox="0 0 227 44" role="img" aria-label="下載免安裝版（Portable）">
+<svg xmlns="http://www.w3.org/2000/svg" width="218" height="44" viewBox="0 0 218 44" role="img" aria-label="下載免安裝版（Portable）">
   <style>
     svg { --line:#d0d7de; --fg:#1f2328; }
     @media (prefers-color-scheme: dark) { svg { --line:#3d444d; --fg:#e6edf3; } }
     .box { fill: none; stroke: var(--line); stroke-width: 1.5; }
-    .icon, .dl { fill: none; stroke: var(--fg); stroke-linecap: round; stroke-linejoin: round; }
-    .icon { stroke-width: 2; }
-    .dl { stroke-width: 1.8; }
+    .icon { fill: none; stroke: var(--fg); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .dl { fill: none; stroke: var(--fg); stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0.75" y="0.75" width="225.5" height="42.5" rx="10" class="box"/>
+  <rect x="0.75" y="0.75" width="216.5" height="42.5" rx="10" class="box"/>
   <g transform="translate(18 13) scale(0.75)" class="icon"><path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/><path d="M3.3 7 12 12l8.7-5"/><path d="M12 22V12"/></g>
   <text x="46" y="27" class="label">免安裝版（Portable）</text>
-  <g transform="translate(194 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
+  <g transform="translate(187 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-setup.en.svg
+++ b/docs/images/ui/btn-setup.en.svg
@@ -1,18 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="283" height="44" viewBox="0 0 283 44" role="img" aria-label="Download the Windows installer (recommended)">
+<svg xmlns="http://www.w3.org/2000/svg" width="306" height="44" viewBox="0 0 306 44" role="img" aria-label="Download the Windows installer (recommended)">
   <style>
     svg { --bg:#2563eb; --fg:#ffffff; }
     @media (prefers-color-scheme: dark) { svg { --bg:#3b82f6; --fg:#ffffff; } }
     .box { fill: var(--bg); }
     .ink { fill: var(--fg); }
+    .dl { fill: none; stroke: var(--fg); stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0" y="0" width="283" height="44" rx="10" class="box"/>
-  <g transform="translate(18 14)" class="ink">
-    <rect x="0" y="0" width="7.2" height="7.2" rx="1"/>
-    <rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/>
-    <rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/>
-    <rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/>
-  </g>
+  <rect x="0" y="0" width="306" height="44" rx="10" class="box"/>
+  <g transform="translate(18 14)" class="ink"><rect x="0" y="0" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/><rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/></g>
   <text x="44" y="27" class="label">Windows Installer (recommended)</text>
+  <g transform="translate(273 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-setup.en.svg
+++ b/docs/images/ui/btn-setup.en.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="306" height="44" viewBox="0 0 306 44" role="img" aria-label="Download the Windows installer (recommended)">
+<svg xmlns="http://www.w3.org/2000/svg" width="301" height="44" viewBox="0 0 301 44" role="img" aria-label="Download the Windows installer (recommended)">
   <style>
     svg { --bg:#2563eb; --fg:#ffffff; }
     @media (prefers-color-scheme: dark) { svg { --bg:#3b82f6; --fg:#ffffff; } }
@@ -8,8 +8,8 @@
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0" y="0" width="306" height="44" rx="10" class="box"/>
+  <rect x="0" y="0" width="301" height="44" rx="10" class="box"/>
   <g transform="translate(18 14)" class="ink"><rect x="0" y="0" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/><rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/></g>
   <text x="44" y="27" class="label">Windows Installer (recommended)</text>
-  <g transform="translate(273 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
+  <g transform="translate(270 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-setup.en.svg
+++ b/docs/images/ui/btn-setup.en.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="283" height="44" viewBox="0 0 283 44" role="img" aria-label="Download the Windows installer (recommended)">
+  <style>
+    svg { --bg:#2563eb; --fg:#ffffff; }
+    @media (prefers-color-scheme: dark) { svg { --bg:#3b82f6; --fg:#ffffff; } }
+    .box { fill: var(--bg); }
+    .ink { fill: var(--fg); }
+    .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
+             font-size: 14px; font-weight: 600; fill: var(--fg); }
+  </style>
+  <rect x="0" y="0" width="283" height="44" rx="10" class="box"/>
+  <g transform="translate(18 14)" class="ink">
+    <rect x="0" y="0" width="7.2" height="7.2" rx="1"/>
+    <rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/>
+    <rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/>
+    <rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/>
+  </g>
+  <text x="44" y="27" class="label">Windows Installer (recommended)</text>
+</svg>

--- a/docs/images/ui/btn-setup.svg
+++ b/docs/images/ui/btn-setup.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="248" height="44" viewBox="0 0 248 44" role="img" aria-label="下載 Windows 安裝版（推薦）">
+<svg xmlns="http://www.w3.org/2000/svg" width="239" height="44" viewBox="0 0 239 44" role="img" aria-label="下載 Windows 安裝版（推薦）">
   <style>
     svg { --bg:#2563eb; --fg:#ffffff; }
     @media (prefers-color-scheme: dark) { svg { --bg:#3b82f6; --fg:#ffffff; } }
@@ -8,8 +8,8 @@
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0" y="0" width="248" height="44" rx="10" class="box"/>
+  <rect x="0" y="0" width="239" height="44" rx="10" class="box"/>
   <g transform="translate(18 14)" class="ink"><rect x="0" y="0" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/><rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/></g>
   <text x="44" y="27" class="label">Windows 安裝版（推薦）</text>
-  <g transform="translate(215 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
+  <g transform="translate(208 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-setup.svg
+++ b/docs/images/ui/btn-setup.svg
@@ -1,18 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="226" height="44" viewBox="0 0 226 44" role="img" aria-label="下載 Windows 安裝版（推薦）">
+<svg xmlns="http://www.w3.org/2000/svg" width="248" height="44" viewBox="0 0 248 44" role="img" aria-label="下載 Windows 安裝版（推薦）">
   <style>
     svg { --bg:#2563eb; --fg:#ffffff; }
     @media (prefers-color-scheme: dark) { svg { --bg:#3b82f6; --fg:#ffffff; } }
     .box { fill: var(--bg); }
     .ink { fill: var(--fg); }
+    .dl { fill: none; stroke: var(--fg); stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
     .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
              font-size: 14px; font-weight: 600; fill: var(--fg); }
   </style>
-  <rect x="0" y="0" width="226" height="44" rx="10" class="box"/>
-  <g transform="translate(18 14)" class="ink">
-    <rect x="0" y="0" width="7.2" height="7.2" rx="1"/>
-    <rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/>
-    <rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/>
-    <rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/>
-  </g>
+  <rect x="0" y="0" width="248" height="44" rx="10" class="box"/>
+  <g transform="translate(18 14)" class="ink"><rect x="0" y="0" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/><rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/><rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/></g>
   <text x="44" y="27" class="label">Windows 安裝版（推薦）</text>
+  <g transform="translate(215 14.5) scale(0.9375)" class="dl"><path d="M8 2.1V10"/><path d="M4.5 6.7 8 10.2 11.5 6.7"/><path d="M3 13.7h10"/></g>
 </svg>

--- a/docs/images/ui/btn-setup.svg
+++ b/docs/images/ui/btn-setup.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="226" height="44" viewBox="0 0 226 44" role="img" aria-label="下載 Windows 安裝版（推薦）">
+  <style>
+    svg { --bg:#2563eb; --fg:#ffffff; }
+    @media (prefers-color-scheme: dark) { svg { --bg:#3b82f6; --fg:#ffffff; } }
+    .box { fill: var(--bg); }
+    .ink { fill: var(--fg); }
+    .label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, 'Microsoft JhengHei', 'PingFang TC', 'Noto Sans TC', sans-serif;
+             font-size: 14px; font-weight: 600; fill: var(--fg); }
+  </style>
+  <rect x="0" y="0" width="226" height="44" rx="10" class="box"/>
+  <g transform="translate(18 14)" class="ink">
+    <rect x="0" y="0" width="7.2" height="7.2" rx="1"/>
+    <rect x="8.8" y="0" width="7.2" height="7.2" rx="1"/>
+    <rect x="0" y="8.8" width="7.2" height="7.2" rx="1"/>
+    <rect x="8.8" y="8.8" width="7.2" height="7.2" rx="1"/>
+  </g>
+  <text x="44" y="27" class="label">Windows 安裝版（推薦）</text>
+</svg>


### PR DESCRIPTION
@
## 內容

兩份 README（中文 / 英文）的標題區塊改版，加入下載量統計卡片，並把文字下載連結換成自製的 SVG 按鈕。

### 1. 加入下載量統計卡片

引用 `github-badges` 倉庫產生的卡片，顯示累積下載量、最近一天／區間新增、每日平均，以及近 12 天的累積折線與每日新增柱狀。每天台灣時間 12:00、24:00 自動更新，本倉不需要任何 workflow 配合。

卡片放在下載按鈕**之後**，而不是取代原本的 badge 位置——避免 300px 高的卡片把下載連結擠出第一屏。

### 2. 移除重複的 `total downloads` badge

該 badge 與卡片的主數字是同一個事實，且兩者快取週期不同（shields 約 5 分鐘、卡片走 camo 更久），會在同一畫面上顯示不一致的數字。`latest release` 與 `license` 是不同事實，保留。

### 3. 下載連結改為 SVG 按鈕

新增 `docs/images/ui/`，與既有的功能截圖區隔開——截圖會隨功能改版重拍，介面素材則跟著 README 版面走。

| 檔案 | 內容 |
|---|---|
| `btn-setup.svg` / `btn-setup.en.svg` | 實心主要按鈕，Windows 圖示 |
| `btn-portable.svg` / `btn-portable.en.svg` | 外框次要按鈕，包裹盒圖示 |

四個檔案都支援 `prefers-color-scheme`，深色模式下邊框、文字與藍色會自動調整。寬度是用瀏覽器實測字寬後回推的，改文字需要重新計算。

### 4. 收緊標題區塊

- ICON 250px → 150px
- `<img>` 移進 `<h1>` 內並以 `<br/>` 換行，消除 `<h1>` 的 `margin-top` 在圖與字之間造成的約 21px 空隙

整體 hero 高度從約 750px 降到約 700px，下載按鈕與統計卡片可一起進到第一屏。

## 已知限制

- 圖片按鈕沒有 hover / focus 效果。GitHub 以 `<img>` 呈現 SVG，指標事件不會進入圖片文件，改用 shields 也一樣。
- 按鈕與卡片的中文字依賴讀者本機已安裝的字型（`Microsoft JhengHei` / `PingFang TC` / `Noto Sans TC`），SVG 不能內嵌字型。

## 檢查重點

- [ ] 深色模式下外框按鈕的邊框與文字是否正確轉為亮色
- [ ] `docs/images/ui/` 的相對路徑 SVG 是否正常顯示
- [ ] 標題下方是否出現 GitHub 預設的 `h1` 底線
@