### PR TITLE
fix: 修正提示視窗複製按鈕在剪貼簿被佔用時導致程式崩潰

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -45,6 +45,7 @@
     <!-- ── Toast ── -->
     <sys:String x:Key="S.Toast.CopyMessage">Copy message</sys:String>
     <sys:String x:Key="S.Toast.Copied">Copied to the clipboard</sys:String>
+    <sys:String x:Key="S.Toast.CopyFailed">✗ Could not copy — the message stays above.</sys:String>
 
     <!-- ── Update ── -->
     <sys:String x:Key="S.Update.WindowTitle">Update available</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -45,7 +45,7 @@
     <!-- ── Toast ── -->
     <sys:String x:Key="S.Toast.CopyMessage">Copy message</sys:String>
     <sys:String x:Key="S.Toast.Copied">Copied to the clipboard</sys:String>
-    <sys:String x:Key="S.Toast.CopyFailed">✗ Could not copy — the message stays above.</sys:String>
+    <sys:String x:Key="S.Toast.CopyFailed">Copy failed. Please try again later.</sys:String>
 
     <!-- ── Update ── -->
     <sys:String x:Key="S.Update.WindowTitle">Update available</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -45,7 +45,7 @@
     <!-- ── Toast ── -->
     <sys:String x:Key="S.Toast.CopyMessage">複製訊息</sys:String>
     <sys:String x:Key="S.Toast.Copied">已複製到剪貼簿</sys:String>
-    <sys:String x:Key="S.Toast.CopyFailed">✗ 無法複製，訊息仍在上方。</sys:String>
+    <sys:String x:Key="S.Toast.CopyFailed">複製失敗，請稍後再試。</sys:String>
 
     <!-- ── Update ── -->
     <sys:String x:Key="S.Update.WindowTitle">發現新版本</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -45,6 +45,7 @@
     <!-- ── Toast ── -->
     <sys:String x:Key="S.Toast.CopyMessage">複製訊息</sys:String>
     <sys:String x:Key="S.Toast.Copied">已複製到剪貼簿</sys:String>
+    <sys:String x:Key="S.Toast.CopyFailed">✗ 無法複製，訊息仍在上方。</sys:String>
 
     <!-- ── Update ── -->
     <sys:String x:Key="S.Update.WindowTitle">發現新版本</sys:String>

--- a/src/OverTranslate/Views/Shell/ToastWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ToastWindow.xaml.cs
@@ -218,28 +218,56 @@ public partial class ToastWindow : Window
 
     /// <remarks>
     /// The clipboard belongs to whatever else is running, and any of it can hold the clipboard open
-    /// long enough for this to fail. WPF already retries for about a second before throwing, so the
-    /// throw means it is genuinely taken — and left unhandled it reaches the dispatcher and takes
-    /// the whole app down over a copy button on a toast the reader was about to dismiss anyway.
+    /// long enough for this to fail — WPF already retries for about a second before throwing. Left
+    /// unhandled that throw reaches the dispatcher and takes the whole app down, over a copy button
+    /// on a toast the reader was about to dismiss anyway.
     /// </remarks>
     private void CopyButton_Click(object sender, RoutedEventArgs e)
     {
+        var text = $"{TitleText.Text}\n{MessageText.Text}";
+        var copied = TryCopy(text);
+
+        // Confirm in place: the toast is about to be dismissed by the pointer leaving, so a second
+        // toast announcing the copy would replace this one and lose the message just copied. On a
+        // failure the message is still on screen above this line, which is where the reader gets it
+        // from instead.
+        ShowCopyHint(
+            copied ? "S.Toast.Copied" : "S.Toast.CopyFailed",
+            copied ? "AppSuccess" : "AppError");
+    }
+
+    /// <remarks>
+    /// A throw does not settle whether the text was copied. SetText publishes it and then flushes
+    /// it so it outlives this process, and the flush is the half that fails most often — which
+    /// leaves the text on the clipboard, pasteable until OverTranslate exits. Telling the reader it
+    /// failed when their next paste would have worked is the worse of the two mistakes, so ask the
+    /// clipboard what actually happened rather than inferring it from the exception.
+    /// </remarks>
+    private static bool TryCopy(string text)
+    {
         try
         {
-            System.Windows.Clipboard.SetText($"{TitleText.Text}\n{MessageText.Text}");
+            System.Windows.Clipboard.SetText(text);
+            return true;
         }
         catch (Exception ex)
         {
-            // The message stays on screen behind this line, which is where the reader can still get
-            // it from — so the hint says the copy failed rather than pretending it succeeded.
             Log.Warn(ex, "Could not copy the toast message to the clipboard");
-            ShowCopyHint("S.Toast.CopyFailed", "AppError");
-            return;
         }
 
-        // Confirm in place: the toast is about to be dismissed by the pointer leaving, so a second
-        // toast announcing the copy would replace this one and lose the message just copied.
-        ShowCopyHint("S.Toast.Copied", "AppSuccess");
+        try
+        {
+            return System.Windows.Clipboard.ContainsText()
+                && System.Windows.Clipboard.GetText() == text;
+        }
+        catch (Exception ex)
+        {
+            // Whatever holds the clipboard shut holds it shut both ways. Unreadable is not the same
+            // as absent, but from here the two are indistinguishable and the safe answer is the one
+            // that leaves the message on screen.
+            Log.Trace(ex, "Could not read the clipboard back after a failed copy");
+            return false;
+        }
     }
 
     // Resource references rather than literals so the line follows a language or theme change the

--- a/src/OverTranslate/Views/Shell/ToastWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ToastWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Media.Animation;
 using System.Windows.Shapes;
 using System.Windows.Threading;
+using NLog;
 using OverTranslate.Services;
 
 namespace OverTranslate.Views.Shell;
@@ -16,6 +17,8 @@ public enum ToastKind
 
 public partial class ToastWindow : Window
 {
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
     private const int DisplayMs = 3000;
     private const int FadeMs    = 350;
 
@@ -213,12 +216,38 @@ public partial class ToastWindow : Window
         BeginAnimation(OpacityProperty, fade);
     }
 
+    /// <remarks>
+    /// The clipboard belongs to whatever else is running, and any of it can hold the clipboard open
+    /// long enough for this to fail. WPF already retries for about a second before throwing, so the
+    /// throw means it is genuinely taken — and left unhandled it reaches the dispatcher and takes
+    /// the whole app down over a copy button on a toast the reader was about to dismiss anyway.
+    /// </remarks>
     private void CopyButton_Click(object sender, RoutedEventArgs e)
     {
-        System.Windows.Clipboard.SetText($"{TitleText.Text}\n{MessageText.Text}");
+        try
+        {
+            System.Windows.Clipboard.SetText($"{TitleText.Text}\n{MessageText.Text}");
+        }
+        catch (Exception ex)
+        {
+            // The message stays on screen behind this line, which is where the reader can still get
+            // it from — so the hint says the copy failed rather than pretending it succeeded.
+            Log.Warn(ex, "Could not copy the toast message to the clipboard");
+            ShowCopyHint("S.Toast.CopyFailed", "AppError");
+            return;
+        }
 
         // Confirm in place: the toast is about to be dismissed by the pointer leaving, so a second
         // toast announcing the copy would replace this one and lose the message just copied.
+        ShowCopyHint("S.Toast.Copied", "AppSuccess");
+    }
+
+    // Resource references rather than literals so the line follows a language or theme change the
+    // same way the rest of the toast does.
+    private void ShowCopyHint(string textKey, string brushKey)
+    {
+        CopyHint.SetResourceReference(System.Windows.Controls.TextBlock.TextProperty, textKey);
+        CopyHint.SetResourceReference(System.Windows.Controls.TextBlock.ForegroundProperty, brushKey);
         CopyHint.Visibility = Visibility.Visible;
     }
 

--- a/src/OverTranslate/Views/Shell/ToastWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ToastWindow.xaml.cs
@@ -45,8 +45,17 @@ public partial class ToastWindow : Window
     private bool _userDismissed;
 
     /// <summary>Shows a toast, replacing whichever one is currently on screen.</summary>
+    /// <remarks>
+    /// Here rather than at the call sites: half of them reach a toast without logging anything of
+    /// their own, so a report that says "an error popped up" cannot be matched to a message. The
+    /// title is enough to identify which one, and unlike the message it is always a fixed resource
+    /// string — a message can carry an exception's text or a path, and the translation failures
+    /// carry whatever was being translated.
+    /// </remarks>
     public static void Show(string title, string message, Rect? selPhysRect = null, ToastKind kind = ToastKind.Info)
     {
+        Log.Info("Toast shown, kind={Kind}, title=\"{Title}\"", kind, title);
+
         Dismiss();
 
         var toast = new ToastWindow(title, message, selPhysRect, kind);
@@ -248,6 +257,11 @@ public partial class ToastWindow : Window
         try
         {
             System.Windows.Clipboard.SetText(text);
+
+            // Debug rather than Info: on its own a successful copy is not worth a line in everyone's
+            // log, but without it a log cannot tell a copy that worked from a button that was never
+            // pressed — which is exactly the question when someone reports the copy doing nothing.
+            Log.Debug("Toast message copied to the clipboard");
             return true;
         }
         catch (Exception ex)
@@ -257,8 +271,15 @@ public partial class ToastWindow : Window
 
         try
         {
-            return System.Windows.Clipboard.ContainsText()
+            var landed = System.Windows.Clipboard.ContainsText()
                 && System.Windows.Clipboard.GetText() == text;
+
+            // Pairs with the warning above: it says the copy threw, this says whether the text got
+            // there anyway. Without both, that warning reads as a failure the user never saw.
+            Log.Debug(landed
+                ? "Toast message was on the clipboard despite the failed copy"
+                : "Toast message did not reach the clipboard");
+            return landed;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## 起因

使用者回報的診斷包（回報代碼 `G8E8ZK`，v2.1.1）裡有兩次未處理例外，同一個原因：

```
System.Runtime.InteropServices.COMException (0x800401D0 CLIPBRD_E_CANT_OPEN)
   at System.Windows.Clipboard.Flush()
   at OverTranslate.Views.Shell.ToastWindow.CopyButton_Click
[ERROR] App — Unhandled UI exception
```

提示視窗右上角的「複製訊息」按鈕直接呼叫 `Clipboard.SetText`，沒有任何防護。剪貼簿被其他程式鎖住時丟出的 COMException 會一路冒到 dispatcher，把整個 App 帶走。App 內其他三個複製點（取詞翻譯、設定頁回報代碼、截圖複製）都有 try/catch，就這一個漏掉。

## 改了什麼

**1. 不再當機**

`CopyButton_Click` 包上 try/catch，失敗時寫 `Log.Warn` 並在提示視窗原地顯示紅色提示，不再讓例外逃到 dispatcher。

**2. 以剪貼簿的實際狀態回報，而不是以例外回報**

`Clipboard.SetText` 是「先把文字放上剪貼簿，再 `Flush` 讓它在程式關閉後仍留存」，而回報者的 stack 停在 `Flush()` —— 文字其實已經在剪貼簿上了。因此改成：`SetText` 丟例外後回讀剪貼簿比對內容，一致就照樣顯示「已複製」，真的沒有才顯示失敗。回讀本身也可能被鎖住，那層一併 catch，讀不到就當作沒複製到。

沒有另外加重試迴圈：WPF 內部已經重試 10 次約 1 秒，再包一層只是多凍 UI 一秒。

**3. 補上診斷用的記錄**

- `ToastWindow.Show` 加一行 INFO，記錄 toast 的 kind 與 title。11 個 toast 呼叫點裡有一半在跳 toast 前不寫任何 log，導致這次無法從診斷包判斷當機當下畫面上是哪一則訊息，只能靠「哪些路徑會留 log」反推。只記 title 不記 message：title 全部是固定資源字串，而 message 可能夾帶例外內容、路徑或被翻譯的文字。
- `TryCopy` 的三種結果各記一行 DEBUG（勾選「記錄詳細資訊」時才會寫）。其中「例外但文字已在剪貼簿上」那行是刻意加的，否則 WARN 單獨出現會被誤讀成使用者複製失敗。

## 新增字串

`S.Toast.CopyFailed`：`Copy failed. Please try again later.` / `複製失敗，請稍後再試。`

## 驗證

- build 成功。
- 測試 675 passed / 2 failed。那 2 個是 `LocalizedLineBreakTests.TheDiagnosticsHints_KeepTheirLineBreak`，在乾淨的 `main` 上同樣是紅的，屬於既有的 `xml:space="preserve"` 問題，與本 PR 無關。
- 用一支拋棄式 WPF probe 載入真正的主題與字串資源算繪 `ToastWindow`，確認深色／淺色、中文／英文四種組合下提示行都能正常顯示、不截字，且失敗與成功兩種狀態高度相同（視窗不會跳動）。

## 已知、本 PR 未處理

提示視窗在兩個主題下都是同一個深色底（`ToastBg` / `ToastTitle` / `ToastMessage` 在 DarkTheme.xaml 與 LightTheme.xaml 的值相同），但 `AppError` / `AppSuccess` 會跟著主題換。因此在淺色主題下，提示行是 `#C42B1C` 落在 `#202020` 上，對比 2.9:1，低於 4.5:1。這不是本 PR 帶入的：既有的綠色「已複製」用 `#0F7B0F`，同一底色上是 3.0:1，一樣不足。修正方向是給提示視窗一組固定的狀態色，不再沿用跟著主題走的那兩個，超出本次修 crash 的範圍。
