### PR TITLE
feat: 拆開診斷資訊的匯出與上傳，上傳前可附上問題說明

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -420,7 +420,7 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsExportedHint">The file is on your device and nothing has been sent. Upload sends it to the developer, together with a note about what went wrong. Open file to see what it contains.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNoEndpointHint">The file is on your device and nothing has been sent. Report the problem through GitHub or the forum and attach it. Open file to see what it contains.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Diagnostics exported</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully. Open file to see what was exported this time.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">The diagnostics were uploaded. If you have more to add, give this report code through GitHub or the forum. Open file to see what was exported this time.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file. Open file to get what was exported this time.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsRetention">Files are deleted automatically after 30 days</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">Copy</sys:String>
@@ -448,9 +448,9 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">⚠ The diagnostics were exported but could not be uploaded</sys:String>
 
     <!-- ── Diagnostics note ── -->
-    <sys:String x:Key="S.Settings.NoteTitle">Tell the developer what happened</sys:String>
-    <sys:String x:Key="S.Settings.NoteIntro">The diagnostics say what the app was doing. This is where you say what you were doing — it goes up with the file. You can leave it empty.</sys:String>
-    <sys:String x:Key="S.Settings.NotePlaceholder" xml:space="preserve">What went wrong, and what you were doing at the time.&#x0a;Anything that makes it happen again is the most useful thing you can write here.</sys:String>
+    <sys:String x:Key="S.Settings.NoteTitle">Report a problem</sys:String>
+    <sys:String x:Key="S.Settings.NoteIntro">What you write here is sent together with the diagnostics, and is used only to help work out what went wrong.</sys:String>
+    <sys:String x:Key="S.Settings.NotePlaceholder">Add what you were doing when the problem appeared, or anything else that might be related — it helps the developer find the cause sooner. This field can be left empty.</sys:String>
     <sys:String x:Key="S.Settings.NoteSending">Uploading…</sys:String>
     <sys:String x:Key="S.Settings.NoteUploadFailed">The upload did not go through. The file is still on your device, so you can try again.</sys:String>
     <sys:String x:Key="S.Settings.NoteAttachFailed">Your message could not be written into the file, so nothing was sent. Please try again.</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -12,6 +12,7 @@
     <!-- ── Shared ── -->
     <sys:String x:Key="S.Common.Reset">Reset</sys:String>
     <sys:String x:Key="S.Common.Close">Close</sys:String>
+    <sys:String x:Key="S.Common.Cancel">Cancel</sys:String>
     <sys:String x:Key="S.Common.Configure">Configure</sys:String>
     <sys:String x:Key="S.Common.ApiKey">API key</sys:String>
 
@@ -412,9 +413,12 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open folder</sys:String>
-    <sys:String x:Key="S.Settings.UploadDiagnostics">Upload diagnostics</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">The diagnostics contain the log files, system information and your current settings, with sensitive data replaced.&#x0a;The diagnostic file is kept on your device and deleted automatically after 30 days.</sys:String>
+    <sys:String x:Key="S.Settings.UploadBundle">Upload</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedTitle">Diagnostics exported</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedHint">The file is on your device and nothing has been sent. Upload sends it to the developer, together with a note about what went wrong. Open file to see what it contains.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNoEndpointHint">The file is on your device and nothing has been sent. Report the problem through GitHub or the forum and attach it. Open file to see what it contains.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Diagnostics exported</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">Give this report code to the developer through GitHub or the forum — the diagnostics were uploaded successfully. Open file to see what was exported this time.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">The diagnostics were exported but could not be uploaded. Please report the problem through GitHub or the forum and attach the file. Open file to get what was exported this time.</sys:String>
@@ -437,11 +441,20 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ Could not open the folder: {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsExported">✓ Diagnostics exported</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ Could not export diagnostics: {0}</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploading">Collecting and uploading…</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExporting">Collecting diagnostics…</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ Uploaded — code {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ Code copied</sys:String>
     <sys:String x:Key="S.Settings.CopyFailed">✗ Could not copy — read the code from the box above.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">⚠ The diagnostics were exported but could not be uploaded</sys:String>
+
+    <!-- ── Diagnostics note ── -->
+    <sys:String x:Key="S.Settings.NoteTitle">Tell the developer what happened</sys:String>
+    <sys:String x:Key="S.Settings.NoteIntro">The diagnostics say what the app was doing. This is where you say what you were doing — it goes up with the file. You can leave it empty.</sys:String>
+    <sys:String x:Key="S.Settings.NotePlaceholder" xml:space="preserve">What went wrong, and what you were doing at the time.&#x0a;Anything that makes it happen again is the most useful thing you can write here.</sys:String>
+    <sys:String x:Key="S.Settings.NoteSending">Uploading…</sys:String>
+    <sys:String x:Key="S.Settings.NoteUploadFailed">The upload did not go through. The file is still on your device, so you can try again.</sys:String>
+    <sys:String x:Key="S.Settings.NoteAttachFailed">Your message could not be written into the file, so nothing was sent. Please try again.</sys:String>
+    <sys:String x:Key="S.Settings.NoteReportManually">Report it on GitHub instead</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} is already assigned to "{1}"</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -416,8 +416,8 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">The diagnostics contain the log files, system information and your current settings, with sensitive data replaced.&#x0a;The diagnostic file is kept on your device and deleted automatically after 30 days.</sys:String>
     <sys:String x:Key="S.Settings.UploadBundle">Upload</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">Report code</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsExportedTitle">Diagnostics exported</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsExportedHint">The file is on your device and nothing has been sent. Upload sends it to the developer, together with a note about what went wrong. Open file to see what it contains.</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedTitle">Exported, not uploaded yet</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedHint">The file is saved on your device and has not been uploaded. Upload sends the diagnostics to the developer together with your own account of the problem; Open file shows what it contains.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNoEndpointHint">The file is on your device and nothing has been sent. Report the problem through GitHub or the forum and attach it. Open file to see what it contains.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">Diagnostics exported</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">The diagnostics were uploaded. If you have more to add, give this report code through GitHub or the forum. Open file to see what was exported this time.</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -440,8 +440,8 @@
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">診斷資訊包含記錄檔、系統資訊與目前設定，敏感資料會被替換。&#x0a;診斷檔會保留在本機，並於 30 天後自動刪除。</sys:String>
     <sys:String x:Key="S.Settings.UploadBundle">上傳</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsExportedTitle">診斷資訊已匯出</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsExportedHint">檔案已存在你的電腦上，目前還沒有送出任何資料。按「上傳」可以連同問題說明一起交給開發者。按「開啟檔案」可查看內容。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedTitle">診斷資訊已匯出，尚未上傳</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedHint">檔案已儲存在你的電腦上，目前尚未上傳。按「上傳」可將診斷資訊與補充說明一併傳送給開發者；按「開啟檔案」可查看內容。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNoEndpointHint">檔案已存在你的電腦上，目前還沒有送出任何資料。請透過 GitHub 或論壇回報問題並附上此檔案。按「開啟檔案」可查看內容。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">診斷資訊已匯出</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">診斷資訊已成功上傳。如需進一步說明，可透過 GitHub 或論壇提供此回報代碼。按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -444,7 +444,7 @@
     <sys:String x:Key="S.Settings.DiagnosticsExportedHint">檔案已存在你的電腦上，目前還沒有送出任何資料。按「上傳」可以連同問題說明一起交給開發者。按「開啟檔案」可查看內容。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNoEndpointHint">檔案已存在你的電腦上，目前還沒有送出任何資料。請透過 GitHub 或論壇回報問題並附上此檔案。按「開啟檔案」可查看內容。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">診斷資訊已匯出</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsUploadedHint">診斷資訊已成功上傳。如需進一步說明，可透過 GitHub 或論壇提供此回報代碼。按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">診斷資訊已成功匯出，但無法上傳。請透過 GitHub 或論壇回報問題並附上檔案。按「開啟檔案」可取得本次匯出的診斷資訊。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsRetention">檔案將於 30 天後自動刪除</sys:String>
     <sys:String x:Key="S.Settings.CopyCode">複製</sys:String>
@@ -472,9 +472,9 @@
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">⚠ 診斷資訊已成功匯出，但無法進行上傳</sys:String>
 
     <!-- ── 診斷資訊說明 ── -->
-    <sys:String x:Key="S.Settings.NoteTitle">告訴開發者發生了什麼事</sys:String>
-    <sys:String x:Key="S.Settings.NoteIntro">診斷資訊記錄的是程式當時在做什麼，這裡則是你當時在做什麼，會跟著檔案一起送出。也可以留空。</sys:String>
-    <sys:String x:Key="S.Settings.NotePlaceholder" xml:space="preserve">發生了什麼問題，以及當下你正在做什麼。&#x0a;如果知道怎麼樣會再發生一次，那會是最有幫助的資訊。</sys:String>
+    <sys:String x:Key="S.Settings.NoteTitle">回報問題</sys:String>
+    <sys:String x:Key="S.Settings.NoteIntro">你填寫的內容會隨診斷資訊一起送出，僅用於協助問題排查。</sys:String>
+    <sys:String x:Key="S.Settings.NotePlaceholder">可補充問題發生時的操作情況或其他相關資訊，幫助開發者更快找到原因。此欄位可以留空。</sys:String>
     <sys:String x:Key="S.Settings.NoteSending">上傳中…</sys:String>
     <sys:String x:Key="S.Settings.NoteUploadFailed">這次沒有上傳成功。檔案還在你的電腦上，可以再試一次。</sys:String>
     <sys:String x:Key="S.Settings.NoteAttachFailed">無法將訊息寫入診斷檔案，因此沒有送出任何資料，請再試一次。</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -9,6 +9,7 @@
     <!-- ── Shared ── -->
     <sys:String x:Key="S.Common.Reset">重設</sys:String>
     <sys:String x:Key="S.Common.Close">關閉</sys:String>
+    <sys:String x:Key="S.Common.Cancel">取消</sys:String>
     <sys:String x:Key="S.Common.Configure">設定</sys:String>
     <sys:String x:Key="S.Common.ApiKey">API Key</sys:String>
 
@@ -436,9 +437,12 @@
     <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟資料夾</sys:String>
-    <sys:String x:Key="S.Settings.UploadDiagnostics">上傳診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadHint" xml:space="preserve">診斷資訊包含記錄檔、系統資訊與目前設定，敏感資料會被替換。&#x0a;診斷檔會保留在本機，並於 30 天後自動刪除。</sys:String>
+    <sys:String x:Key="S.Settings.UploadBundle">上傳</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeLabel">回報代碼</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedTitle">診斷資訊已匯出</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExportedHint">檔案已存在你的電腦上，目前還沒有送出任何資料。按「上傳」可以連同問題說明一起交給開發者。按「開啟檔案」可查看內容。</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsNoEndpointHint">檔案已存在你的電腦上，目前還沒有送出任何資料。請透過 GitHub 或論壇回報問題並附上此檔案。按「開啟檔案」可查看內容。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailedTitle">診斷資訊已匯出</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadedHint" xml:space="preserve">將此回報代碼透過 GitHub 或論壇提供給開發者即可，診斷資訊已成功上傳。按「開啟檔案」可查看本次匯出的診斷資訊。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsNotUploadedHint" xml:space="preserve">診斷資訊已成功匯出，但無法上傳。請透過 GitHub 或論壇回報問題並附上檔案。按「開啟檔案」可取得本次匯出的診斷資訊。</sys:String>
@@ -461,11 +465,20 @@
     <sys:String x:Key="S.Settings.OpenFolderFailed">✗ 無法開啟資料夾：{0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsExported">✓ 已匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsFailed">✗ 無法匯出診斷資訊：{0}</sys:String>
-    <sys:String x:Key="S.Settings.DiagnosticsUploading">正在整理並上傳…</sys:String>
+    <sys:String x:Key="S.Settings.DiagnosticsExporting">正在整理診斷資訊…</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploaded">✓ 已上傳，代碼 {0}</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsCodeCopied">✓ 已複製代碼</sys:String>
     <sys:String x:Key="S.Settings.CopyFailed">✗ 無法複製，請直接看上方顯示的代碼。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsUploadFailed">⚠ 診斷資訊已成功匯出，但無法進行上傳</sys:String>
+
+    <!-- ── 診斷資訊說明 ── -->
+    <sys:String x:Key="S.Settings.NoteTitle">告訴開發者發生了什麼事</sys:String>
+    <sys:String x:Key="S.Settings.NoteIntro">診斷資訊記錄的是程式當時在做什麼，這裡則是你當時在做什麼，會跟著檔案一起送出。也可以留空。</sys:String>
+    <sys:String x:Key="S.Settings.NotePlaceholder" xml:space="preserve">發生了什麼問題，以及當下你正在做什麼。&#x0a;如果知道怎麼樣會再發生一次，那會是最有幫助的資訊。</sys:String>
+    <sys:String x:Key="S.Settings.NoteSending">上傳中…</sys:String>
+    <sys:String x:Key="S.Settings.NoteUploadFailed">這次沒有上傳成功。檔案還在你的電腦上，可以再試一次。</sys:String>
+    <sys:String x:Key="S.Settings.NoteAttachFailed">無法將訊息寫入診斷檔案，因此沒有送出任何資料，請再試一次。</sys:String>
+    <sys:String x:Key="S.Settings.NoteReportManually">改用 GitHub 回報</sys:String>
     <sys:String x:Key="S.Settings.HotkeyTaken">✗ {0} 已指派給「{1}」</sys:String>
 
 </ResourceDictionary>

--- a/src/OverTranslate/Services/DiagnosticBundleService.cs
+++ b/src/OverTranslate/Services/DiagnosticBundleService.cs
@@ -142,6 +142,48 @@ public static class DiagnosticBundleService
         Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
     }
 
+    /// <summary>What the user's own account of the problem is called inside the bundle.</summary>
+    public const string NoteEntryName = "note.txt";
+
+    /// <summary>
+    /// As much as anyone writes into a box before they would rather be talking to a person, with
+    /// room to spare. It exists so the field has a limit at all, not to cut anybody off.
+    /// </summary>
+    public const int MaxNoteLength = 4000;
+
+    /// <summary>
+    /// Writes the user's own account of the problem into a bundle already on disk, replacing any
+    /// note it already carries. A blank note writes nothing. Blocking — call it off the UI thread.
+    /// </summary>
+    /// <remarks>
+    /// Into the zip rather than alongside the upload. The note is prose someone typed in their own
+    /// language and at whatever length they needed; the upload's headers are printable ASCII,
+    /// trimmed to 64 characters, and land in key metadata that is capped in kilobytes. It also
+    /// means the copy left on their disk says the same thing as the copy that was sent, and that
+    /// carrying a note costs the receiving end no change at all.
+    ///
+    /// Line endings are normalised because this is read in whatever the reader double-clicks, and
+    /// on Windows that is still sometimes something that renders a lone \n as one long line.
+    /// </remarks>
+    public static void AttachNote(string bundlePath, string note)
+    {
+        var text = note.Trim();
+        if (text.Length == 0) return;
+
+        using (var archive = ZipFile.Open(bundlePath, ZipArchiveMode.Update))
+        {
+            // Update appends, so a second attempt after a failed upload would otherwise leave two
+            // entries of the same name in the archive — legal in the format, and read back as
+            // whichever one the extractor happens to reach first.
+            archive.GetEntry(NoteEntryName)?.Delete();
+            AddText(archive, NoteEntryName, text.ReplaceLineEndings("\r\n"));
+        }
+
+        // Length only, never the text: it is the user's own words about their own machine, and it
+        // is already in the file this line is about.
+        Log.Info("Diagnostic note attached, {0} characters", text.Length);
+    }
+
     /// <summary>
     /// How long an export stays on disk, matching what the uploaded copy gets. One number for both,
     /// so the interface can state it once without having to say which copy it means.

--- a/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml
+++ b/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml
@@ -69,9 +69,20 @@
                                Margin="0,0,0,10"/>
 
                     <Grid>
+                        <!-- A fixed height, unlike the prompt editor this style was written for:
+                             that one is in a card that scrolls, while this card is centred on the
+                             screen, so a box that grew with the text would push the send button
+                             down the screen as someone typed towards it. The template's own
+                             scroller takes over instead. -->
+                        <!-- On the box rather than on the ScrollViewer inside the style's template,
+                             where it looks like it belongs and does nothing: TextBoxBase pushes its
+                             own value onto PART_ContentHost when the template is applied, and its
+                             own default is Hidden. The box scrolls either way — this is what makes
+                             the bar appear while it does. -->
                         <TextBox x:Name="NoteBox"
                                  Style="{StaticResource SettingsMultilineTextBox}"
-                                 MinHeight="150"
+                                 Height="150"
+                                 VerticalScrollBarVisibility="Auto"
                                  SpellCheck.IsEnabled="False"
                                  TextChanged="NoteBox_TextChanged"/>
                         <!-- IsHitTestVisible off so clicking the prompt still lands in the box -->

--- a/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml
+++ b/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml
@@ -1,0 +1,199 @@
+<UserControl x:Class="OverTranslate.Views.Settings.DiagnosticNoteOverlay"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Visibility="Collapsed"
+             Focusable="True">
+
+    <!-- Scrim: swallows clicks so the page underneath stays inert, and dismisses on click -->
+    <Grid x:Name="Scrim"
+          Background="#8C000000"
+          MouseLeftButtonDown="Scrim_MouseLeftButtonDown">
+
+        <Border x:Name="Card"
+                Width="520"
+                UseLayoutRounding="True"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                CornerRadius="12"
+                Background="{DynamicResource AppCardBg}"
+                BorderBrush="{DynamicResource AppBorder}"
+                BorderThickness="1"
+                RenderTransformOrigin="0.5,0.5"
+                MouseLeftButtonDown="Card_MouseLeftButtonDown">
+            <Border.RenderTransform>
+                <ScaleTransform x:Name="CardScale" ScaleX="1" ScaleY="1"/>
+            </Border.RenderTransform>
+            <Border.Effect>
+                <DropShadowEffect BlurRadius="28" ShadowDepth="6" Opacity="0.3" Color="#000000"/>
+            </Border.Effect>
+
+            <Grid Margin="24,18,24,18">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0" Margin="0,0,0,14">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="&#xE939;" Style="{StaticResource CardHeaderIcon}" FontSize="18"/>
+                        <TextBlock Text="{DynamicResource S.Settings.NoteTitle}"
+                                   FontFamily="{StaticResource AppFont}"
+                                   FontSize="17"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource AppTextPrimary}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <!-- Hidden while the upload is in flight, along with every other way out: the
+                         request is already on the wire and closing the card would leave the page
+                         behind it with no idea how it ended. -->
+                    <Button x:Name="CloseBtn"
+                            Style="{StaticResource OverlayCloseButton}"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            Margin="0,0,-8,0"
+                            ToolTip="{DynamicResource S.Common.Close}"
+                            Click="CloseBtn_Click"/>
+                </Grid>
+
+                <Rectangle Grid.Row="1" Height="1" Fill="{DynamicResource AppSeparator}"/>
+
+                <StackPanel Grid.Row="2" Margin="0,16,0,0">
+                    <TextBlock Text="{DynamicResource S.Settings.NoteIntro}"
+                               FontFamily="{StaticResource AppFont}"
+                               FontSize="{StaticResource AppFontSize}"
+                               Foreground="{DynamicResource AppTextSecondary}"
+                               TextWrapping="Wrap"
+                               LineHeight="20"
+                               Margin="0,0,0,10"/>
+
+                    <Grid>
+                        <TextBox x:Name="NoteBox"
+                                 Style="{StaticResource SettingsMultilineTextBox}"
+                                 MinHeight="150"
+                                 SpellCheck.IsEnabled="False"
+                                 TextChanged="NoteBox_TextChanged"/>
+                        <!-- IsHitTestVisible off so clicking the prompt still lands in the box -->
+                        <TextBlock x:Name="NotePlaceholder"
+                                   Text="{DynamicResource S.Settings.NotePlaceholder}"
+                                   IsHitTestVisible="False"
+                                   FontFamily="{StaticResource AppFont}"
+                                   FontSize="{StaticResource AppFontSize}"
+                                   Foreground="{DynamicResource AppTextSecondary}"
+                                   Opacity="0.7"
+                                   Margin="15,11,15,0"
+                                   LineHeight="21"
+                                   VerticalAlignment="Top"
+                                   TextWrapping="Wrap"/>
+                    </Grid>
+
+                    <!-- What is actually about to leave the machine, named next to the box that is
+                         about to send it. The file name is the one thing here the user can check
+                         against what they exported a moment ago. -->
+                    <StackPanel Orientation="Horizontal" Margin="2,10,0,0">
+                        <TextBlock Text="&#xE7C3;"
+                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource AppTextSecondary}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,6,0"/>
+                        <TextBlock x:Name="BundleNameText"
+                                   FontFamily="{StaticResource AppFont}"
+                                   FontSize="12"
+                                   Foreground="{DynamicResource AppTextSecondary}"
+                                   TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <!-- The failure state stays inside the card rather than dismissing it: what was
+                         typed is still in the box, the button is still there to press again, and the
+                         one thing that changes is that there is now a way out that does not need the
+                         upload to work. -->
+                    <Border x:Name="FailurePanel"
+                            Visibility="Collapsed"
+                            Margin="0,12,0,0"
+                            Background="{DynamicResource AppInputBg}"
+                            BorderBrush="{DynamicResource AppBorder}"
+                            BorderThickness="1"
+                            CornerRadius="6"
+                            Padding="12,10">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#xE7BA;"
+                                       FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                       FontSize="13"
+                                       Foreground="{DynamicResource AppError}"
+                                       VerticalAlignment="Top"
+                                       Margin="0,1,9,0"/>
+                            <TextBlock x:Name="FailureText"
+                                       FontFamily="{StaticResource AppFont}"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource AppTextSecondary}"
+                                       TextWrapping="Wrap"
+                                       LineHeight="18"
+                                       MaxWidth="404">
+                                <Run x:Name="FailureRun"/>
+                                <LineBreak/>
+                                <Hyperlink NavigateUri="https://github.com/asd880921/OverTranslate/issues"
+                                           RequestNavigate="Hyperlink_RequestNavigate"><Run Text="{DynamicResource S.Settings.NoteReportManually}"/></Hyperlink>
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <StackPanel Grid.Row="3"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right"
+                            Margin="0,18,0,0">
+                    <Button x:Name="CancelBtn"
+                            Style="{StaticResource FlatButton}"
+                            Height="34"
+                            Padding="18,0"
+                            Margin="0,0,8,0"
+                            Content="{DynamicResource S.Common.Cancel}"
+                            Click="CancelBtn_Click"/>
+
+                    <Button x:Name="SendBtn"
+                            Style="{StaticResource AccentButton}"
+                            Height="34"
+                            Padding="18,0"
+                            Click="SendBtn_Click">
+                        <StackPanel Orientation="Horizontal">
+                            <!-- Same ring as the overlay's own processing indicator, at the size
+                                 this button's text is set in. Collapsed until the press, so the
+                                 button reads as a button rather than as something already working. -->
+                            <Viewbox x:Name="SendSpinner"
+                                     Width="13" Height="13"
+                                     Visibility="Collapsed"
+                                     Margin="0,0,8,0"
+                                     VerticalAlignment="Center">
+                                <Path Data="M 8,0 A 8,8 0 1 1 0,8 L 2.2,8 A 5.8,5.8 0 1 0 8,2.2 Z"
+                                      Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      RenderTransformOrigin="0.5,0.5">
+                                    <Path.RenderTransform>
+                                        <RotateTransform/>
+                                    </Path.RenderTransform>
+                                    <Path.Triggers>
+                                        <EventTrigger RoutedEvent="Path.Loaded">
+                                            <BeginStoryboard>
+                                                <Storyboard RepeatBehavior="Forever">
+                                                    <DoubleAnimation Storyboard.TargetProperty="RenderTransform.Angle"
+                                                                     From="0"
+                                                                     To="360"
+                                                                     Duration="0:0:0.9"/>
+                                                </Storyboard>
+                                            </BeginStoryboard>
+                                        </EventTrigger>
+                                    </Path.Triggers>
+                                </Path>
+                            </Viewbox>
+                            <TextBlock x:Name="SendLabel"
+                                       Text="{DynamicResource S.Settings.UploadBundle}"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml
+++ b/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml
@@ -32,12 +32,11 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <Grid Grid.Row="0" Margin="0,0,0,14">
+                <Grid Grid.Row="0" Margin="0,0,0,2">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock Text="&#xE939;" Style="{StaticResource CardHeaderIcon}" FontSize="18"/>
+                        <TextBlock Text="&#xE8BD;" Style="{StaticResource CardHeaderIcon}" FontSize="18"/>
                         <TextBlock Text="{DynamicResource S.Settings.NoteTitle}"
                                    FontFamily="{StaticResource AppFont}"
                                    FontSize="17"
@@ -57,9 +56,10 @@
                             Click="CloseBtn_Click"/>
                 </Grid>
 
-                <Rectangle Grid.Row="1" Height="1" Fill="{DynamicResource AppSeparator}"/>
-
-                <StackPanel Grid.Row="2" Margin="0,16,0,0">
+                <!-- No rule under the header. The card is one question with one field: a line across
+                     it divides nothing, and the intro underneath is the title's own second sentence
+                     rather than a separate section. -->
+                <StackPanel Grid.Row="1" Margin="0,14,0,0">
                     <TextBlock Text="{DynamicResource S.Settings.NoteIntro}"
                                FontFamily="{StaticResource AppFont}"
                                FontSize="{StaticResource AppFontSize}"
@@ -141,7 +141,7 @@
                     </Border>
                 </StackPanel>
 
-                <StackPanel Grid.Row="3"
+                <StackPanel Grid.Row="2"
                             Orientation="Horizontal"
                             HorizontalAlignment="Right"
                             Margin="0,18,0,0">

--- a/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml.cs
+++ b/src/OverTranslate/Views/Settings/DiagnosticNoteOverlay.xaml.cs
@@ -1,0 +1,300 @@
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Navigation;
+using NLog;
+using OverTranslate.Services;
+// UseWindowsForms puts System.Windows.Forms in the implicit usings, so these names collide
+using UserControl = System.Windows.Controls.UserControl;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
+
+namespace OverTranslate.Views.Settings;
+
+/// <summary>
+/// How the note panel ended: a code if the bundle went up, and whether an attempt was made and
+/// failed. Both false-ish means it was dismissed without sending anything.
+/// </summary>
+public sealed record DiagnosticNoteResult(string? Code, bool AttemptFailed);
+
+/// <summary>
+/// Modal panel that collects what the user wants to say about the problem, attaches it to the
+/// bundle they have already exported, and sends the two together.
+/// </summary>
+/// <remarks>
+/// The reason this exists at all: a bundle says what the machine was doing and nothing about what
+/// the person was trying to do, and the people who would open a GitHub issue to supply the second
+/// half are a small fraction of the people who press a button in the app they already have open.
+///
+/// Drawn on top of the shell rather than in a window of its own, like
+/// <see cref="ServiceSettingsOverlay"/>, so the app keeps a single visible surface.
+///
+/// Nothing here persists. The note is written into the zip at the moment of sending and is not
+/// kept anywhere else — dismissing the panel is meant to leave no trace, because what gets typed
+/// into it is a description of someone's own machine and their own frustration.
+/// </remarks>
+public partial class DiagnosticNoteOverlay : UserControl
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    private static readonly Duration FadeDuration = new(TimeSpan.FromMilliseconds(140));
+
+    /// <summary>The bundle this panel is about to send. Set by <see cref="Open"/>.</summary>
+    private string _bundlePath = "";
+
+    /// <summary>True from the press until the request settles. Every way out is shut meanwhile.</summary>
+    private bool _uploading;
+
+    /// <summary>Set once a send has been tried and did not produce a code.</summary>
+    private bool _attemptFailed;
+
+    /// <summary>The code from a successful send, carried out through <see cref="Closed"/>.</summary>
+    private string? _code;
+
+    /// <summary>
+    /// Which failure is on screen, so it can be re-rendered in the new language. Held as the key
+    /// rather than the string for the same reason everything else here is.
+    /// </summary>
+    private string? _failureKey;
+
+    /// <summary>Raised once the panel has been dismissed, with what became of the bundle.</summary>
+    public event EventHandler<DiagnosticNoteResult>? Closed;
+
+    public DiagnosticNoteOverlay()
+    {
+        InitializeComponent();
+
+        // The service owns the limit: it is the one that has to fit the note into a bundle with an
+        // upload ceiling, and a box that accepted more would be promising something it cannot keep.
+        NoteBox.MaxLength = DiagnosticBundleService.MaxNoteLength;
+    }
+
+    // ── Open / close ─────────────────────────────────────────────────────────
+
+    public void Open(string bundlePath)
+    {
+        _bundlePath = bundlePath;
+        _code = null;
+        _attemptFailed = false;
+
+        NoteBox.Text = "";
+        BundleNameText.Text = Path.GetFileName(bundlePath);
+        HideFailure();
+        SetUploading(false);
+
+        Visibility = Visibility.Visible;
+
+        LocalizationService.LanguageChanged += OnLanguageChanged;
+
+        // WPF switches text off pixel snapping while it is being animated and ramps it back over
+        // about a second — the card is cached as a bitmap for the length of the scale so the title
+        // does not soften and re-sharpen on the way in. Same as the service panel.
+        Card.CacheMode = new BitmapCache { SnapsToDevicePixels = true };
+
+        var fade = new DoubleAnimation { From = 0, To = 1, Duration = FadeDuration };
+        fade.Completed += (_, _) => ReleaseAnimations();
+        BeginAnimation(OpacityProperty, fade);
+
+        var grow = new DoubleAnimation
+        {
+            From = 0.96, To = 1,
+            Duration = FadeDuration,
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+        };
+        CardScale.BeginAnimation(ScaleTransform.ScaleXProperty, grow);
+        CardScale.BeginAnimation(ScaleTransform.ScaleYProperty, grow);
+
+        // The box is what this panel is for, so it is what the caret is in when it appears
+        NoteBox.Focus();
+    }
+
+    public void Close()
+    {
+        // The request is on the wire and the page behind this one is waiting to be told how it
+        // ended. Every route here is guarded, but they are guarded in one place.
+        if (_uploading) return;
+
+        LocalizationService.LanguageChanged -= OnLanguageChanged;
+
+        var result = new DiagnosticNoteResult(_code, _attemptFailed);
+
+        var fade = new DoubleAnimation { From = 1, To = 0, Duration = FadeDuration };
+        fade.Completed += (_, _) =>
+        {
+            Visibility = Visibility.Collapsed;
+            ReleaseAnimations();
+
+            // Cleared on the way out rather than on the way in: what was typed is a description of
+            // someone's own machine, and it has no reason to still be in memory once the panel is
+            // gone.
+            NoteBox.Text = "";
+
+            Closed?.Invoke(this, result);
+        };
+        BeginAnimation(OpacityProperty, fade);
+    }
+
+    // DoubleAnimation holds the properties it animated under the clock's control after it finishes;
+    // handing them back drops the composition layer the transition needed.
+    private void ReleaseAnimations()
+    {
+        BeginAnimation(OpacityProperty, null);
+        Opacity = 1;
+
+        CardScale.BeginAnimation(ScaleTransform.ScaleXProperty, null);
+        CardScale.BeginAnimation(ScaleTransform.ScaleYProperty, null);
+        CardScale.ScaleX = 1;
+        CardScale.ScaleY = 1;
+
+        Card.CacheMode = null;
+    }
+
+    private void CloseBtn_Click(object sender, RoutedEventArgs e) => Close();
+
+    private void CancelBtn_Click(object sender, RoutedEventArgs e) => Close();
+
+    private void Scrim_MouseLeftButtonDown(object sender, MouseButtonEventArgs e) => Close();
+
+    // Clicks inside the card must not bubble up to the scrim's dismiss handler
+    private void Card_MouseLeftButtonDown(object sender, MouseButtonEventArgs e) => e.Handled = true;
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        // Escape only, and no Enter: the box takes multiple lines, and a panel whose one destructive
+        // action is on the key that ends a paragraph would send half-written reports.
+        if (e.Key == Key.Escape)
+        {
+            Close();
+            e.Handled = true;
+        }
+        base.OnKeyDown(e);
+    }
+
+    // ── Sending ──────────────────────────────────────────────────────────────
+
+    /// <remarks>
+    /// The note is written into the bundle rather than sent beside it, so it arrives wherever the
+    /// bundle does and in whatever language it was typed in. See
+    /// <see cref="DiagnosticBundleService.AttachNote"/>.
+    ///
+    /// A failure leaves the panel exactly as it was, note included. The bundle is already on disk
+    /// either way, so the worst case is that the user closes this and reports it by hand — which is
+    /// what the line under the error says, with the link to say it through.
+    /// </remarks>
+    private async void SendBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_uploading) return;
+
+        HideFailure();
+        SetUploading(true);
+
+        var note = NoteBox.Text;
+        string? code = null;
+
+        try
+        {
+            // Off the UI thread: it rewrites a zip that can be several megabytes, and freezing the
+            // window while sending a bug report is its own bug report.
+            await Task.Run(() => DiagnosticBundleService.AttachNote(_bundlePath, note));
+
+            code = await DiagnosticUploadService.UploadAsync(_bundlePath);
+        }
+        catch (DiagnosticUploadException ex)
+        {
+            // One wording for every reason an upload can fail, as everywhere else this is reported:
+            // whether it was the network, the size or a refusal, the next move is the same.
+            Log.Warn(ex, "Diagnostic upload with note failed");
+            _attemptFailed = true;
+            ShowFailure("S.Settings.NoteUploadFailed");
+        }
+        catch (Exception ex)
+        {
+            // The note could not be written into the bundle, so nothing was sent. Said separately
+            // because the fix is different: this one is worth simply trying again.
+            Log.Error(ex, "Could not attach the note to the diagnostic bundle");
+            _attemptFailed = true;
+            ShowFailure("S.Settings.NoteAttachFailed");
+        }
+        finally
+        {
+            SetUploading(false);
+        }
+
+        if (code is null) return;
+
+        _code = code;
+        _attemptFailed = false;
+        Close();
+    }
+
+    /// <summary>
+    /// The panel while the bundle is on its way: nothing can be typed, and every way out is shut
+    /// until it is known whether a code came back.
+    /// </summary>
+    /// <remarks>
+    /// The send button keeps its colour and loses only its clicks. Disabling it would dim the one
+    /// thing on screen carrying the spinner, and a greyed-out control with a spinner in it reads as
+    /// something that has stopped rather than something that is working.
+    /// </remarks>
+    private void SetUploading(bool uploading)
+    {
+        _uploading = uploading;
+
+        NoteBox.IsEnabled   = !uploading;
+        CancelBtn.IsEnabled = !uploading;
+        CloseBtn.IsEnabled  = !uploading;
+
+        SendBtn.IsHitTestVisible = !uploading;
+        SendSpinner.Visibility   = uploading ? Visibility.Visible : Visibility.Collapsed;
+        SendLabel.SetResourceReference(
+            TextBlock.TextProperty,
+            uploading ? "S.Settings.NoteSending" : "S.Settings.UploadBundle");
+    }
+
+    private void ShowFailure(string key)
+    {
+        _failureKey = key;
+        FailureRun.Text = LocalizationService.Get(key);
+        FailurePanel.Visibility = Visibility.Visible;
+    }
+
+    private void HideFailure()
+    {
+        _failureKey = null;
+        FailurePanel.Visibility = Visibility.Collapsed;
+    }
+
+    /// <summary>
+    /// Re-renders the one string this panel sets in code. Everything else is a resource reference
+    /// and follows the change on its own.
+    /// </summary>
+    private void OnLanguageChanged(object? sender, EventArgs e)
+    {
+        if (_failureKey is { } key)
+            FailureRun.Text = LocalizationService.Get(key);
+    }
+
+    // ── Box ──────────────────────────────────────────────────────────────────
+
+    private void NoteBox_TextChanged(object sender, TextChangedEventArgs e) =>
+        NotePlaceholder.Visibility =
+            NoteBox.Text.Length == 0 ? Visibility.Visible : Visibility.Collapsed;
+
+    private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            // A browser that will not open is not a reason to lose the panel the user is standing in
+            Log.Warn(ex, "Could not open {0}", e.Uri.AbsoluteUri);
+        }
+
+        e.Handled = true;
+    }
+}

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -710,9 +710,12 @@
                      neither has a claim on the extra width, so a shared row of their own keeps the
                      split off the columns the rows above depend on. -->
                 <Grid Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2">
+                    <!-- Not an even split: 外觀 is two radio buttons and a list, while 進階設定 carries
+                         the row of buttons whose labels are the longest on the page in every
+                         language. The extra width goes where there is something to fit. -->
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="0.8*"/>
+                        <ColumnDefinition Width="1.2*"/>
                     </Grid.ColumnDefinitions>
                     <!-- ══════════ 外觀 ══════════ -->
                     <Border Grid.Column="0"
@@ -884,101 +887,118 @@
                                     CornerRadius="6"
                                     Padding="12,10">
                                 <StackPanel>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
+                                    <!-- Docked rather than laid out in columns. In a row of Auto
+                                         columns the heading took its full width whatever the card
+                                         could spare, so an English title two words longer than the
+                                         Chinese one pushed 開啟檔案 off the edge. Here the buttons
+                                         take what they need first and the heading gets what is
+                                         left: what gives is the wording, not a control the user
+                                         has to be able to press. -->
+                                    <DockPanel LastChildFill="True">
+                                        <!-- 14 to the left of the group: without it a heading that
+                                             happens to fill the row ends up touching the first
+                                             button, and the two read as one run-on control. -->
+                                        <StackPanel DockPanel.Dock="Right"
+                                                    Orientation="Horizontal"
+                                                    VerticalAlignment="Center"
+                                                    Margin="14,0,0,0">
+
+                                            <!-- The next step, and the only accent in this panel: the
+                                                 export is done and this is what the user came here to
+                                                 do with it. Gone once a code is showing, because by
+                                                 then it has been done — and back if the send failed,
+                                                 where it is the retry.
+
+                                                 Upload and Copy are never on screen together, so
+                                                 neither needs a margin and only Open carries one. -->
+                                            <Button x:Name="UploadDiagnosticsBtn"
+                                                    Style="{StaticResource AccentButton}"
+                                                    Height="30"
+                                                    Padding="12,0"
+                                                    Visibility="Collapsed"
+                                                    Click="UploadDiagnosticsBtn_Click">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBlock Text="&#xE898;"
+                                                               FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                               FontSize="13"
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,6,0"/>
+                                                    <TextBlock Text="{DynamicResource S.Settings.UploadBundle}"
+                                                               VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                            </Button>
+
+                                            <Button x:Name="CopyDiagnosticsCodeBtn"
+                                                    Style="{StaticResource FlatButton}"
+                                                    Height="30"
+                                                    Padding="12,0"
+                                                    Click="CopyDiagnosticsCodeBtn_Click">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBlock Text="&#xE8C8;"
+                                                               FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                               FontSize="13"
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,6,0"/>
+                                                    <TextBlock Text="{DynamicResource S.Settings.CopyCode}"
+                                                               VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                            </Button>
+
+                                            <Button x:Name="OpenDiagnosticsBundleBtn"
+                                                    Style="{StaticResource FlatButton}"
+                                                    Height="30"
+                                                    Padding="12,0"
+                                                    Margin="6,0,0,0"
+                                                    Click="OpenDiagnosticsBundleBtn_Click">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBlock Text="&#xE8E5;"
+                                                               FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                               FontSize="13"
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,6,0"/>
+                                                    <TextBlock Text="{DynamicResource S.Settings.OpenBundle}"
+                                                               VerticalAlignment="Center"/>
+                                                </StackPanel>
+                                            </Button>
+                                        </StackPanel>
 
                                         <!-- The glyph carries the state, because the rest of the row
                                              changes shape between the two: on failure there is no
                                              code and no Copy, and a heading that differs only in its
                                              wording is one a reader has to actually read before they
-                                             know which of the two happened. -->
-                                        <TextBlock Grid.Column="0" x:Name="DiagnosticsResultGlyph"
-                                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                                   FontSize="15"
-                                                   Foreground="{DynamicResource AppTextSecondary}"
-                                                   VerticalAlignment="Center"
-                                                   Margin="0,0,8,0"/>
+                                             know which of the two happened.
 
-                                        <TextBlock Grid.Column="1" x:Name="DiagnosticsResultTitle"
-                                                   Style="{StaticResource OptionTitle}"
-                                                   VerticalAlignment="Center"/>
+                                             The heading trims rather than wraps: it sits beside a row
+                                             of buttons, and a second line would push them off their
+                                             own vertical centre. It only reaches that on a window
+                                             narrow enough that the card is already tight. -->
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <TextBlock x:Name="DiagnosticsResultGlyph"
+                                                       FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                       FontSize="15"
+                                                       Foreground="{DynamicResource AppTextSecondary}"
+                                                       VerticalAlignment="Center"
+                                                       Margin="0,0,8,0"/>
 
-                                        <!-- A monospaced face, because these characters get read back
-                                             one at a time against whatever the user typed into a forum
-                                             post, and a proportional face is where 0/O and 1/I go
-                                             wrong. The alphabet the worker draws from already excludes
-                                             that pair; the face makes the exclusion visible. -->
-                                        <TextBlock Grid.Column="2" x:Name="DiagnosticsCodeText"
-                                                   FontFamily="Consolas, Cascadia Mono, Courier New"
-                                                   FontSize="18"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource AppAccent}"
-                                                   Margin="10,0,0,0"
-                                                   VerticalAlignment="Center"/>
+                                            <TextBlock x:Name="DiagnosticsResultTitle"
+                                                       Style="{StaticResource OptionTitle}"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       VerticalAlignment="Center"/>
 
-                                        <!-- The next step, and the only accent in this panel: the
-                                             export is done and this is what the user came here to
-                                             do with it. Gone once a code is showing, because by
-                                             then it has been done — and back if the send failed,
-                                             where it is the retry. -->
-                                        <Button Grid.Column="4" x:Name="UploadDiagnosticsBtn"
-                                                Style="{StaticResource AccentButton}"
-                                                Height="30"
-                                                Padding="12,0"
-                                                Visibility="Collapsed"
-                                                Click="UploadDiagnosticsBtn_Click">
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="&#xE898;"
-                                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                                           FontSize="13"
-                                                           VerticalAlignment="Center"
-                                                           Margin="0,0,6,0"/>
-                                                <TextBlock Text="{DynamicResource S.Settings.UploadBundle}"
-                                                           VerticalAlignment="Center"/>
-                                            </StackPanel>
-                                        </Button>
-
-                                        <Button Grid.Column="5" x:Name="CopyDiagnosticsCodeBtn"
-                                                Style="{StaticResource FlatButton}"
-                                                Height="30"
-                                                Padding="12,0"
-                                                Click="CopyDiagnosticsCodeBtn_Click">
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="&#xE8C8;"
-                                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                                           FontSize="13"
-                                                           VerticalAlignment="Center"
-                                                           Margin="0,0,6,0"/>
-                                                <TextBlock Text="{DynamicResource S.Settings.CopyCode}"
-                                                           VerticalAlignment="Center"/>
-                                            </StackPanel>
-                                        </Button>
-
-                                        <Button Grid.Column="6" x:Name="OpenDiagnosticsBundleBtn"
-                                                Style="{StaticResource FlatButton}"
-                                                Height="30"
-                                                Padding="12,0"
-                                                Margin="6,0,0,0"
-                                                Click="OpenDiagnosticsBundleBtn_Click">
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="&#xE8E5;"
-                                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                                           FontSize="13"
-                                                           VerticalAlignment="Center"
-                                                           Margin="0,0,6,0"/>
-                                                <TextBlock Text="{DynamicResource S.Settings.OpenBundle}"
-                                                           VerticalAlignment="Center"/>
-                                            </StackPanel>
-                                        </Button>
-                                    </Grid>
+                                            <!-- A monospaced face, because these characters get read back
+                                                 one at a time against whatever the user typed into a forum
+                                                 post, and a proportional face is where 0/O and 1/I go
+                                                 wrong. The alphabet the worker draws from already excludes
+                                                 that pair; the face makes the exclusion visible. -->
+                                            <TextBlock x:Name="DiagnosticsCodeText"
+                                                       FontFamily="Consolas, Cascadia Mono, Courier New"
+                                                       FontSize="18"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource AppAccent}"
+                                                       Margin="10,0,0,0"
+                                                       VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </DockPanel>
 
                                     <TextBlock x:Name="DiagnosticsResultHint"
                                                Style="{StaticResource OptionDescription}"

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -714,8 +714,8 @@
                          the row of buttons whose labels are the longest on the page in every
                          language. The extra width goes where there is something to fit. -->
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="0.8*"/>
-                        <ColumnDefinition Width="1.2*"/>
+                        <ColumnDefinition Width="0.9*"/>
+                        <ColumnDefinition Width="1.1*"/>
                     </Grid.ColumnDefinitions>
                     <!-- ══════════ 外觀 ══════════ -->
                     <Border Grid.Column="0"

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -889,6 +889,7 @@
                                             <ColumnDefinition Width="*"/>
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
 
                                         <!-- The glyph carries the state, because the rest of the row
@@ -920,7 +921,29 @@
                                                    Margin="10,0,0,0"
                                                    VerticalAlignment="Center"/>
 
-                                        <Button Grid.Column="4" x:Name="CopyDiagnosticsCodeBtn"
+                                        <!-- The next step, and the only accent in this panel: the
+                                             export is done and this is what the user came here to
+                                             do with it. Gone once a code is showing, because by
+                                             then it has been done — and back if the send failed,
+                                             where it is the retry. -->
+                                        <Button Grid.Column="4" x:Name="UploadDiagnosticsBtn"
+                                                Style="{StaticResource AccentButton}"
+                                                Height="30"
+                                                Padding="12,0"
+                                                Visibility="Collapsed"
+                                                Click="UploadDiagnosticsBtn_Click">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#xE898;"
+                                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                           FontSize="13"
+                                                           VerticalAlignment="Center"
+                                                           Margin="0,0,6,0"/>
+                                                <TextBlock Text="{DynamicResource S.Settings.UploadBundle}"
+                                                           VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Button>
+
+                                        <Button Grid.Column="5" x:Name="CopyDiagnosticsCodeBtn"
                                                 Style="{StaticResource FlatButton}"
                                                 Height="30"
                                                 Padding="12,0"
@@ -936,7 +959,7 @@
                                             </StackPanel>
                                         </Button>
 
-                                        <Button Grid.Column="5" x:Name="OpenDiagnosticsBundleBtn"
+                                        <Button Grid.Column="6" x:Name="OpenDiagnosticsBundleBtn"
                                                 Style="{StaticResource FlatButton}"
                                                 Height="30"
                                                 Padding="12,0"

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -832,12 +832,14 @@
                                         Margin="0,0,4,0"
                                         Click="ExportDiagnosticsBtn_Click">
                                     <StackPanel Orientation="Horizontal">
-                                        <!-- Upload, the pair of the Download glyph 更新 already uses
-                                             on this same shape of control. No Foreground on
-                                             either block: both inherit the button's, which is
-                                             the one thing that differs between these two styles
-                                             and the one thing that must keep differing. -->
-                                        <TextBlock Text="&#xE898;"
+                                        <!-- Save, because that is now all this press does: it writes
+                                             a file and stops. The upload arrow it used to carry has
+                                             moved to the button that actually uploads, in the panel
+                                             below, where the two now read as the two steps they are.
+                                             No Foreground on either block: both inherit the button's,
+                                             which is the one thing that differs between these two
+                                             styles and the one thing that must keep differing. -->
+                                        <TextBlock Text="&#xE74E;"
                                                    FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                                    FontSize="13"
                                                    VerticalAlignment="Center"

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -81,6 +81,7 @@
 
         <!-- Settings cards scroll; the auto-save bar below stays put so it is always reachable -->
         <ScrollViewer Grid.Row="1"
+                      x:Name="CardsScroll"
                       VerticalScrollBarVisibility="Auto"
                       HorizontalScrollBarVisibility="Disabled"
                       Padding="0,0,8,0">

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -627,7 +627,7 @@ public partial class SettingsPage : UserControl
         UploadDiagnosticsBtn.Visibility =
             DiagnosticUploadService.IsConfigured ? Visibility.Visible : Visibility.Collapsed;
 
-        DiagnosticsResultPanel.Visibility = Visibility.Visible;
+        ShowDiagnosticsResultPanel();
     }
 
     /// <summary>The panel as it looks when a bundle went up and came back with a code.</summary>
@@ -647,7 +647,7 @@ public partial class SettingsPage : UserControl
         // which arrives at the other end as a second report from someone who only had one problem.
         UploadDiagnosticsBtn.Visibility = Visibility.Collapsed;
 
-        DiagnosticsResultPanel.Visibility = Visibility.Visible;
+        ShowDiagnosticsResultPanel();
     }
 
     /// <summary>
@@ -682,8 +682,89 @@ public partial class SettingsPage : UserControl
         // still sitting on the disk.
         UploadDiagnosticsBtn.Visibility = Visibility.Visible;
 
-        DiagnosticsResultPanel.Visibility = Visibility.Visible;
+        ShowDiagnosticsResultPanel();
     }
+
+    /// <summary>
+    /// Shows the result panel, and scrolls to it when it has landed past the bottom of the page.
+    /// </summary>
+    /// <remarks>
+    /// The panel appears at the foot of the last card on a page that scrolls, so on anything short
+    /// of a tall window it arrives off screen. Without this the press looks like it did nothing:
+    /// the status line flashes and fades, and everything it produced — the code, the upload button,
+    /// the file — is somewhere the user has been given no reason to look.
+    ///
+    /// After a layout pass, because the panel became visible a moment ago and has no height yet;
+    /// scrolling to a zero-height element lands in the wrong place.
+    /// </remarks>
+    private void ShowDiagnosticsResultPanel()
+    {
+        DiagnosticsResultPanel.Visibility = Visibility.Visible;
+        Dispatcher.BeginInvoke(new Action(RevealDiagnosticsResult), DispatcherPriority.Loaded);
+    }
+
+    /// <summary>Room left under the panel once it has been scrolled to, so it is not flush.</summary>
+    private const double RevealPadding = 12;
+
+    private static readonly Duration RevealDuration = new(TimeSpan.FromMilliseconds(280));
+
+    /// <remarks>
+    /// Animated rather than jumped, and that is the point rather than decoration: movement is what
+    /// says something appeared down here, where an instant re-position is indistinguishable from
+    /// the page having always looked that way — which is the thing this is trying to fix. Windows'
+    /// animation setting is the local reduced-motion preference, and with it off the scroll goes
+    /// straight there.
+    /// </remarks>
+    private void RevealDiagnosticsResult()
+    {
+        if (CardsScroll.Content is not FrameworkElement content) return;
+
+        // False if the user has navigated off the page while the export was running, in which case
+        // there is nothing on screen to scroll and no ancestor to measure against.
+        if (!DiagnosticsResultPanel.IsVisible) return;
+
+        var top = DiagnosticsResultPanel
+            .TransformToAncestor(content)
+            .Transform(new System.Windows.Point(0, 0)).Y;
+
+        var target = Math.Min(
+            top + DiagnosticsResultPanel.ActualHeight + RevealPadding - CardsScroll.ViewportHeight,
+            CardsScroll.ScrollableHeight);
+
+        // Only when it is genuinely out of sight. Moving the page under the eyes of someone who can
+        // already see the panel is the same interruption for none of the benefit.
+        if (target <= CardsScroll.VerticalOffset) return;
+
+        if (!SystemParameters.ClientAreaAnimation)
+        {
+            CardsScroll.ScrollToVerticalOffset(target);
+            return;
+        }
+
+        CardsScroll.BeginAnimation(ScrollOffsetProperty, new DoubleAnimation
+        {
+            From = CardsScroll.VerticalOffset,
+            To = target,
+            Duration = RevealDuration,
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+
+            // Held rather than released at the end, unlike every other animation on this page:
+            // releasing hands the property back to its default of zero, and the callback below
+            // would scroll the page to the top the moment the movement finished.
+        });
+    }
+
+    /// <summary>
+    /// What the scroll animation drives. <see cref="ScrollViewer.VerticalOffset"/> is read-only, so
+    /// the animation moves this instead and every tick scrolls by hand.
+    /// </summary>
+    private static readonly DependencyProperty ScrollOffsetProperty =
+        DependencyProperty.RegisterAttached(
+            "ScrollOffset",
+            typeof(double),
+            typeof(SettingsPage),
+            new PropertyMetadata(0.0, (d, e) =>
+                ((ScrollViewer)d).ScrollToVerticalOffset((double)e.NewValue)));
 
     /// <summary>Segoe MDL2 Completed, the tick in a circle.</summary>
     private const string CompletedGlyph = "\uE930";

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -509,19 +509,14 @@ public partial class SettingsPage : UserControl
     }
 
     /// <summary>
-    /// Collects the bundle and, where an endpoint is compiled in, sends it and shows the code that
-    /// comes back.
+    /// Collects the bundle and stops there, leaving what happens to it to the row that appears
+    /// underneath.
     /// </summary>
     /// <remarks>
-    /// One button for both halves, because the two halves are one intention: nobody collects a
-    /// diagnostic bundle for its own sake. What that costs is the chance to open the zip before it
-    /// goes — paid for by the explanation on the heading, by a label that says it uploads, and by
-    /// the row afterwards that opens what was sent.
-    ///
-    /// The upload is nested inside its own try on purpose. A failure there is not a failure of the
-    /// press: the bundle is already written, and every one of those paths ends by opening Explorer
-    /// on it — which is the whole of #126, still there for the offline machine, the blocked network
-    /// and the person who would simply rather attach it themselves.
+    /// Collecting and sending used to be one press, on the grounds that nobody collects a bundle
+    /// for its own sake. True, and it left no room for the half a bundle cannot carry: what the
+    /// user was trying to do when it went wrong. Splitting them buys the moment in between, which
+    /// is where <see cref="DiagnosticNoteOverlay"/> now asks for exactly that.
     ///
     /// Off the UI thread because the bundle copies and compresses every log file there is, which on
     /// a machine that has filled its five archives is a dozen megabytes — not long, but long enough
@@ -536,51 +531,103 @@ public partial class SettingsPage : UserControl
         // the next one invites it to be copied as though it were the new one.
         DiagnosticsResultPanel.Visibility = Visibility.Collapsed;
 
-        var uploading = DiagnosticUploadService.IsConfigured;
         try
         {
-            if (uploading) ShowProgress(LocalizationService.Get("S.Settings.DiagnosticsUploading"));
+            ShowProgress(LocalizationService.Get("S.Settings.DiagnosticsExporting"));
 
             var path = await Task.Run(() => DiagnosticBundleService.Export());
             _lastBundlePath = path;
 
-            if (!uploading)
-            {
-                FlashSuccess(LocalizationService.Get("S.Settings.DiagnosticsExported"));
+            ShowExported();
+            FlashSuccess(LocalizationService.Get("S.Settings.DiagnosticsExported"));
 
-                // The real confirmation: the status line fades after a moment and cannot show a path
-                // worth reading anyway, whereas Explorer opens with the file already selected and
-                // ready to be dragged into a forum post — which is the entire point of the feature.
+            // Only where there is nowhere to send it. With an endpoint the panel that just appeared
+            // is the next step and says so, and an Explorer window arriving over it is a second
+            // instruction contradicting the first. Without one, this is still #126: the file exists
+            // to be dragged into a forum post, and Explorer opens with it already selected.
+            if (!DiagnosticUploadService.IsConfigured)
                 DiagnosticBundleService.Reveal(path);
-                return;
-            }
-
-            try
-            {
-                var code = await DiagnosticUploadService.UploadAsync(path);
-
-                ShowUploaded(code);
-                FlashSuccess(LocalizationService.Format("S.Settings.DiagnosticsUploaded", code));
-            }
-            catch (DiagnosticUploadException)
-            {
-                // No Explorer window here, unlike the path with no endpoint at all. The panel that
-                // appears says to press Open file, and a window opening by itself at the same moment
-                // is a second instruction contradicting the first.
-                ShowNotUploaded();
-                ShowWarning(LocalizationService.Get("S.Settings.DiagnosticsUploadFailed"));
-            }
         }
         catch (Exception ex)
         {
-            // Only the collection can land here now, and if that failed there is no file to fall
-            // back to — which is why this one still names the error.
+            // If the collection failed there is no file to fall back to, which is why this one
+            // names the error.
             ShowError(LocalizationService.Format("S.Settings.DiagnosticsFailed", ex.Message));
         }
         finally
         {
             ExportDiagnosticsBtn.IsEnabled = true;
         }
+    }
+
+    /// <summary>
+    /// Opens the panel that asks what went wrong and sends the bundle with the answer attached.
+    /// </summary>
+    /// <remarks>
+    /// The panel belongs to the shell rather than to this page, like the service one: its scrim has
+    /// to cover the nav rail, and an upload in flight is exactly the moment the user must not be
+    /// able to navigate away from the thing that will tell them how it went.
+    /// </remarks>
+    private void UploadDiagnosticsBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_lastBundlePath is null) return;
+
+        if (Window.GetWindow(this) is Shell.ShellWindow shell)
+            shell.OpenDiagnosticNote(_lastBundlePath);
+    }
+
+    /// <summary>
+    /// Brings the result panel in line with what became of the bundle, once the note panel is gone.
+    /// </summary>
+    /// <remarks>
+    /// Public because the shell owns the note panel and hands its outcome back here — the same
+    /// arrangement <see cref="RefreshServiceTiles"/> has with the service panel.
+    ///
+    /// Dismissing without sending leaves the panel exactly as the export left it: the bundle is
+    /// still there, the Upload button is still there, and nothing has happened that the page has
+    /// anything to say about.
+    /// </remarks>
+    public void ReportDiagnosticUpload(DiagnosticNoteResult result)
+    {
+        if (result.Code is { } code)
+        {
+            ShowUploaded(code);
+            FlashSuccess(LocalizationService.Format("S.Settings.DiagnosticsUploaded", code));
+            return;
+        }
+
+        if (result.AttemptFailed)
+        {
+            ShowNotUploaded();
+            ShowWarning(LocalizationService.Get("S.Settings.DiagnosticsUploadFailed"));
+        }
+    }
+
+    /// <summary>
+    /// The panel as it looks when a bundle has been written and has not been sent anywhere.
+    /// </summary>
+    /// <remarks>
+    /// Upload leads because it is the reason the export was pressed, and it is the only thing here
+    /// that has not happened yet. It is absent entirely in a build with no endpoint, where the
+    /// panel is a receipt rather than a step.
+    /// </remarks>
+    private void ShowExported()
+    {
+        DiagnosticsResultGlyph.Text = CompletedGlyph;
+        DiagnosticsResultTitle.SetResourceReference(
+            TextBlock.TextProperty, "S.Settings.DiagnosticsExportedTitle");
+        DiagnosticsResultHint.SetResourceReference(
+            TextBlock.TextProperty,
+            DiagnosticUploadService.IsConfigured
+                ? "S.Settings.DiagnosticsExportedHint"
+                : "S.Settings.DiagnosticsNoEndpointHint");
+
+        DiagnosticsCodeText.Visibility = Visibility.Collapsed;
+        CopyDiagnosticsCodeBtn.Visibility = Visibility.Collapsed;
+        UploadDiagnosticsBtn.Visibility =
+            DiagnosticUploadService.IsConfigured ? Visibility.Visible : Visibility.Collapsed;
+
+        DiagnosticsResultPanel.Visibility = Visibility.Visible;
     }
 
     /// <summary>The panel as it looks when a bundle went up and came back with a code.</summary>
@@ -595,6 +642,10 @@ public partial class SettingsPage : UserControl
         DiagnosticsCodeText.Text = code;
         DiagnosticsCodeText.Visibility = Visibility.Visible;
         CopyDiagnosticsCodeBtn.Visibility = Visibility.Visible;
+
+        // It has been sent. Leaving the button there invites a second copy of the same bundle,
+        // which arrives at the other end as a second report from someone who only had one problem.
+        UploadDiagnosticsBtn.Visibility = Visibility.Collapsed;
 
         DiagnosticsResultPanel.Visibility = Visibility.Visible;
     }
@@ -626,6 +677,11 @@ public partial class SettingsPage : UserControl
         DiagnosticsCodeText.Visibility = Visibility.Collapsed;
         CopyDiagnosticsCodeBtn.Visibility = Visibility.Collapsed;
 
+        // Stays, as the retry. The reasons an upload fails are mostly the ones that pass on their
+        // own — a network coming back, a rate limit expiring — and the bundle it would send is
+        // still sitting on the disk.
+        UploadDiagnosticsBtn.Visibility = Visibility.Visible;
+
         DiagnosticsResultPanel.Visibility = Visibility.Visible;
     }
 
@@ -636,12 +692,12 @@ public partial class SettingsPage : UserControl
     private const string FailedGlyph = "\uE7BA";
 
     /// <summary>
-    /// Points the export button and its explanation at whichever of the two stories is true for this
-    /// build: with an endpoint compiled in, one press collects and sends; without one, it collects
-    /// and nothing leaves the machine.
+    /// Points the card's explanation at whichever of the two stories is true for this build: with an
+    /// endpoint compiled in there is somewhere to send the export afterwards; without one, nothing
+    /// ever leaves the machine. The button itself says the same thing in both — it only exports.
     /// </summary>
     /// <remarks>
-    /// Resource references rather than assignments, so both survive a language change — the page
+    /// A resource reference rather than an assignment, so it survives a language change — the page
     /// rebuilds itself on one, and a plain Text assignment would come back in the old language.
     ///
     /// A build with no endpoint is a supported state, not a broken one: it is what every build was
@@ -651,10 +707,6 @@ public partial class SettingsPage : UserControl
     private void ApplyDiagnosticUploadAvailability()
     {
         var configured = DiagnosticUploadService.IsConfigured;
-
-        ExportDiagnosticsLabel.SetResourceReference(
-            TextBlock.TextProperty,
-            configured ? "S.Settings.UploadDiagnostics" : "S.Settings.ExportDiagnostics");
 
         DiagnosticsHintText.SetResourceReference(
             TextBlock.TextProperty,

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -429,6 +429,7 @@
                  window is not what the scrim is protecting. -->
             <shell:AboutOverlay Grid.ColumnSpan="2" x:Name="About"/>
             <settings:ServiceSettingsOverlay Grid.ColumnSpan="2" x:Name="ServiceSettings"/>
+            <settings:DiagnosticNoteOverlay Grid.ColumnSpan="2" x:Name="DiagnosticNote"/>
         </Grid>
     </Grid>
 </Window>

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -132,6 +132,7 @@ public partial class ShellWindow : Window
         // Subscribed once here rather than per open, so the handler is not stacked up by a user who
         // opens the service panel more than once.
         ServiceSettings.Closed += (_, _) => _settingsPage.RefreshServiceTiles();
+        DiagnosticNote.Closed += (_, result) => _settingsPage.ReportDiagnosticUpload(result);
 
         // Subscribed rather than refreshed on show: a session ending brings this window back with
         // Show(), not through ShowOrActivate, so nothing else would clear the disabled state and
@@ -605,6 +606,18 @@ public partial class ShellWindow : Window
     /// </remarks>
     public void OpenServiceSettings(Models.TranslationProvider provider)
         => ServiceSettings.Open(provider);
+
+    /// <summary>
+    /// Opens the panel that collects what the user wants to say about the problem and sends the
+    /// bundle with it.
+    /// </summary>
+    /// <remarks>
+    /// Hosted here for the same reason the service panel is: the scrim has to cover the nav rail,
+    /// and an upload in flight is exactly the moment the user must not be able to navigate away
+    /// from the thing that will tell them how it went.
+    /// </remarks>
+    public void OpenDiagnosticNote(string bundlePath)
+        => DiagnosticNote.Open(bundlePath);
 
     protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
     {

--- a/tests/OverTranslate.Tests/LocalizedLineBreakTests.cs
+++ b/tests/OverTranslate.Tests/LocalizedLineBreakTests.cs
@@ -19,11 +19,13 @@ namespace OverTranslate.Tests;
 // a test that fails for something nobody is fixing is a test people learn to ignore.
 public class LocalizedLineBreakTests
 {
+    // The two result-panel hints were written as two lines and have since been rewritten as one
+    // paragraph each — deliberately, as the wording changed around the export and upload being
+    // separate presses. They are out because a break is no longer what they are asking for; the
+    // card's own hint still is, and is what this guards.
     private static readonly string[] TwoLineKeys =
     {
         "S.Settings.DiagnosticsUploadHint",
-        "S.Settings.DiagnosticsUploadedHint",
-        "S.Settings.DiagnosticsNotUploadedHint",
     };
 
     [Theory]


### PR DESCRIPTION
## 起因

診斷包能說清楚程式當時在做什麼，但說不出使用者當時想做什麼。願意為了補上這一半而特地去 GitHub 開 issue 的人，遠少於願意在已經開著的 App 裡按一顆按鈕的人。

原本「匯出並上傳」是同一顆按鈕，一按到底，中間沒有任何可以讓使用者說話的位置。這個 PR 把它拆成兩步，並在中間放進一個問題說明視窗。

## 流程

1. **匯出診斷資訊** —— 純匯出。狀態列顯示「正在整理診斷資訊…」，完成後結果面板顯示「診斷資訊已匯出，尚未上傳」。
2. 結果面板上多一顆 **上傳**（本面板唯一的強調色，因為它是唯一還沒發生的事）。
3. 按下後彈出 `DiagnosticNoteOverlay`，形式與翻譯服務設定視窗一致（同樣的遮罩、卡片、淡入縮放、Esc 關閉，掛在 `ShellWindow` 底下所以蓋得住側邊導覽列）。內容是一個多行輸入框（可留空）、即將送出的檔名，以及送出／取消。
4. 送出時按鈕保留強調色但吃掉點擊，換上旋轉環與「上傳中…」，輸入框與所有離開路徑（取消、右上關閉、Esc、點遮罩）全部關閉，直到有結果為止。
5. 成功 → 視窗關閉，設定頁換成回報代碼那一組（代碼、複製、開啟檔案），上傳鍵消失。
6. 失敗 → 視窗留著，寫的字還在，面板內顯示紅色說明並附「改用 GitHub 回報」連結。關掉後設定頁顯示「已匯出但無法上傳」，且上傳鍵留著作為重試。

## 說明怎麼送到維護者手上

`DiagnosticBundleService.AttachNote(path, note)` 在上傳前把說明以 UTF-8 寫進既有 zip 的 `note.txt`。

之所以寫進 zip 而不是隨上傳的 header 送：說明是使用者用自己的語言、自己需要的長度寫的，而 header 會被收件端剝成可列印 ASCII 並截到 64 字元，且存進 KV metadata 有容量上限。寫進 zip 也代表留在使用者電腦上的那份與送出的那份說的是同一件事，而且**收件端完全不用改**。

Update 模式會 append，所以先刪同名 entry 再寫，否則重試會在壓縮檔裡留下兩個同名項目。log 只記字數不記內容。

## 其他調整

- 匯出後不再自動開啟檔案總管，**除非**這個 build 沒有上傳端點。有端點時面板本身就是下一步，檔案總管蓋上來會變成兩個互相矛盾的指示；沒端點時那仍然是原本的離線路徑，保持不動。
- 匯出後自動捲動到結果面板。面板出現在會捲動的頁面最底部，視窗不夠高時會落在畫面外，使用者不會知道剛才那一按產生了什麼。用動畫而非瞬間跳位：會動的頁面才在說「下面出現了東西」。Windows 動畫效果關閉時直接定位。
- 匯出按鈕圖示由上傳箭頭改為 Save，與結果面板的上傳箭頭形成「存到本機／送出去」兩步。
- 進階設定卡片由與外觀卡片平分改為 `0.9*` / `1.1*`。原本結果列是 7 欄 Grid、標題欄為 `Auto`，英文標題比中文長，會把「開啟檔案」整顆推出卡片外；改用 `DockPanel` 讓按鈕先取得所需寬度，長標題只會截斷文字，不會擠掉使用者得按下去的控制項。
- `S.Settings.UploadDiagnostics`（舊的按鈕標籤）已無人使用，兩個語系都移除。

## 測試

`LocalizedLineBreakTests` 原本在 `main` 上就是紅的：它要求 `DiagnosticsUploadedHint` 與 `DiagnosticsNotUploadedHint` 保持兩行，但這兩句稍早已被改寫成單一段落。本 PR 再次改寫其中一句，確認了那個意圖，因此把這兩個 key 從清單移除，只留下確實仍是兩行的 `DiagnosticsUploadHint`，並在測試中註明原因。

現在是 677 passed / 0 failed。

版面另以拋棄式 WPF probe 載入真實主題與字串資源算繪確認：中英文 × 已匯出／已上傳四種組合皆無裁切、間距正常；回報視窗在空白與超長文字下卡片高度固定為 520×341，輸入框固定 150 並顯示捲軸。
