### PR TITLE
fix: 修正工具匣選單關閉與游標定位

### DIFF
--- a/src/OverTranslate/Layout/TrayMenuPlacement.cs
+++ b/src/OverTranslate/Layout/TrayMenuPlacement.cs
@@ -9,19 +9,53 @@ namespace OverTranslate.Layout;
 /// </summary>
 internal static class TrayMenuPlacement
 {
-    public static (int Left, int Top) Place(Point pointer, Size size, Rect workArea, double gap)
+    public static (int Left, int Top) Place(
+        Point pointer,
+        Size windowSize,
+        Rect workArea,
+        double gap,
+        double contentInset)
     {
+        var contentWidth = Math.Max(0, windowSize.Width - contentInset * 2);
+        var contentHeight = Math.Max(0, windowSize.Height - contentInset * 2);
         var minX = workArea.Left + gap;
-        var maxX = Math.Max(minX, workArea.Right - size.Width - gap);
+        var maxX = Math.Max(minX, workArea.Right - contentWidth - gap);
         var minY = workArea.Top + gap;
-        var maxY = Math.Max(minY, workArea.Bottom - size.Height - gap);
+        var maxY = Math.Max(minY, workArea.Bottom - contentHeight - gap);
 
-        var left = Math.Clamp(pointer.X, minX, maxX);
-        var above = pointer.Y - size.Height;
-        var top = above >= minY
-            ? Math.Min(above, maxY)
-            : Math.Clamp(pointer.Y + gap, minY, maxY);
+        var bestLeft = 0.0;
+        var bestTop = 0.0;
+        var bestDistance = double.MaxValue;
 
-        return ((int)Math.Round(left), (int)Math.Round(top));
+        // Prefer above-left when multiple corners can touch the pointer exactly, matching the
+        // familiar direction of a tray context menu. Clamping naturally selects another corner
+        // when the pointer is beside the top, left or right taskbar instead.
+        var corners = new[]
+        {
+            (Right: false, Bottom: true),
+            (Right: true, Bottom: true),
+            (Right: false, Bottom: false),
+            (Right: true, Bottom: false)
+        };
+
+        foreach (var corner in corners)
+        {
+            var left = Math.Clamp(
+                pointer.X - (corner.Right ? contentWidth : 0), minX, maxX);
+            var top = Math.Clamp(
+                pointer.Y - (corner.Bottom ? contentHeight : 0), minY, maxY);
+            var cornerX = left + (corner.Right ? contentWidth : 0);
+            var cornerY = top + (corner.Bottom ? contentHeight : 0);
+            var distance = Math.Pow(pointer.X - cornerX, 2) + Math.Pow(pointer.Y - cornerY, 2);
+
+            if (distance >= bestDistance) continue;
+            bestDistance = distance;
+            bestLeft = left;
+            bestTop = top;
+        }
+
+        return (
+            (int)Math.Round(bestLeft - contentInset),
+            (int)Math.Round(bestTop - contentInset));
     }
 }

--- a/src/OverTranslate/Layout/TrayMenuPlacement.cs
+++ b/src/OverTranslate/Layout/TrayMenuPlacement.cs
@@ -1,0 +1,27 @@
+using Point = System.Windows.Point;
+using Rect = System.Windows.Rect;
+using Size = System.Windows.Size;
+
+namespace OverTranslate.Layout;
+
+/// <summary>
+/// Places the tray menu beside the pointer and inside that monitor's physical-pixel work area.
+/// </summary>
+internal static class TrayMenuPlacement
+{
+    public static (int Left, int Top) Place(Point pointer, Size size, Rect workArea, double gap)
+    {
+        var minX = workArea.Left + gap;
+        var maxX = Math.Max(minX, workArea.Right - size.Width - gap);
+        var minY = workArea.Top + gap;
+        var maxY = Math.Max(minY, workArea.Bottom - size.Height - gap);
+
+        var left = Math.Clamp(pointer.X, minX, maxX);
+        var above = pointer.Y - size.Height;
+        var top = above >= minY
+            ? Math.Min(above, maxY)
+            : Math.Clamp(pointer.Y + gap, minY, maxY);
+
+        return ((int)Math.Round(left), (int)Math.Round(top));
+    }
+}

--- a/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
@@ -1,6 +1,9 @@
 using System.Windows;
 using System.Windows.Input;
+using OverTranslate.Layout;
 using OverTranslate.Services;
+using Point = System.Windows.Point;
+using Size = System.Windows.Size;
 
 namespace OverTranslate.Views.Shell;
 
@@ -20,35 +23,28 @@ public partial class TrayMenuWindow : Window
 
         // Start off-screen; Loaded repositions after ActualWidth/Height are measured
         Left = -9999;
-        Top  = -9999;
+        Top = -9999;
 
-        Loaded      += (_, _) => PositionWindow();
+        Loaded += (_, _) =>
+        {
+            PositionWindow();
+            Activate();
+        };
         Deactivated += (_, _) => Dismiss();
-        KeyDown     += (_, e) => { if (e.Key == Key.Escape) Dismiss(); };
+        KeyDown += (_, e) => { if (e.Key == Key.Escape) Dismiss(); };
     }
 
     private void PositionWindow()
     {
-        var src  = PresentationSource.FromVisual(this);
-        double dpiX = src?.CompositionTarget?.TransformToDevice.M11 ?? 1.0;
-        double dpiY = src?.CompositionTarget?.TransformToDevice.M22 ?? 1.0;
+        var area = System.Windows.Forms.Screen.FromPoint(_cursorPhys).WorkingArea;
+        var scale = ScreenGeometry.ScaleAt(_cursorPhys.X, _cursorPhys.Y);
+        var (left, top) = TrayMenuPlacement.Place(
+            new Point(_cursorPhys.X, _cursorPhys.Y),
+            new Size(ActualWidth * scale, ActualHeight * scale),
+            new Rect(area.Left, area.Top, area.Width, area.Height),
+            4 * scale);
 
-        // Convert physical cursor coords → WPF DIPs
-        double cx = _cursorPhys.X / dpiX;
-        double cy = _cursorPhys.Y / dpiY;
-
-        var wa = SystemParameters.WorkArea;
-
-        // Default: align left edge with cursor, bottom edge with cursor (appears above)
-        double left = cx;
-        double top  = cy - ActualHeight;
-
-        if (left + ActualWidth > wa.Right) left = wa.Right - ActualWidth - 4;
-        if (left < wa.Left)                left = wa.Left  + 4;
-        if (top  < wa.Top)                 top  = cy + 4;  // no room above → show below
-
-        Left = left;
-        Top  = top;
+        ScreenGeometry.MoveToPhysical(this, left, top);
     }
 
     private void Dismiss()

--- a/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
@@ -1,7 +1,10 @@
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
 using OverTranslate.Layout;
 using OverTranslate.Services;
+using Button = System.Windows.Controls.Button;
 using Point = System.Windows.Point;
 using Size = System.Windows.Size;
 
@@ -35,6 +38,7 @@ public partial class TrayMenuWindow : Window
         };
         Deactivated += (_, _) => Dismiss();
         KeyDown += (_, e) => { if (e.Key == Key.Escape) Dismiss(); };
+        PreviewMouseDown += DismissOnNonButtonClick;
     }
 
     private void PositionWindow()
@@ -56,6 +60,29 @@ public partial class TrayMenuWindow : Window
         if (_dismissed) return;
         _dismissed = true;
         Close();
+    }
+
+    private void DismissOnNonButtonClick(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton != MouseButton.Left && e.ChangedButton != MouseButton.Right) return;
+        if (e.OriginalSource is DependencyObject source && IsInsideButton(source)) return;
+
+        Dismiss();
+    }
+
+    internal static bool IsInsideButton(DependencyObject? element)
+    {
+        while (element is not null)
+        {
+            if (element is Button) return true;
+
+            DependencyObject? visualParent = element is Visual or Visual3D
+                ? VisualTreeHelper.GetParent(element)
+                : null;
+            element = visualParent ?? LogicalTreeHelper.GetParent(element);
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
@@ -9,6 +9,9 @@ namespace OverTranslate.Views.Shell;
 
 public partial class TrayMenuWindow : Window
 {
+    private const double EdgeGap = 4;
+    private const double ShadowInset = 18;
+
     public event EventHandler? OpenTranslationRequested;
     public event EventHandler? OpenSettingsRequested;
     public event EventHandler? ExitRequested;
@@ -42,7 +45,8 @@ public partial class TrayMenuWindow : Window
             new Point(_cursorPhys.X, _cursorPhys.Y),
             new Size(ActualWidth * scale, ActualHeight * scale),
             new Rect(area.Left, area.Top, area.Width, area.Height),
-            4 * scale);
+            EdgeGap * scale,
+            ShadowInset * scale);
 
         ScreenGeometry.MoveToPhysical(this, left, top);
     }

--- a/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
+++ b/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
@@ -11,6 +11,8 @@ namespace OverTranslate.Tests;
 /// </summary>
 public class TrayMenuWindowTests
 {
+    private const double ShadowInset = 18;
+
     private static string Source(string file) => File.ReadAllText(Path.Combine(
         StringsParityTests.ProjectDirectory(), "Views", "Shell", file));
 
@@ -40,10 +42,10 @@ public class TrayMenuWindowTests
         var workArea = new Rect(48, 0, 1872, 1080);
 
         var (left, top) = TrayMenuPlacement.Place(
-            new Point(20, 600), new Size(240, 180), workArea, 4);
+            new Point(20, 600), new Size(240, 180), workArea, 4, ShadowInset);
 
-        Assert.Equal(52, left);
-        Assert.Equal(420, top);
+        Assert.Equal(34, left);
+        Assert.Equal(438, top);
     }
 
     [Fact]
@@ -52,10 +54,24 @@ public class TrayMenuWindowTests
         var workArea = new Rect(0, 48, 1920, 1032);
 
         var (left, top) = TrayMenuPlacement.Place(
-            new Point(900, 20), new Size(240, 180), workArea, 4);
+            new Point(900, 20), new Size(240, 180), workArea, 4, ShadowInset);
 
-        Assert.Equal(900, left);
-        Assert.Equal(52, top);
+        Assert.Equal(882, left);
+        Assert.Equal(34, top);
+    }
+
+    [Fact]
+    public void A_right_taskbar_uses_the_visible_bottom_right_corner()
+    {
+        var workArea = new Rect(0, 0, 1872, 1080);
+        var window = new Size(240, 180);
+        var pointer = new Point(1900, 600);
+
+        var (left, top) = TrayMenuPlacement.Place(
+            pointer, window, workArea, 4, ShadowInset);
+
+        Assert.Equal(workArea.Right - 4, left + window.Width - ShadowInset);
+        Assert.Equal(pointer.Y, top + window.Height - ShadowInset);
     }
 
     [Fact]
@@ -64,9 +80,23 @@ public class TrayMenuWindowTests
         var workArea = new Rect(-1920, 0, 1920, 1040);
 
         var (left, top) = TrayMenuPlacement.Place(
-            new Point(-10, 1030), new Size(240, 180), workArea, 4);
+            new Point(-10, 1030), new Size(240, 180), workArea, 4, ShadowInset);
 
-        Assert.Equal(-244, left);
-        Assert.Equal(850, top);
+        Assert.Equal(-232, left);
+        Assert.Equal(868, top);
+    }
+
+    [Fact]
+    public void The_visible_corner_nearest_a_bottom_tray_icon_is_as_close_as_the_work_area_allows()
+    {
+        var workArea = new Rect(0, 0, 1920, 1040);
+        var window = new Size(276, 216);
+        var pointer = new Point(400, 1060);
+
+        var (left, top) = TrayMenuPlacement.Place(
+            pointer, window, workArea, 4, ShadowInset);
+
+        Assert.Equal(pointer.X, left + ShadowInset);
+        Assert.Equal(workArea.Bottom - 4, top + window.Height - ShadowInset);
     }
 }

--- a/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
+++ b/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
@@ -1,5 +1,8 @@
 using Xunit;
 using OverTranslate.Layout;
+using OverTranslate.Views.Shell;
+using System.Windows.Controls;
+using Button = System.Windows.Controls.Button;
 using Point = System.Windows.Point;
 using Rect = System.Windows.Rect;
 using Size = System.Windows.Size;
@@ -34,6 +37,30 @@ public class TrayMenuWindowTests
 
         Assert.Contains("Activate();", source);
         Assert.Contains("Deactivated", source);
+    }
+
+    [Fact]
+    public void Clicking_the_menu_chrome_dismisses_it_without_treating_a_button_as_chrome()
+    {
+        var source = Source("TrayMenuWindow.xaml.cs");
+
+        Assert.Contains("PreviewMouseDown", source);
+        Assert.Contains("DismissOnNonButtonClick", source);
+        Assert.Contains("IsInsideButton", source);
+    }
+
+    [Fact]
+    public void A_button_and_its_content_are_not_menu_chrome()
+    {
+        OnUiThread(() =>
+        {
+            var label = new TextBlock();
+            var button = new Button { Content = label };
+
+            Assert.True(TrayMenuWindow.IsInsideButton(button));
+            Assert.True(TrayMenuWindow.IsInsideButton(label));
+            Assert.False(TrayMenuWindow.IsInsideButton(new Border()));
+        });
     }
 
     [Fact]
@@ -98,5 +125,22 @@ public class TrayMenuWindowTests
 
         Assert.Equal(pointer.X, left + ShadowInset);
         Assert.Equal(workArea.Bottom - 4, top + window.Height - ShadowInset);
+    }
+
+    private static void OnUiThread(Action action)
+    {
+        Exception? failure = null;
+        var thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { failure = ex; }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (failure is not null)
+            throw new Xunit.Sdk.XunitException(failure.ToString());
     }
 }

--- a/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
+++ b/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
@@ -1,0 +1,72 @@
+using Xunit;
+using OverTranslate.Layout;
+using Point = System.Windows.Point;
+using Rect = System.Windows.Rect;
+using Size = System.Windows.Size;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The tray menu behaves like a context menu even though it is implemented as a WPF window.
+/// </summary>
+public class TrayMenuWindowTests
+{
+    private static string Source(string file) => File.ReadAllText(Path.Combine(
+        StringsParityTests.ProjectDirectory(), "Views", "Shell", file));
+
+    [Fact]
+    public void The_menu_uses_the_pointer_monitor_and_physical_pixels()
+    {
+        var source = Source("TrayMenuWindow.xaml.cs");
+
+        Assert.Contains("Screen.FromPoint", source);
+        Assert.Contains("ScreenGeometry.ScaleAt", source);
+        Assert.Contains("ScreenGeometry.MoveToPhysical", source);
+        Assert.DoesNotContain("SystemParameters.WorkArea", source);
+    }
+
+    [Fact]
+    public void Showing_the_menu_activates_it_so_clicking_elsewhere_deactivates_and_closes_it()
+    {
+        var source = Source("TrayMenuWindow.xaml.cs");
+
+        Assert.Contains("Activate();", source);
+        Assert.Contains("Deactivated", source);
+    }
+
+    [Fact]
+    public void A_left_taskbar_keeps_the_menu_inside_the_remaining_work_area()
+    {
+        var workArea = new Rect(48, 0, 1872, 1080);
+
+        var (left, top) = TrayMenuPlacement.Place(
+            new Point(20, 600), new Size(240, 180), workArea, 4);
+
+        Assert.Equal(52, left);
+        Assert.Equal(420, top);
+    }
+
+    [Fact]
+    public void A_top_taskbar_puts_the_menu_below_it_when_there_is_no_room_above()
+    {
+        var workArea = new Rect(0, 48, 1920, 1032);
+
+        var (left, top) = TrayMenuPlacement.Place(
+            new Point(900, 20), new Size(240, 180), workArea, 4);
+
+        Assert.Equal(900, left);
+        Assert.Equal(52, top);
+    }
+
+    [Fact]
+    public void A_pointer_on_a_negative_coordinate_monitor_stays_on_that_monitor()
+    {
+        var workArea = new Rect(-1920, 0, 1920, 1040);
+
+        var (left, top) = TrayMenuPlacement.Place(
+            new Point(-10, 1030), new Size(240, 180), workArea, 4);
+
+        Assert.Equal(-244, left);
+        Assert.Equal(850, top);
+    }
+}


### PR DESCRIPTION
修正工具匣右鍵選單失焦時未關閉，以及點擊選單內非按鈕區域時未關閉的問題。定位改用游標所在螢幕的工作區與 DPI，並從可見卡片四角選擇最靠近游標的位置。

測試：dotnet test tests\OverTranslate.Tests\OverTranslate.Tests.csproj（691 通過、2 略過）