### PR TITLE
feat: 新增取詞翻譯自動複製與收起模式

### DIFF
--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -205,6 +205,9 @@ public class AppSettings
     /// </remarks>
     public CaptureSettings Capture { get; set; } = new();
 
+    /// <summary>What 取詞翻譯 keeps between lookups, grouped.</summary>
+    public QuickLookupSettings QuickLookup { get; set; } = new();
+
     /// <summary>What 即時翻譯 keeps between sittings, grouped.</summary>
     public RealtimeSettings Realtime { get; set; } = new();
 }

--- a/src/OverTranslate/Models/QuickLookupSettings.cs
+++ b/src/OverTranslate/Models/QuickLookupSettings.cs
@@ -10,4 +10,10 @@ public class QuickLookupSettings
     /// copying without an explicit gesture is useful only when the reader has chosen that workflow.
     /// </summary>
     public bool AutoCopyTranslation { get; set; } = false;
+
+    /// <summary>
+    /// Whether the popup replaces its detailed result with the compact status-and-preview view.
+    /// False keeps the complete translation, actions and dictionary visible on a first run.
+    /// </summary>
+    public bool ResultsCollapsed { get; set; } = false;
 }

--- a/src/OverTranslate/Models/QuickLookupSettings.cs
+++ b/src/OverTranslate/Models/QuickLookupSettings.cs
@@ -1,0 +1,13 @@
+namespace OverTranslate.Models;
+
+/// <summary>
+/// Everything 取詞翻譯 keeps between lookups, under one key.
+/// </summary>
+public class QuickLookupSettings
+{
+    /// <summary>
+    /// Whether each successful translation replaces the clipboard contents. Off by default because
+    /// copying without an explicit gesture is useful only when the reader has chosen that workflow.
+    /// </summary>
+    public bool AutoCopyTranslation { get; set; } = false;
+}

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -133,7 +133,7 @@ Translation failed: {1}</sys:String>
     <sys:String x:Key="S.QuickLookup.AutoCopyHint">Automatically copies the result to the clipboard when translation finishes</sys:String>
     <sys:String x:Key="S.QuickLookup.Collapse">Collapse</sys:String>
     <sys:String x:Key="S.QuickLookup.Expand">Expand</sys:String>
-    <sys:String x:Key="S.QuickLookup.TranslationCopied">Automatically copied to the clipboard</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationCopied">Copied to clipboard</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">All settings</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">Press {0} to open it. It closes when you switch to another window; pin it to keep it on screen.</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -131,6 +131,10 @@ Translation failed: {1}</sys:String>
     <sys:String x:Key="S.QuickLookup.ProviderHint">Shared with screen translation and text translation</sys:String>
     <sys:String x:Key="S.QuickLookup.AutoCopy">Automatically copy translation results</sys:String>
     <sys:String x:Key="S.QuickLookup.AutoCopyHint">Automatically copies the result to the clipboard when translation finishes</sys:String>
+    <sys:String x:Key="S.QuickLookup.Collapse">Collapse</sys:String>
+    <sys:String x:Key="S.QuickLookup.Expand">Expand</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationComplete">Translation complete</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationCopied">Translation complete and copied to the clipboard</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">All settings</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">Press {0} to open it. It closes when you switch to another window; pin it to keep it on screen.</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -133,8 +133,7 @@ Translation failed: {1}</sys:String>
     <sys:String x:Key="S.QuickLookup.AutoCopyHint">Automatically copies the result to the clipboard when translation finishes</sys:String>
     <sys:String x:Key="S.QuickLookup.Collapse">Collapse</sys:String>
     <sys:String x:Key="S.QuickLookup.Expand">Expand</sys:String>
-    <sys:String x:Key="S.QuickLookup.TranslationComplete">Translation complete</sys:String>
-    <sys:String x:Key="S.QuickLookup.TranslationCopied">Translation complete and copied to the clipboard</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationCopied">Automatically copied to the clipboard</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">All settings</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">Press {0} to open it. It closes when you switch to another window; pin it to keep it on screen.</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -129,6 +129,8 @@ Translation failed: {1}</sys:String>
     <sys:String x:Key="S.QuickLookup.SpeakSourceUnknown">The language of the original is not known yet. It can be read aloud once the translation is back.</sys:String>
     <sys:String x:Key="S.QuickLookup.Provider">Translation service</sys:String>
     <sys:String x:Key="S.QuickLookup.ProviderHint">Shared with screen translation and text translation</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopy">Automatically copy results after translation</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopyHint">Replaces the clipboard whenever Quick Lookup finishes translating</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">All settings</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">Press {0} to open it. It closes when you switch to another window; pin it to keep it on screen.</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -129,8 +129,8 @@ Translation failed: {1}</sys:String>
     <sys:String x:Key="S.QuickLookup.SpeakSourceUnknown">The language of the original is not known yet. It can be read aloud once the translation is back.</sys:String>
     <sys:String x:Key="S.QuickLookup.Provider">Translation service</sys:String>
     <sys:String x:Key="S.QuickLookup.ProviderHint">Shared with screen translation and text translation</sys:String>
-    <sys:String x:Key="S.QuickLookup.AutoCopy">Automatically copy results after translation</sys:String>
-    <sys:String x:Key="S.QuickLookup.AutoCopyHint">Replaces the clipboard whenever Quick Lookup finishes translating</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopy">Automatically copy translation results</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopyHint">Automatically copies the result to the clipboard when translation finishes</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">All settings</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">Press {0} to open it. It closes when you switch to another window; pin it to keep it on screen.</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -135,8 +135,8 @@
     <sys:String x:Key="S.QuickLookup.SpeakSourceUnknown">還不知道原文是什麼語言，翻譯完成後就可以朗讀。</sys:String>
     <sys:String x:Key="S.QuickLookup.Provider">翻譯服務</sys:String>
     <sys:String x:Key="S.QuickLookup.ProviderHint">與螢幕翻譯及文字翻譯共用此服務</sys:String>
-    <sys:String x:Key="S.QuickLookup.AutoCopy">翻譯後自動將結果複製到剪貼簿</sys:String>
-    <sys:String x:Key="S.QuickLookup.AutoCopyHint">每次取詞翻譯完成後，立即取代剪貼簿內容</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopy">自動複製翻譯結果</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopyHint">翻譯完成後，自動將結果複製到剪貼簿</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">完整設定</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">按 {0} 開啟。切換至其他視窗時會自動關閉；如需持續顯示，可釘選此視窗。</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -139,8 +139,7 @@
     <sys:String x:Key="S.QuickLookup.AutoCopyHint">翻譯完成後，自動將結果複製到剪貼簿</sys:String>
     <sys:String x:Key="S.QuickLookup.Collapse">收起</sys:String>
     <sys:String x:Key="S.QuickLookup.Expand">展開</sys:String>
-    <sys:String x:Key="S.QuickLookup.TranslationComplete">翻譯完成</sys:String>
-    <sys:String x:Key="S.QuickLookup.TranslationCopied">翻譯完成，已自動複製到剪貼簿</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationCopied">已自動複製到剪貼簿</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">完整設定</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">按 {0} 開啟。切換至其他視窗時會自動關閉；如需持續顯示，可釘選此視窗。</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -135,6 +135,8 @@
     <sys:String x:Key="S.QuickLookup.SpeakSourceUnknown">還不知道原文是什麼語言，翻譯完成後就可以朗讀。</sys:String>
     <sys:String x:Key="S.QuickLookup.Provider">翻譯服務</sys:String>
     <sys:String x:Key="S.QuickLookup.ProviderHint">與螢幕翻譯及文字翻譯共用此服務</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopy">翻譯後自動將結果複製到剪貼簿</sys:String>
+    <sys:String x:Key="S.QuickLookup.AutoCopyHint">每次取詞翻譯完成後，立即取代剪貼簿內容</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">完整設定</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">按 {0} 開啟。切換至其他視窗時會自動關閉；如需持續顯示，可釘選此視窗。</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -137,6 +137,10 @@
     <sys:String x:Key="S.QuickLookup.ProviderHint">與螢幕翻譯及文字翻譯共用此服務</sys:String>
     <sys:String x:Key="S.QuickLookup.AutoCopy">自動複製翻譯結果</sys:String>
     <sys:String x:Key="S.QuickLookup.AutoCopyHint">翻譯完成後，自動將結果複製到剪貼簿</sys:String>
+    <sys:String x:Key="S.QuickLookup.Collapse">收起</sys:String>
+    <sys:String x:Key="S.QuickLookup.Expand">展開</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationComplete">翻譯完成</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationCopied">翻譯完成，已自動複製到剪貼簿</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">完整設定</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">按 {0} 開啟。切換至其他視窗時會自動關閉；如需持續顯示，可釘選此視窗。</sys:String>
 

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -139,7 +139,7 @@
     <sys:String x:Key="S.QuickLookup.AutoCopyHint">翻譯完成後，自動將結果複製到剪貼簿</sys:String>
     <sys:String x:Key="S.QuickLookup.Collapse">收起</sys:String>
     <sys:String x:Key="S.QuickLookup.Expand">展開</sys:String>
-    <sys:String x:Key="S.QuickLookup.TranslationCopied">已自動複製到剪貼簿</sys:String>
+    <sys:String x:Key="S.QuickLookup.TranslationCopied">已複製到剪貼簿</sys:String>
     <sys:String x:Key="S.QuickLookup.OpenFullSettings">完整設定</sys:String>
     <sys:String x:Key="S.QuickLookup.SettingsHint">按 {0} 開啟。切換至其他視窗時會自動關閉；如需持續顯示，可釘選此視窗。</sys:String>
 

--- a/src/OverTranslate/Services/SelectedTextReader.cs
+++ b/src/OverTranslate/Services/SelectedTextReader.cs
@@ -38,12 +38,15 @@ internal static class SelectedTextReader
     /// completion timeout lets that common path open the popup promptly without giving up on a copy
     /// that has already started publishing its formats.
     /// </remarks>
-    private static readonly TimeSpan CopyStartTimeout = TimeSpan.FromMilliseconds(90);
+    private static readonly TimeSpan CopyStartTimeout = TimeSpan.FromMilliseconds(150);
 
     /// <summary>How long an observed clipboard update may take to publish readable text.</summary>
     private static readonly TimeSpan CopyCompletionTimeout = TimeSpan.FromMilliseconds(320);
 
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(15);
+
+    /// <summary>How long Ctrl+C stays physically observable to applications that poll per frame.</summary>
+    private static readonly TimeSpan CopyChordHold = TimeSpan.FromMilliseconds(40);
 
     /// <summary>
     /// The most text this will carry into the popup.
@@ -87,7 +90,7 @@ internal static class SelectedTextReader
 
         try
         {
-            SendCopy();
+            await SendCopy();
 
             var maxStartPolls = (int)Math.Ceiling(
                 CopyStartTimeout.TotalMilliseconds / PollInterval.TotalMilliseconds);
@@ -109,6 +112,23 @@ internal static class SelectedTextReader
         finally
         {
             Restore(snapshot);
+        }
+    }
+
+    /// <summary>Keeps an injected copy chord down long enough to cross a frame boundary.</summary>
+    internal static async Task HoldCopyChordAsync(
+        Action press,
+        Func<Task> hold,
+        Action release)
+    {
+        press();
+        try
+        {
+            await hold();
+        }
+        finally
+        {
+            release();
         }
     }
 
@@ -143,12 +163,20 @@ internal static class SelectedTextReader
 
             if (changed)
             {
-                if (completionPolls >= maxCompletionPolls) return "";
+                if (completionPolls >= maxCompletionPolls)
+                {
+                    Log.Debug("Copy changed the clipboard but did not publish readable text before timeout");
+                    return "";
+                }
                 completionPolls++;
             }
             else
             {
-                if (startPolls >= maxStartPolls) return "";
+                if (startPolls >= maxStartPolls)
+                {
+                    Log.Debug("Copy did not change the clipboard before timeout");
+                    return "";
+                }
                 startPolls++;
             }
 
@@ -262,29 +290,35 @@ internal static class SelectedTextReader
     /// Sends Ctrl+C to whatever has the foreground.
     /// </summary>
     /// <remarks>
-    /// The modifiers are released first, and that is the whole reason this is not two keybd_event
-    /// calls. It runs from a global shortcut, so the keys that triggered it are still physically
-    /// down when it does: with Ctrl+Alt+Q held, a synthesised C arrives at the target application as
-    /// Ctrl+Alt+C — which copies nothing and, in a few applications, does something else entirely.
-    /// Telling the system the modifiers are up first is what makes the copy a plain copy.
+    /// The modifiers are released first so the injected chord is a plain Ctrl+C. Ctrl and C then
+    /// remain down briefly rather than being pressed and released in one SendInput batch: ordinary
+    /// controls consume every key event, but a game may sample keyboard state once per frame and
+    /// miss a chord whose complete lifetime falls between two samples.
     ///
     /// The user's own key releases arrive afterwards as repeats of an up state, which every
     /// application already tolerates.
     /// </remarks>
-    private static void SendCopy()
+    private static Task SendCopy()
     {
-        var inputs = new List<INPUT>();
+        var press = new List<INPUT>();
 
         foreach (var modifier in new ushort[] { VK_MENU, VK_SHIFT, VK_LWIN, VK_RWIN, VK_CONTROL })
-            inputs.Add(Key(modifier, up: true));
+            press.Add(Key(modifier, up: true));
 
-        inputs.Add(Key(VK_CONTROL, up: false));
-        inputs.Add(Key(VK_C, up: false));
-        inputs.Add(Key(VK_C, up: true));
-        inputs.Add(Key(VK_CONTROL, up: true));
+        press.Add(Key(VK_CONTROL, up: false));
+        press.Add(Key(VK_C, up: false));
 
-        var array = inputs.ToArray();
-        SendInput((uint)array.Length, array, Marshal.SizeOf<INPUT>());
+        return HoldCopyChordAsync(
+            () => InjectKeys(press.ToArray()),
+            () => Task.Delay(CopyChordHold),
+            () => InjectKeys([Key(VK_C, up: true), Key(VK_CONTROL, up: true)]));
+    }
+
+    private static void InjectKeys(INPUT[] inputs)
+    {
+        var sent = SendInput((uint)inputs.Length, inputs, Marshal.SizeOf<INPUT>());
+        if (sent != (uint)inputs.Length)
+            Log.Debug("SendInput accepted {SentCount} of {RequestedCount} keyboard events", sent, inputs.Length);
     }
 
     private const ushort VK_SHIFT = 0x10;
@@ -293,7 +327,6 @@ internal static class SelectedTextReader
     private const ushort VK_LWIN = 0x5B;
     private const ushort VK_RWIN = 0x5C;
     private const ushort VK_C = 0x43;
-
     private const uint INPUT_KEYBOARD = 1;
     private const uint KEYEVENTF_KEYUP = 0x0002;
 

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -327,6 +327,13 @@
                     <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center">
                         <Rectangle Width="1" Margin="6,6" Fill="{DynamicResource AppSeparator}"/>
 
+                        <!-- Always present because this changes how the result is presented, not
+                             whether the feature is enabled. The glyph shows the available action:
+                             up collapses the detail, down brings it back. -->
+                        <Button x:Name="CollapseBtn"
+                                Style="{StaticResource HeaderIconButton}"
+                                Click="CollapseBtn_Click"/>
+
                         <!-- The design this was drawn from has no pin, and a popup that dies a
                              second after the pointer leaves needs one — so it is here, quiet until
                              the pointer is on the window and lit once it is holding the popup open.
@@ -523,6 +530,40 @@
                                 </StackPanel>
                             </Grid>
                         </ScrollViewer>
+
+                        <!-- Compact result: translation work is unchanged, only the presentation is
+                             reduced to system state plus one unobtrusive line of translated text. -->
+                        <Grid x:Name="CompactResultPanel" Visibility="Collapsed">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <ProgressBar x:Name="CompactTranslationLoadingBar"
+                                         Grid.Row="0"
+                                         Height="2.5"
+                                         IsIndeterminate="True"
+                                         Visibility="Collapsed"
+                                         BorderThickness="0"
+                                         Background="Transparent"
+                                         Foreground="{DynamicResource AppAccent}"/>
+
+                            <StackPanel Grid.Row="1" Margin="18,10,18,11">
+                                <TextBlock x:Name="CompactStatusText"
+                                           FontFamily="{StaticResource AppFont}"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Visibility="Collapsed"/>
+                                <TextBlock x:Name="CompactTranslatedText"
+                                           FontFamily="{StaticResource AppFont}"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource AppTextSecondary}"
+                                           Margin="0,3,0,0"
+                                           TextWrapping="NoWrap"
+                                           TextTrimming="CharacterEllipsis"
+                                           Visibility="Collapsed"/>
+                            </StackPanel>
+                        </Grid>
 
                         <!-- Settings -->
                         <StackPanel x:Name="SettingsPanel" Margin="18,14,18,16" Visibility="Collapsed">

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -220,15 +220,24 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <!-- The reduced mark, not the full app icon: at this size the full one turns
-                         to mush, and nothing here needs the app identified — the user opened this
-                         window on purpose. Sized by the style rather than here, so the one place
-                         that decides how big the mark is stays with the mark. -->
-                    <ContentControl x:Name="BrandIcon"
-                                    Grid.Column="0"
-                                    Style="{StaticResource AppGlyphMark}"
-                                    Margin="2,0,10,0"
-                                    VerticalAlignment="Center"/>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <!-- The reduced mark, not the full app icon: at this size the full one turns
+                             to mush, and nothing here needs the app identified — the user opened this
+                             window on purpose. Sized by the style rather than here, so the one place
+                             that decides how big the mark is stays with the mark. -->
+                        <ContentControl x:Name="BrandIcon"
+                                        Style="{StaticResource AppGlyphMark}"
+                                        Margin="2,0,4,0"
+                                        VerticalAlignment="Center"/>
+
+                        <!-- Always present because this changes how the result is presented, not
+                             whether the feature is enabled. It sits beside the input whose result
+                             it controls; the glyph shows the available action. -->
+                        <Button x:Name="CollapseBtn"
+                                Style="{StaticResource HeaderIconButton}"
+                                Margin="0,0,4,0"
+                                Click="CollapseBtn_Click"/>
+                    </StackPanel>
 
                     <!-- The box, its placeholder and its clear button share one cell, so the prompt
                          sits exactly where the first character will land and the button sits inside
@@ -326,13 +335,6 @@
 
                     <StackPanel Grid.Column="4" Orientation="Horizontal" VerticalAlignment="Center">
                         <Rectangle Width="1" Margin="6,6" Fill="{DynamicResource AppSeparator}"/>
-
-                        <!-- Always present because this changes how the result is presented, not
-                             whether the feature is enabled. The glyph shows the available action:
-                             up collapses the detail, down brings it back. -->
-                        <Button x:Name="CollapseBtn"
-                                Style="{StaticResource HeaderIconButton}"
-                                Click="CollapseBtn_Click"/>
 
                         <!-- The design this was drawn from has no pin, and a popup that dies a
                              second after the pointer leaves needs one — so it is here, quiet until
@@ -556,9 +558,9 @@
                                            Visibility="Collapsed"/>
                                 <TextBlock x:Name="CompactTranslatedText"
                                            FontFamily="{StaticResource AppFont}"
-                                           FontSize="12"
-                                           Foreground="{DynamicResource AppTextSecondary}"
-                                           Margin="0,3,0,0"
+                                           FontSize="13"
+                                           FontWeight="Bold"
+                                           Foreground="{DynamicResource AppTextPrimary}"
                                            TextWrapping="NoWrap"
                                            TextTrimming="CharacterEllipsis"
                                            Visibility="Collapsed"/>

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -662,6 +662,37 @@
                         </StackPanel>
                     </Grid>
                 </Border>
+
+                <!-- Auto-copy feedback belongs to the window but not to either result layout.
+                     Overlaying both rows keeps compact and expanded results the same height, while
+                     remaining inside Surface makes it follow the window's open/close transform. -->
+                <Border x:Name="AutoCopyConfirmation"
+                        Grid.RowSpan="2"
+                        Panel.ZIndex="1"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Margin="0,0,12,12"
+                        Padding="10,6"
+                        Background="{DynamicResource ToastBg}"
+                        BorderBrush="{DynamicResource ToastBorder}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        IsHitTestVisible="False"
+                        Visibility="Collapsed">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="&#xE8C8;"
+                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource ToastTitle}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,6,0"/>
+                        <TextBlock Text="{DynamicResource S.QuickLookup.TranslationCopied}"
+                                   FontFamily="{StaticResource AppFont}"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource ToastTitle}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
             </Grid>
         </Border>
     </Grid>

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -565,14 +565,14 @@
                                                Foreground="{Binding Foreground, ElementName=TranslatedText}"
                                                VerticalAlignment="Center"
                                                TextWrapping="Wrap"
-                                               MaxWidth="540"
+                                               MaxWidth="440"
                                                Visibility="Collapsed"/>
 
                                     <Button x:Name="CompactTgtTtsBtn"
                                             Style="{StaticResource HeaderIconButton}"
                                             Content="{Binding Content, ElementName=TgtTtsBtn}"
-                                            Margin="6,0,0,0"
-                                            VerticalAlignment="Center"
+                                            Margin="8,4,0,0"
+                                            VerticalAlignment="Top"
                                             Visibility="{Binding Visibility, ElementName=CompactTranslatedText}"
                                             ToolTip="{DynamicResource S.Translation.SpeakResult}"
                                             Click="TgtTtsBtn_Click"/>

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -556,14 +556,33 @@
                                            FontSize="12"
                                            TextWrapping="Wrap"
                                            Visibility="Collapsed"/>
-                                <TextBlock x:Name="CompactTranslatedText"
-                                           FontFamily="{StaticResource AppFont}"
-                                           FontSize="13"
-                                           FontWeight="Bold"
-                                           Foreground="{DynamicResource AppTextPrimary}"
-                                           TextWrapping="NoWrap"
-                                           TextTrimming="CharacterEllipsis"
-                                           Visibility="Collapsed"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock x:Name="CompactTranslatedText"
+                                               Grid.Column="0"
+                                               FontFamily="{StaticResource AppFont}"
+                                               FontSize="14"
+                                               FontWeight="Bold"
+                                               Foreground="{Binding Foreground, ElementName=TranslatedText}"
+                                               VerticalAlignment="Center"
+                                               TextWrapping="NoWrap"
+                                               TextTrimming="CharacterEllipsis"
+                                               Visibility="Collapsed"/>
+
+                                    <Button x:Name="CompactTgtTtsBtn"
+                                            Grid.Column="1"
+                                            Style="{StaticResource HeaderIconButton}"
+                                            Content="{Binding Content, ElementName=TgtTtsBtn}"
+                                            Margin="6,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Visibility="{Binding Visibility, ElementName=CompactTranslatedText}"
+                                            ToolTip="{DynamicResource S.Translation.SpeakResult}"
+                                            Click="TgtTtsBtn_Click"/>
+                                </Grid>
                             </StackPanel>
                         </Grid>
 

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -673,8 +673,8 @@
                         VerticalAlignment="Bottom"
                         Margin="0,0,12,12"
                         Padding="10,6"
-                        Background="{DynamicResource ToastBg}"
-                        BorderBrush="{DynamicResource ToastBorder}"
+                        Background="{DynamicResource AppHeaderBg}"
+                        BorderBrush="{DynamicResource AppButtonBorder}"
                         BorderThickness="1"
                         CornerRadius="8"
                         IsHitTestVisible="False"
@@ -683,13 +683,13 @@
                         <TextBlock Text="&#xE8C8;"
                                    FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                    FontSize="12"
-                                   Foreground="{DynamicResource ToastTitle}"
+                                   Foreground="{DynamicResource AppAccent}"
                                    VerticalAlignment="Center"
                                    Margin="0,0,6,0"/>
                         <TextBlock Text="{DynamicResource S.QuickLookup.TranslationCopied}"
                                    FontFamily="{StaticResource AppFont}"
                                    FontSize="12"
-                                   Foreground="{DynamicResource ToastTitle}"
+                                   Foreground="{DynamicResource AppTextPrimary}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
                 </Border>

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -563,6 +563,7 @@
                                                FontSize="14"
                                                FontWeight="SemiBold"
                                                LineHeight="20"
+                                               TextOptions.TextFormattingMode="Ideal"
                                                Foreground="{Binding Foreground, ElementName=TranslatedText}"
                                                Margin="0,5,0,0"
                                                VerticalAlignment="Top"

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -549,6 +549,30 @@
 
                             <Rectangle Height="1" Fill="{DynamicResource AppSeparator}" Margin="0,0,0,12"/>
 
+                            <Grid Margin="0,0,0,14">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+
+                                <StackPanel Grid.Column="0" VerticalAlignment="Center" Margin="0,0,12,0">
+                                    <TextBlock Text="{DynamicResource S.QuickLookup.AutoCopy}"
+                                               Style="{StaticResource SettingRowLabel}"
+                                               TextWrapping="Wrap"/>
+                                    <TextBlock Text="{DynamicResource S.QuickLookup.AutoCopyHint}"
+                                               Style="{StaticResource FieldHint}"
+                                               Margin="0,2,0,0"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+
+                                <CheckBox x:Name="AutoCopyToggle"
+                                          Grid.Column="1"
+                                          Style="{StaticResource ToggleSwitch}"
+                                          AutomationProperties.Name="{DynamicResource S.QuickLookup.AutoCopy}"/>
+                            </Grid>
+
+                            <Rectangle Height="1" Fill="{DynamicResource AppSeparator}" Margin="0,0,0,12"/>
+
                             <!-- Wayfinding: this panel holds the two settings worth reaching without
                                  leaving the popup, and this line is how the reader gets to the rest
                                  of them rather than concluding there are none. -->

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -420,6 +420,7 @@
                                            TextOptions.TextFormattingMode="Ideal"
                                            TextOptions.TextRenderingMode="ClearType"
                                            Foreground="{DynamicResource AppTextPrimary}"
+                                           VerticalAlignment="Top"
                                            TextWrapping="Wrap"
                                            MaxWidth="440"/>
 
@@ -430,7 +431,7 @@
                                 <Button x:Name="TgtTtsBtn"
                                         Style="{StaticResource HeaderIconButton}"
                                         Content="&#xE767;"
-                                        Margin="8,4,0,0"
+                                        Margin="8,1,0,0"
                                         VerticalAlignment="Top"
                                         Visibility="Collapsed"
                                         ToolTip="{DynamicResource S.Translation.SpeakResult}"
@@ -556,14 +557,15 @@
                                            FontSize="12"
                                            TextWrapping="Wrap"
                                            Visibility="Collapsed"/>
-                                <StackPanel Orientation="Horizontal">
+                                <StackPanel x:Name="CompactTranslationRow" Orientation="Horizontal">
                                     <TextBlock x:Name="CompactTranslatedText"
                                                FontFamily="{StaticResource AppFont}"
                                                FontSize="14"
                                                FontWeight="SemiBold"
                                                LineHeight="20"
                                                Foreground="{Binding Foreground, ElementName=TranslatedText}"
-                                               VerticalAlignment="Center"
+                                               Margin="0,5,0,0"
+                                               VerticalAlignment="Top"
                                                TextWrapping="Wrap"
                                                MaxWidth="440"
                                                Visibility="Collapsed"/>
@@ -571,7 +573,7 @@
                                     <Button x:Name="CompactTgtTtsBtn"
                                             Style="{StaticResource HeaderIconButton}"
                                             Content="{Binding Content, ElementName=TgtTtsBtn}"
-                                            Margin="8,4,0,0"
+                                            Margin="8,0,0,0"
                                             VerticalAlignment="Top"
                                             Visibility="{Binding Visibility, ElementName=CompactTranslatedText}"
                                             ToolTip="{DynamicResource S.Translation.SpeakResult}"

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml
@@ -556,25 +556,19 @@
                                            FontSize="12"
                                            TextWrapping="Wrap"
                                            Visibility="Collapsed"/>
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
-
+                                <StackPanel Orientation="Horizontal">
                                     <TextBlock x:Name="CompactTranslatedText"
-                                               Grid.Column="0"
                                                FontFamily="{StaticResource AppFont}"
                                                FontSize="14"
-                                               FontWeight="Bold"
+                                               FontWeight="SemiBold"
+                                               LineHeight="20"
                                                Foreground="{Binding Foreground, ElementName=TranslatedText}"
                                                VerticalAlignment="Center"
-                                               TextWrapping="NoWrap"
-                                               TextTrimming="CharacterEllipsis"
+                                               TextWrapping="Wrap"
+                                               MaxWidth="540"
                                                Visibility="Collapsed"/>
 
                                     <Button x:Name="CompactTgtTtsBtn"
-                                            Grid.Column="1"
                                             Style="{StaticResource HeaderIconButton}"
                                             Content="{Binding Content, ElementName=TgtTtsBtn}"
                                             Margin="6,0,0,0"
@@ -582,7 +576,7 @@
                                             Visibility="{Binding Visibility, ElementName=CompactTranslatedText}"
                                             ToolTip="{DynamicResource S.Translation.SpeakResult}"
                                             Click="TgtTtsBtn_Click"/>
-                                </Grid>
+                                </StackPanel>
                             </StackPanel>
                         </Grid>
 

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -755,6 +755,16 @@ public partial class QuickLookupWindow : Window
         if (e.Key == Key.Escape)
         {
             e.Handled = true;
+
+            if (_pinned)
+            {
+                // Pinning promises the popup survives ordinary dismissal gestures. Escape still
+                // gives the reader a quick reset, and clearing through the same path as the button
+                // also cancels any translation that belongs to the previous text.
+                ClearSourceText();
+                return;
+            }
+
             BeginClose();
             return;
         }
@@ -860,6 +870,9 @@ public partial class QuickLookupWindow : Window
     /// from somewhere else, and retyping it means going back for it.
     /// </remarks>
     private void ClearBtn_Click(object sender, RoutedEventArgs e)
+        => ClearSourceText();
+
+    private void ClearSourceText()
     {
         SourceTextBox.SelectAll();
         SourceTextBox.SelectedText = "";

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -312,6 +312,8 @@ public partial class QuickLookupWindow : Window
         SrcLangBox.SelectionChanged  += LangBox_SelectionChanged;
         TgtLangBox.SelectionChanged  += LangBox_SelectionChanged;
         ProviderBox.SelectionChanged += ProviderBox_SelectionChanged;
+        AutoCopyToggle.Checked       += AutoCopyToggle_Toggled;
+        AutoCopyToggle.Unchecked     += AutoCopyToggle_Toggled;
 
         foreach (var picker in new[] { SrcLangBox, TgtLangBox, ProviderBox })
         {
@@ -929,6 +931,8 @@ public partial class QuickLookupWindow : Window
             SetTranslationLoading(false);
             _detectedLang = detected ?? "";
             TranslatedText.Text = results.FirstOrDefault()?.TranslatedText ?? "";
+            if (settings.QuickLookup.AutoCopyTranslation)
+                CopyTranslation(showConfirmation: false);
             StatusText.Visibility = Visibility.Collapsed;
             ShowResult();
 
@@ -1141,6 +1145,11 @@ public partial class QuickLookupWindow : Window
     /// </remarks>
     private void CopyBtn_Click(object sender, RoutedEventArgs e)
     {
+        CopyTranslation(showConfirmation: true);
+    }
+
+    private void CopyTranslation(bool showConfirmation)
+    {
         if (TranslatedText.Text.Length == 0) return;
 
         try
@@ -1152,6 +1161,8 @@ public partial class QuickLookupWindow : Window
             Log.Warn(ex, "Could not copy the translation");
             return;
         }
+
+        if (!showConfirmation) return;
 
         RenderCopyLabel(copied: true);
         _copiedHold.Stop();
@@ -1235,6 +1246,16 @@ public partial class QuickLookupWindow : Window
         TgtLangBox.SelectedValue = LanguageData.GetValidTargetCode(settings.TargetLanguage);
         ProviderBox.SelectedValue = settings.Provider;
         if (ProviderBox.SelectedValue is null) ProviderBox.SelectedIndex = 0;
+        AutoCopyToggle.IsChecked = settings.QuickLookup.AutoCopyTranslation;
+    }
+
+    private void AutoCopyToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_suppressAuto) return;
+
+        SettingsService.Instance.Current.QuickLookup.AutoCopyTranslation =
+            AutoCopyToggle.IsChecked == true;
+        SettingsService.Instance.Save();
     }
 
     private void LangBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -1069,14 +1069,18 @@ public partial class QuickLookupWindow : Window
 
     private void RenderCompactCompletion()
     {
-        CompactStatusText.Text = LocalizationService.Get(
-            _lastResultAutoCopied
-                ? "S.QuickLookup.TranslationCopied"
-                : "S.QuickLookup.TranslationComplete");
+        CompactStatusText.Text = _lastResultAutoCopied
+            ? LocalizationService.Get("S.QuickLookup.TranslationCopied")
+            : "";
         CompactStatusText.SetResourceReference(ForegroundProperty, "AppAccent");
-        CompactStatusText.Visibility = Visibility.Visible;
+        CompactStatusText.Visibility = _lastResultAutoCopied
+            ? Visibility.Visible
+            : Visibility.Collapsed;
 
         CompactTranslatedText.Text = TranslatedText.Text;
+        CompactTranslatedText.Margin = _lastResultAutoCopied
+            ? new Thickness(0, 3, 0, 0)
+            : new Thickness(0);
         CompactTranslatedText.Visibility = TranslatedText.Text.Length > 0
             ? Visibility.Visible
             : Visibility.Collapsed;

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -1078,7 +1078,7 @@ public partial class QuickLookupWindow : Window
             : Visibility.Collapsed;
 
         CompactTranslatedText.Text = TranslatedText.Text;
-        CompactTranslatedText.Margin = _lastResultAutoCopied
+        CompactTranslationRow.Margin = _lastResultAutoCopied
             ? new Thickness(0, 3, 0, 0)
             : new Thickness(0);
         CompactTranslatedText.Visibility = TranslatedText.Text.Length > 0

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -120,6 +120,12 @@ public partial class QuickLookupWindow : Window
     /// <summary>True while the gear panel is showing instead of the result.</summary>
     private bool _settingsOpen;
 
+    /// <summary>Whether results use the compact status-and-preview presentation.</summary>
+    private bool _resultsCollapsed;
+
+    /// <summary>Whether the current successful result was automatically copied.</summary>
+    private bool _lastResultAutoCopied;
+
     /// <summary>True while one of the pickers has its list down — see <see cref="OnDeactivated"/>.</summary>
     private bool _dropDownOpen;
 
@@ -289,6 +295,7 @@ public partial class QuickLookupWindow : Window
     private QuickLookupWindow()
     {
         InitializeComponent();
+        _resultsCollapsed = SettingsService.Instance.Current.QuickLookup.ResultsCollapsed;
 
         _debounce = new DispatcherTimer { Interval = DebounceDelay };
         _debounce.Tick += (_, _) => { _debounce.Stop(); _ = TranslateNowAsync(); };
@@ -355,6 +362,8 @@ public partial class QuickLookupWindow : Window
 
         RenderChrome();
         RenderCopyLabel(copied: false);
+        RenderCollapseButton();
+        RenderResultPresentation();
         RenderSettingsButton();
         RenderSettingsHint();
     }
@@ -944,9 +953,10 @@ public partial class QuickLookupWindow : Window
             SetTranslationLoading(false);
             _detectedLang = detected ?? "";
             TranslatedText.Text = results.FirstOrDefault()?.TranslatedText ?? "";
-            if (settings.QuickLookup.AutoCopyTranslation)
-                CopyTranslation(showConfirmation: false);
+            _lastResultAutoCopied = settings.QuickLookup.AutoCopyTranslation
+                                    && CopyTranslation(showConfirmation: false);
             StatusText.Visibility = Visibility.Collapsed;
+            RenderCompactCompletion();
             ShowResult();
 
             var dictionarySource = LanguageData.IsAutomaticSource(srcLang) ? _detectedLang : srcLang;
@@ -958,6 +968,7 @@ public partial class QuickLookupWindow : Window
 
             SetTranslationLoading(false);
             Log.Warn(ex, "取詞翻譯 could not translate");
+            _lastResultAutoCopied = false;
             TranslatedText.Text = "";
             ShowStatus(
                 LocalizationService.Format(
@@ -1012,7 +1023,11 @@ public partial class QuickLookupWindow : Window
     }
 
     private void SetTranslationLoading(bool loading)
-        => TranslationLoadingBar.Visibility = loading ? Visibility.Visible : Visibility.Collapsed;
+    {
+        var visibility = loading ? Visibility.Visible : Visibility.Collapsed;
+        TranslationLoadingBar.Visibility = visibility;
+        CompactTranslationLoadingBar.Visibility = visibility;
+    }
 
     /// <remarks>
     /// Silent while the gear panel is up. A translation finishing is not a reason to take the user
@@ -1023,8 +1038,8 @@ public partial class QuickLookupWindow : Window
     {
         if (_settingsOpen) return;
 
-        ResultPanel.Visibility = Visibility.Visible;
         SettingsPanel.Visibility = Visibility.Collapsed;
+        RenderResultPresentation();
         // Both belong to a translation rather than to the panel, so neither is on screen while the
         // status line is still saying 翻譯中.
         var hasResult = TranslatedText.Text.Length > 0;
@@ -1042,7 +1057,29 @@ public partial class QuickLookupWindow : Window
         StatusText.SetResourceReference(
             ForegroundProperty, isError ? "AppError" : "AppAccent");
         StatusText.Visibility = Visibility.Visible;
+
+        CompactStatusText.Text = text;
+        CompactStatusText.SetResourceReference(
+            ForegroundProperty, isError ? "AppError" : "AppAccent");
+        CompactStatusText.Visibility = Visibility.Visible;
+        CompactTranslatedText.Text = "";
+        CompactTranslatedText.Visibility = Visibility.Collapsed;
         ShowResult();
+    }
+
+    private void RenderCompactCompletion()
+    {
+        CompactStatusText.Text = LocalizationService.Get(
+            _lastResultAutoCopied
+                ? "S.QuickLookup.TranslationCopied"
+                : "S.QuickLookup.TranslationComplete");
+        CompactStatusText.SetResourceReference(ForegroundProperty, "AppAccent");
+        CompactStatusText.Visibility = Visibility.Visible;
+
+        CompactTranslatedText.Text = TranslatedText.Text;
+        CompactTranslatedText.Visibility = TranslatedText.Text.Length > 0
+            ? Visibility.Visible
+            : Visibility.Collapsed;
     }
 
     /// <summary>
@@ -1161,9 +1198,9 @@ public partial class QuickLookupWindow : Window
         CopyTranslation(showConfirmation: true);
     }
 
-    private void CopyTranslation(bool showConfirmation)
+    private bool CopyTranslation(bool showConfirmation)
     {
-        if (TranslatedText.Text.Length == 0) return;
+        if (TranslatedText.Text.Length == 0) return false;
 
         try
         {
@@ -1172,14 +1209,15 @@ public partial class QuickLookupWindow : Window
         catch (Exception ex)
         {
             Log.Warn(ex, "Could not copy the translation");
-            return;
+            return false;
         }
 
-        if (!showConfirmation) return;
+        if (!showConfirmation) return true;
 
         RenderCopyLabel(copied: true);
         _copiedHold.Stop();
         _copiedHold.Start();
+        return true;
     }
 
     private void RenderCopyLabel(bool copied) =>
@@ -1189,6 +1227,44 @@ public partial class QuickLookupWindow : Window
     // ══════════════════════════ Settings panel ══════════════════════════
 
     private void SettingsBtn_Click(object sender, RoutedEventArgs e) => ShowSettings(!_settingsOpen);
+
+    private void CollapseBtn_Click(object sender, RoutedEventArgs e)
+    {
+        _resultsCollapsed = !_resultsCollapsed;
+        SettingsService.Instance.Current.QuickLookup.ResultsCollapsed = _resultsCollapsed;
+        SettingsService.Instance.Save();
+
+        RenderCollapseButton();
+        if (_settingsOpen) return;
+
+        RenderResultPresentation();
+        ShowBody(HasBodyContent());
+    }
+
+    /// <summary>
+    /// Shows the action rather than the state: an up chevron removes detail, a down chevron restores
+    /// it. There is no transition — this can sit in a copy-and-paste loop and must answer instantly.
+    /// </summary>
+    private void RenderCollapseButton()
+    {
+        CollapseBtn.Content = _resultsCollapsed ? "\uE70D" : "\uE70E";
+        var label = LocalizationService.Get(
+            _resultsCollapsed ? "S.QuickLookup.Expand" : "S.QuickLookup.Collapse");
+        CollapseBtn.ToolTip = label;
+        System.Windows.Automation.AutomationProperties.SetName(CollapseBtn, label);
+    }
+
+    private void RenderResultPresentation()
+    {
+        ResultPanel.Visibility = _resultsCollapsed ? Visibility.Collapsed : Visibility.Visible;
+        CompactResultPanel.Visibility = _resultsCollapsed ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private bool HasBodyContent() =>
+        !string.IsNullOrWhiteSpace(SourceTextBox.Text)
+        && (TranslatedText.Text.Length > 0
+            || StatusText.Visibility == Visibility.Visible
+            || TranslationLoadingBar.Visibility == Visibility.Visible);
 
     /// <summary>
     /// Points the one button in the header that means two things at whichever one it means now.
@@ -1227,13 +1303,14 @@ public partial class QuickLookupWindow : Window
             RenderSettingsHint();
             SettingsPanel.Visibility = Visibility.Visible;
             ResultPanel.Visibility = Visibility.Collapsed;
+            CompactResultPanel.Visibility = Visibility.Collapsed;
             ShowBody(true);
             return;
         }
 
         SettingsPanel.Visibility = Visibility.Collapsed;
-        ResultPanel.Visibility = Visibility.Visible;
-        ShowBody(TranslatedText.Text.Length > 0 || StatusText.Visibility == Visibility.Visible);
+        RenderResultPresentation();
+        ShowBody(HasBodyContent());
     }
 
     private void RenderSettingsHint() =>
@@ -1384,9 +1461,12 @@ public partial class QuickLookupWindow : Window
     {
         RenderChrome();
         RenderCopyLabel(copied: false);
+        RenderCollapseButton();
         RenderSettingsButton();
         RenderSettingsHint();
         RenderSourceTtsAvailability();
+        if (TranslatedText.Text.Length > 0 && StatusText.Visibility != Visibility.Visible)
+            RenderCompactCompletion();
     }
 
     protected override void OnClosed(EventArgs e)

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -76,7 +76,7 @@ public partial class QuickLookupWindow : Window
     /// </remarks>
     private static readonly TimeSpan ForegroundWatchInterval = TimeSpan.FromMilliseconds(150);
 
-    /// <summary>How long 複製 says it copied before going back to offering to.</summary>
+    /// <summary>How long copy confirmation remains before returning to the resting UI.</summary>
     private static readonly TimeSpan CopiedHold = TimeSpan.FromMilliseconds(1400);
 
     private readonly TtsService _tts = new();
@@ -122,9 +122,6 @@ public partial class QuickLookupWindow : Window
 
     /// <summary>Whether results use the compact status-and-preview presentation.</summary>
     private bool _resultsCollapsed;
-
-    /// <summary>Whether the current successful result was automatically copied.</summary>
-    private bool _lastResultAutoCopied;
 
     /// <summary>True while one of the pickers has its list down — see <see cref="OnDeactivated"/>.</summary>
     private bool _dropDownOpen;
@@ -301,7 +298,12 @@ public partial class QuickLookupWindow : Window
         _debounce.Tick += (_, _) => { _debounce.Stop(); _ = TranslateNowAsync(); };
 
         _copiedHold = new DispatcherTimer { Interval = CopiedHold };
-        _copiedHold.Tick += (_, _) => { _copiedHold.Stop(); RenderCopyLabel(copied: false); };
+        _copiedHold.Tick += (_, _) =>
+        {
+            _copiedHold.Stop();
+            RenderCopyLabel(copied: false);
+            HideAutoCopyConfirmation(immediate: false);
+        };
 
         _foregroundWatch = new DispatcherTimer { Interval = ForegroundWatchInterval };
         _foregroundWatch.Tick += (_, _) => CheckForeground();
@@ -929,6 +931,8 @@ public partial class QuickLookupWindow : Window
         var text = SourceTextBox.Text;
         if (string.IsNullOrWhiteSpace(text)) return;
 
+        HideAutoCopyConfirmation(immediate: true);
+
         var settings = SettingsService.Instance.Current;
         var srcLang = LanguageData.GetValidSourceCode(SrcLangBox.SelectedValue as string);
         var tgtLang = LanguageData.GetValidTargetCode(TgtLangBox.SelectedValue as string);
@@ -953,8 +957,8 @@ public partial class QuickLookupWindow : Window
             SetTranslationLoading(false);
             _detectedLang = detected ?? "";
             TranslatedText.Text = results.FirstOrDefault()?.TranslatedText ?? "";
-            _lastResultAutoCopied = settings.QuickLookup.AutoCopyTranslation
-                                    && CopyTranslation(showConfirmation: false);
+            if (settings.QuickLookup.AutoCopyTranslation)
+                CopyTranslation(showConfirmation: false);
             StatusText.Visibility = Visibility.Collapsed;
             RenderCompactCompletion();
             ShowResult();
@@ -968,7 +972,6 @@ public partial class QuickLookupWindow : Window
 
             SetTranslationLoading(false);
             Log.Warn(ex, "取詞翻譯 could not translate");
-            _lastResultAutoCopied = false;
             TranslatedText.Text = "";
             ShowStatus(
                 LocalizationService.Format(
@@ -1069,18 +1072,10 @@ public partial class QuickLookupWindow : Window
 
     private void RenderCompactCompletion()
     {
-        CompactStatusText.Text = _lastResultAutoCopied
-            ? LocalizationService.Get("S.QuickLookup.TranslationCopied")
-            : "";
-        CompactStatusText.SetResourceReference(ForegroundProperty, "AppAccent");
-        CompactStatusText.Visibility = _lastResultAutoCopied
-            ? Visibility.Visible
-            : Visibility.Collapsed;
-
+        CompactStatusText.Text = "";
+        CompactStatusText.Visibility = Visibility.Collapsed;
         CompactTranslatedText.Text = TranslatedText.Text;
-        CompactTranslationRow.Margin = _lastResultAutoCopied
-            ? new Thickness(0, 3, 0, 0)
-            : new Thickness(0);
+        CompactTranslationRow.Margin = new Thickness(0);
         CompactTranslatedText.Visibility = TranslatedText.Text.Length > 0
             ? Visibility.Visible
             : Visibility.Collapsed;
@@ -1193,9 +1188,8 @@ public partial class QuickLookupWindow : Window
     // ══════════════════════════ Copying ══════════════════════════
 
     /// <remarks>
-    /// Confirmed on the button itself rather than with a toast. A toast would appear outside this
-    /// window, which is a place the pointer then has to not be for the popup to survive — and the
-    /// message would outlive the window it was about.
+    /// Manual copies confirm on their button. Automatic copies use an in-window overlay because
+    /// neither the expanded nor compact result should gain a status line for transient feedback.
     /// </remarks>
     private void CopyBtn_Click(object sender, RoutedEventArgs e)
     {
@@ -1216,9 +1210,17 @@ public partial class QuickLookupWindow : Window
             return false;
         }
 
-        if (!showConfirmation) return true;
+        if (showConfirmation)
+        {
+            HideAutoCopyConfirmation(immediate: true);
+            RenderCopyLabel(copied: true);
+        }
+        else
+        {
+            RenderCopyLabel(copied: false);
+            ShowAutoCopyConfirmation();
+        }
 
-        RenderCopyLabel(copied: true);
         _copiedHold.Stop();
         _copiedHold.Start();
         return true;
@@ -1227,6 +1229,35 @@ public partial class QuickLookupWindow : Window
     private void RenderCopyLabel(bool copied) =>
         CopyLabel.Text = LocalizationService.Get(
             copied ? "S.QuickLookup.Copied" : "S.QuickLookup.Copy");
+
+    private void ShowAutoCopyConfirmation()
+    {
+        AutoCopyConfirmation.BeginAnimation(OpacityProperty, null);
+        AutoCopyConfirmation.Opacity = 1;
+        AutoCopyConfirmation.Visibility = Visibility.Visible;
+    }
+
+    private void HideAutoCopyConfirmation(bool immediate)
+    {
+        AutoCopyConfirmation.BeginAnimation(OpacityProperty, null);
+        if (AutoCopyConfirmation.Visibility != Visibility.Visible) return;
+
+        if (immediate)
+        {
+            AutoCopyConfirmation.Visibility = Visibility.Collapsed;
+            AutoCopyConfirmation.Opacity = 1;
+            return;
+        }
+
+        var fade = new DoubleAnimation(1, 0, TimeSpan.FromMilliseconds(150));
+        fade.Completed += (_, _) =>
+        {
+            AutoCopyConfirmation.Visibility = Visibility.Collapsed;
+            AutoCopyConfirmation.Opacity = 1;
+            AutoCopyConfirmation.BeginAnimation(OpacityProperty, null);
+        };
+        AutoCopyConfirmation.BeginAnimation(OpacityProperty, fade);
+    }
 
     // ══════════════════════════ Settings panel ══════════════════════════
 

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -77,7 +77,7 @@ public partial class QuickLookupWindow : Window
     private static readonly TimeSpan ForegroundWatchInterval = TimeSpan.FromMilliseconds(150);
 
     private static readonly TimeSpan ManualCopyHold = TimeSpan.FromMilliseconds(1400);
-    private static readonly TimeSpan AutoCopyHold = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan AutoCopyHold = TimeSpan.FromMilliseconds(1500);
 
     private readonly TtsService _tts = new();
     private readonly DispatcherTimer _debounce;

--- a/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
+++ b/src/OverTranslate/Views/QuickLookup/QuickLookupWindow.xaml.cs
@@ -76,8 +76,8 @@ public partial class QuickLookupWindow : Window
     /// </remarks>
     private static readonly TimeSpan ForegroundWatchInterval = TimeSpan.FromMilliseconds(150);
 
-    /// <summary>How long copy confirmation remains before returning to the resting UI.</summary>
-    private static readonly TimeSpan CopiedHold = TimeSpan.FromMilliseconds(1400);
+    private static readonly TimeSpan ManualCopyHold = TimeSpan.FromMilliseconds(1400);
+    private static readonly TimeSpan AutoCopyHold = TimeSpan.FromSeconds(2);
 
     private readonly TtsService _tts = new();
     private readonly DispatcherTimer _debounce;
@@ -297,7 +297,7 @@ public partial class QuickLookupWindow : Window
         _debounce = new DispatcherTimer { Interval = DebounceDelay };
         _debounce.Tick += (_, _) => { _debounce.Stop(); _ = TranslateNowAsync(); };
 
-        _copiedHold = new DispatcherTimer { Interval = CopiedHold };
+        _copiedHold = new DispatcherTimer { Interval = ManualCopyHold };
         _copiedHold.Tick += (_, _) =>
         {
             _copiedHold.Stop();
@@ -1222,6 +1222,7 @@ public partial class QuickLookupWindow : Window
         }
 
         _copiedHold.Stop();
+        _copiedHold.Interval = showConfirmation ? ManualCopyHold : AutoCopyHold;
         _copiedHold.Start();
         return true;
     }

--- a/src/OverTranslate/appsettings.json
+++ b/src/OverTranslate/appsettings.json
@@ -14,5 +14,8 @@
   "Theme": "Dark",
   "AutoTranslateAfterSelection": false,
   "SaveScreenshotToDisk": false,
-  "ScreenshotSavePath": ""
+  "ScreenshotSavePath": "",
+  "QuickLookup": {
+    "AutoCopyTranslation": false
+  }
 }

--- a/src/OverTranslate/appsettings.json
+++ b/src/OverTranslate/appsettings.json
@@ -16,6 +16,7 @@
   "SaveScreenshotToDisk": false,
   "ScreenshotSavePath": "",
   "QuickLookup": {
-    "AutoCopyTranslation": false
+    "AutoCopyTranslation": false,
+    "ResultsCollapsed": false
   }
 }

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -78,7 +78,7 @@ public class QuickLookupWindowMarkupTests
             .Single(e => (string?)e.Attribute(X + "Name") == "CompactTranslatedText");
 
         Assert.Equal("Wrap", (string?)result.Attribute("TextWrapping"));
-        Assert.Equal("540", (string?)result.Attribute("MaxWidth"));
+        Assert.Equal("440", (string?)result.Attribute("MaxWidth"));
         Assert.Null((string?)result.Attribute("TextTrimming"));
         Assert.Equal("14", (string?)result.Attribute("FontSize"));
         Assert.Equal("SemiBold", (string?)result.Attribute("FontWeight"));
@@ -98,6 +98,8 @@ public class QuickLookupWindowMarkupTests
         Assert.Equal("{StaticResource HeaderIconButton}", (string?)button.Attribute("Style"));
         Assert.Equal("{Binding Content, ElementName=TgtTtsBtn}", (string?)button.Attribute("Content"));
         Assert.Equal("{Binding Visibility, ElementName=CompactTranslatedText}", (string?)button.Attribute("Visibility"));
+        Assert.Equal("8,4,0,0", (string?)button.Attribute("Margin"));
+        Assert.Equal("Top", (string?)button.Attribute("VerticalAlignment"));
         Assert.Equal("TgtTtsBtn_Click", (string?)button.Attribute("Click"));
     }
 

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -55,6 +55,32 @@ public class QuickLookupWindowMarkupTests
     }
 
     /// <summary>
+    /// The presentation toggle belongs to the always-visible header rather than either result
+    /// panel, so a compact popup can always be expanded again.
+    /// </summary>
+    [Fact]
+    public void The_result_presentation_toggle_is_always_available()
+    {
+        var toggle = Window()
+            .Descendants()
+            .Single(e => (string?)e.Attribute(X + "Name") == "CollapseBtn");
+
+        Assert.Null((string?)toggle.Attribute("Visibility"));
+    }
+
+    /// <summary>The compact preview must stay compact even when the translation is long.</summary>
+    [Fact]
+    public void The_compact_translation_is_one_trimmed_line()
+    {
+        var result = Window()
+            .Descendants()
+            .Single(e => (string?)e.Attribute(X + "Name") == "CompactTranslatedText");
+
+        Assert.Equal("NoWrap", (string?)result.Attribute("TextWrapping"));
+        Assert.Equal("CharacterEllipsis", (string?)result.Attribute("TextTrimming"));
+    }
+
+    /// <summary>
     /// The transparent shadow canvas is an implementation detail. It must not leave the visible
     /// card below the screen edge when Windows places the popup's actual window against that edge.
     /// </summary>

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -106,6 +106,24 @@ public class QuickLookupWindowMarkupTests
         Assert.Equal("TgtTtsBtn_Click", (string?)button.Attribute("Click"));
     }
 
+    /// <summary>Auto-copy feedback overlays both result layouts without resizing or intercepting them.</summary>
+    [Fact]
+    public void Auto_copy_confirmation_is_a_non_interactive_overlay()
+    {
+        var confirmation = Window()
+            .Descendants()
+            .Single(e => (string?)e.Attribute(X + "Name") == "AutoCopyConfirmation");
+
+        Assert.Equal("1", (string?)confirmation.Attribute("Panel.ZIndex"));
+        Assert.Equal("Right", (string?)confirmation.Attribute("HorizontalAlignment"));
+        Assert.Equal("Bottom", (string?)confirmation.Attribute("VerticalAlignment"));
+        Assert.Equal("2", (string?)confirmation.Attribute("Grid.RowSpan"));
+        Assert.Equal("False", (string?)confirmation.Attribute("IsHitTestVisible"));
+        Assert.Equal("Collapsed", (string?)confirmation.Attribute("Visibility"));
+        Assert.Equal("Grid", confirmation.Parent?.Name.LocalName);
+        Assert.Equal("BodyHost", (string?)confirmation.ElementsBeforeSelf().Last().Attribute(X + "Name"));
+    }
+
     /// <summary>Each speech button is centered on the first line box, independent of script glyph size.</summary>
     [Fact]
     public void The_result_tts_buttons_align_to_the_first_line_box()

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -66,6 +66,7 @@ public class QuickLookupWindowMarkupTests
             .Single(e => (string?)e.Attribute(X + "Name") == "CollapseBtn");
 
         Assert.Null((string?)toggle.Attribute("Visibility"));
+        Assert.Equal("0", (string?)toggle.Parent?.Attribute("Grid.Column"));
     }
 
     /// <summary>The compact preview must stay compact even when the translation is long.</summary>
@@ -78,6 +79,9 @@ public class QuickLookupWindowMarkupTests
 
         Assert.Equal("NoWrap", (string?)result.Attribute("TextWrapping"));
         Assert.Equal("CharacterEllipsis", (string?)result.Attribute("TextTrimming"));
+        Assert.Equal("13", (string?)result.Attribute("FontSize"));
+        Assert.Equal("Bold", (string?)result.Attribute("FontWeight"));
+        Assert.Equal("{DynamicResource AppTextPrimary}", (string?)result.Attribute("Foreground"));
     }
 
     /// <summary>

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -83,6 +83,8 @@ public class QuickLookupWindowMarkupTests
         Assert.Equal("14", (string?)result.Attribute("FontSize"));
         Assert.Equal("SemiBold", (string?)result.Attribute("FontWeight"));
         Assert.Equal("20", (string?)result.Attribute("LineHeight"));
+        Assert.Equal("0,5,0,0", (string?)result.Attribute("Margin"));
+        Assert.Equal("Top", (string?)result.Attribute("VerticalAlignment"));
         Assert.Equal("{Binding Foreground, ElementName=TranslatedText}", (string?)result.Attribute("Foreground"));
         Assert.Equal("Horizontal", (string?)result.Parent?.Attribute("Orientation"));
     }
@@ -98,9 +100,27 @@ public class QuickLookupWindowMarkupTests
         Assert.Equal("{StaticResource HeaderIconButton}", (string?)button.Attribute("Style"));
         Assert.Equal("{Binding Content, ElementName=TgtTtsBtn}", (string?)button.Attribute("Content"));
         Assert.Equal("{Binding Visibility, ElementName=CompactTranslatedText}", (string?)button.Attribute("Visibility"));
-        Assert.Equal("8,4,0,0", (string?)button.Attribute("Margin"));
+        Assert.Equal("8,0,0,0", (string?)button.Attribute("Margin"));
         Assert.Equal("Top", (string?)button.Attribute("VerticalAlignment"));
         Assert.Equal("TgtTtsBtn_Click", (string?)button.Attribute("Click"));
+    }
+
+    /// <summary>Each speech button is centered on the first line box, independent of script glyph size.</summary>
+    [Fact]
+    public void The_result_tts_buttons_align_to_the_first_line_box()
+    {
+        var window = Window();
+        XElement Element(string name) => window
+            .Descendants()
+            .Single(e => (string?)e.Attribute(X + "Name") == name);
+
+        Assert.Equal("32", (string?)Element("TranslatedText").Attribute("LineHeight"));
+        Assert.Equal("Top", (string?)Element("TranslatedText").Attribute("VerticalAlignment"));
+        Assert.Equal("8,1,0,0", (string?)Element("TgtTtsBtn").Attribute("Margin"));
+        Assert.Equal("Top", (string?)Element("TgtTtsBtn").Attribute("VerticalAlignment"));
+        Assert.Equal("20", (string?)Element("CompactTranslatedText").Attribute("LineHeight"));
+        Assert.Equal("0,5,0,0", (string?)Element("CompactTranslatedText").Attribute("Margin"));
+        Assert.Equal("8,0,0,0", (string?)Element("CompactTgtTtsBtn").Attribute("Margin"));
     }
 
     /// <summary>

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -83,6 +83,7 @@ public class QuickLookupWindowMarkupTests
         Assert.Equal("14", (string?)result.Attribute("FontSize"));
         Assert.Equal("SemiBold", (string?)result.Attribute("FontWeight"));
         Assert.Equal("20", (string?)result.Attribute("LineHeight"));
+        Assert.Equal("Ideal", (string?)result.Attribute("TextOptions.TextFormattingMode"));
         Assert.Equal("0,5,0,0", (string?)result.Attribute("Margin"));
         Assert.Equal("Top", (string?)result.Attribute("VerticalAlignment"));
         Assert.Equal("{Binding Foreground, ElementName=TranslatedText}", (string?)result.Attribute("Foreground"));

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -120,6 +120,8 @@ public class QuickLookupWindowMarkupTests
         Assert.Equal("2", (string?)confirmation.Attribute("Grid.RowSpan"));
         Assert.Equal("False", (string?)confirmation.Attribute("IsHitTestVisible"));
         Assert.Equal("Collapsed", (string?)confirmation.Attribute("Visibility"));
+        Assert.Equal("{DynamicResource AppHeaderBg}", (string?)confirmation.Attribute("Background"));
+        Assert.Equal("{DynamicResource AppButtonBorder}", (string?)confirmation.Attribute("BorderBrush"));
         Assert.Equal("Grid", confirmation.Parent?.Name.LocalName);
         Assert.Equal("BodyHost", (string?)confirmation.ElementsBeforeSelf().Last().Attribute(X + "Name"));
     }

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -79,9 +79,23 @@ public class QuickLookupWindowMarkupTests
 
         Assert.Equal("NoWrap", (string?)result.Attribute("TextWrapping"));
         Assert.Equal("CharacterEllipsis", (string?)result.Attribute("TextTrimming"));
-        Assert.Equal("13", (string?)result.Attribute("FontSize"));
+        Assert.Equal("14", (string?)result.Attribute("FontSize"));
         Assert.Equal("Bold", (string?)result.Attribute("FontWeight"));
-        Assert.Equal("{DynamicResource AppTextPrimary}", (string?)result.Attribute("Foreground"));
+        Assert.Equal("{Binding Foreground, ElementName=TranslatedText}", (string?)result.Attribute("Foreground"));
+    }
+
+    /// <summary>The compact result exposes the same target-language speech action as the full result.</summary>
+    [Fact]
+    public void The_compact_translation_reuses_the_full_result_tts_action()
+    {
+        var button = Window()
+            .Descendants()
+            .Single(e => (string?)e.Attribute(X + "Name") == "CompactTgtTtsBtn");
+
+        Assert.Equal("{StaticResource HeaderIconButton}", (string?)button.Attribute("Style"));
+        Assert.Equal("{Binding Content, ElementName=TgtTtsBtn}", (string?)button.Attribute("Content"));
+        Assert.Equal("{Binding Visibility, ElementName=CompactTranslatedText}", (string?)button.Attribute("Visibility"));
+        Assert.Equal("TgtTtsBtn_Click", (string?)button.Attribute("Click"));
     }
 
     /// <summary>

--- a/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
+++ b/tests/OverTranslate.Tests/QuickLookupWindowMarkupTests.cs
@@ -69,19 +69,22 @@ public class QuickLookupWindowMarkupTests
         Assert.Equal("0", (string?)toggle.Parent?.Attribute("Grid.Column"));
     }
 
-    /// <summary>The compact preview must stay compact even when the translation is long.</summary>
+    /// <summary>The compact preview wraps long translations while keeping the speech action beside them.</summary>
     [Fact]
-    public void The_compact_translation_is_one_trimmed_line()
+    public void The_compact_translation_wraps_before_the_tts_action()
     {
         var result = Window()
             .Descendants()
             .Single(e => (string?)e.Attribute(X + "Name") == "CompactTranslatedText");
 
-        Assert.Equal("NoWrap", (string?)result.Attribute("TextWrapping"));
-        Assert.Equal("CharacterEllipsis", (string?)result.Attribute("TextTrimming"));
+        Assert.Equal("Wrap", (string?)result.Attribute("TextWrapping"));
+        Assert.Equal("540", (string?)result.Attribute("MaxWidth"));
+        Assert.Null((string?)result.Attribute("TextTrimming"));
         Assert.Equal("14", (string?)result.Attribute("FontSize"));
-        Assert.Equal("Bold", (string?)result.Attribute("FontWeight"));
+        Assert.Equal("SemiBold", (string?)result.Attribute("FontWeight"));
+        Assert.Equal("20", (string?)result.Attribute("LineHeight"));
         Assert.Equal("{Binding Foreground, ElementName=TranslatedText}", (string?)result.Attribute("Foreground"));
+        Assert.Equal("Horizontal", (string?)result.Parent?.Attribute("Orientation"));
     }
 
     /// <summary>The compact result exposes the same target-language speech action as the full result.</summary>

--- a/tests/OverTranslate.Tests/SelectedTextReaderTests.cs
+++ b/tests/OverTranslate.Tests/SelectedTextReaderTests.cs
@@ -14,6 +14,19 @@ namespace OverTranslate.Tests;
 public class SelectedTextReaderTests
 {
     [Fact]
+    public async Task The_copy_chord_is_released_only_after_its_hold_interval()
+    {
+        var events = new List<string>();
+
+        await SelectedTextReader.HoldCopyChordAsync(
+            () => events.Add("press"),
+            () => { events.Add("hold"); return Task.CompletedTask; },
+            () => events.Add("release"));
+
+        Assert.Equal(["press", "hold", "release"], events);
+    }
+
+    [Fact]
     public async Task A_clipboard_change_before_text_is_ready_is_not_mistaken_for_no_selection()
     {
         var sequences = new Queue<uint>(new uint[] { 10, 11, 11 });

--- a/tests/OverTranslate.Tests/SettingsParsingTests.cs
+++ b/tests/OverTranslate.Tests/SettingsParsingTests.cs
@@ -189,6 +189,7 @@ public class SettingsParsingTests
         Assert.Equal("Dark", settings.Theme);
         Assert.Equal("Ctrl+Alt+A", settings.HotkeyDisplay);
         Assert.Equal(LanguageData.AutomaticSourceLanguage, settings.SourceLanguage);
+        Assert.False(settings.QuickLookup.AutoCopyTranslation);
     }
 
     // A round trip has to survive, or the tolerant read would quietly drop values on every save.
@@ -219,6 +220,10 @@ public class SettingsParsingTests
             Capture =
             {
                 VerticalText = true,
+            },
+            QuickLookup =
+            {
+                AutoCopyTranslation = true,
             },
             Realtime =
             {
@@ -260,6 +265,7 @@ public class SettingsParsingTests
         Assert.Equal("Ctrl+Shift+D", settings.RealtimePauseHotkeyDisplay);
         Assert.False(settings.RealtimePauseHotkeyEnabled);
         Assert.True(settings.Capture.VerticalText);
+        Assert.True(settings.QuickLookup.AutoCopyTranslation);
         Assert.Equal(3, settings.Realtime.BlockCount);
         Assert.Equal(RealtimeCaptureMode.Window, settings.Realtime.CaptureMode);
         Assert.Equal(@"\\.\DISPLAY2", settings.Realtime.CaptureScreenDeviceName);
@@ -338,17 +344,19 @@ public class SettingsParsingTests
 
         var lastFlatKey = json.IndexOf("\"SkippedUpdateVersion\"", StringComparison.Ordinal);
         var captureGroup = json.IndexOf("\"Capture\":", StringComparison.Ordinal);
+        var quickLookupGroup = json.IndexOf("\"QuickLookup\":", StringComparison.Ordinal);
         var realtimeGroup = json.IndexOf("\"Realtime\":", StringComparison.Ordinal);
         var rootKeys = System.Text.Json.JsonDocument.Parse(json).RootElement
             .EnumerateObject()
             .Select(property => property.Name)
             .ToList();
 
-        Assert.True(lastFlatKey >= 0 && captureGroup >= 0 && realtimeGroup >= 0);
+        Assert.True(
+            lastFlatKey >= 0 && captureGroup >= 0 && quickLookupGroup >= 0 && realtimeGroup >= 0);
         Assert.True(
             captureGroup > lastFlatKey,
             "grouped settings must be written after every flat one");
-        Assert.Equal(["Capture", "Realtime"], rootKeys.TakeLast(2));
+        Assert.Equal(["Capture", "QuickLookup", "Realtime"], rootKeys.TakeLast(3));
     }
 
     // Written before either shortcut could be switched off: both have to come back on, or upgrading

--- a/tests/OverTranslate.Tests/SettingsParsingTests.cs
+++ b/tests/OverTranslate.Tests/SettingsParsingTests.cs
@@ -190,6 +190,7 @@ public class SettingsParsingTests
         Assert.Equal("Ctrl+Alt+A", settings.HotkeyDisplay);
         Assert.Equal(LanguageData.AutomaticSourceLanguage, settings.SourceLanguage);
         Assert.False(settings.QuickLookup.AutoCopyTranslation);
+        Assert.False(settings.QuickLookup.ResultsCollapsed);
     }
 
     // A round trip has to survive, or the tolerant read would quietly drop values on every save.
@@ -224,6 +225,7 @@ public class SettingsParsingTests
             QuickLookup =
             {
                 AutoCopyTranslation = true,
+                ResultsCollapsed = true,
             },
             Realtime =
             {
@@ -266,6 +268,7 @@ public class SettingsParsingTests
         Assert.False(settings.RealtimePauseHotkeyEnabled);
         Assert.True(settings.Capture.VerticalText);
         Assert.True(settings.QuickLookup.AutoCopyTranslation);
+        Assert.True(settings.QuickLookup.ResultsCollapsed);
         Assert.Equal(3, settings.Realtime.BlockCount);
         Assert.Equal(RealtimeCaptureMode.Window, settings.Realtime.CaptureMode);
         Assert.Equal(@"\\.\DISPLAY2", settings.Realtime.CaptureScreenDeviceName);


### PR DESCRIPTION
## 摘要

- 新增取詞翻譯自動複製結果設定，獨立保存於 QuickLookup 分類並提供中英文文案
- 新增可記憶的翻譯結果收起模式、精簡結果朗讀按鈕與釘選時 Esc 清空輸入
- 新增符合深淺主題的視窗內複製提示，停留 1.5 秒後淡出
- 改善遊戲中取詞快捷鍵的按鍵注入時序與剪貼簿等待穩定性

## 驗證

- SelectedTextReaderTests：7/7 通過
- QuickLookupWindowMarkupTests：9/9 通過
- 已在遊戲內實測取詞穩定性與空選取延遲