### PR TITLE
fix: 工具匣選單跨過工具列貼齊游標

### DIFF
--- a/src/OverTranslate/Layout/TrayMenuPlacement.cs
+++ b/src/OverTranslate/Layout/TrayMenuPlacement.cs
@@ -5,23 +5,30 @@ using Size = System.Windows.Size;
 namespace OverTranslate.Layout;
 
 /// <summary>
-/// Places the tray menu beside the pointer and inside that monitor's physical-pixel work area.
+/// Places the tray menu beside the pointer, inside that monitor's physical-pixel bounds.
 /// </summary>
+/// <remarks>
+/// The bounds, not the work area — the pointer is on a tray icon, and a tray icon is on the
+/// taskbar, which the work area excludes. See TrayMenuWindow.PositionWindow.
+/// </remarks>
 internal static class TrayMenuPlacement
 {
+    /// <param name="monitor">
+    /// The region the menu has to stay inside: the whole monitor, taskbar included.
+    /// </param>
     public static (int Left, int Top) Place(
         Point pointer,
         Size windowSize,
-        Rect workArea,
+        Rect monitor,
         double gap,
         double contentInset)
     {
         var contentWidth = Math.Max(0, windowSize.Width - contentInset * 2);
         var contentHeight = Math.Max(0, windowSize.Height - contentInset * 2);
-        var minX = workArea.Left + gap;
-        var maxX = Math.Max(minX, workArea.Right - contentWidth - gap);
-        var minY = workArea.Top + gap;
-        var maxY = Math.Max(minY, workArea.Bottom - contentHeight - gap);
+        var minX = monitor.Left + gap;
+        var maxX = Math.Max(minX, monitor.Right - contentWidth - gap);
+        var minY = monitor.Top + gap;
+        var maxY = Math.Max(minY, monitor.Bottom - contentHeight - gap);
 
         var bestLeft = 0.0;
         var bestTop = 0.0;

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -903,14 +903,28 @@
             <Setter.Value>
                 <ControlTemplate TargetType="TextBox">
                     <Grid Background="Transparent">
-                        <TextBlock x:Name="Placeholder"
-                                   Text="{DynamicResource S.Common.SearchLanguage}"
-                                   FontFamily="{TemplateBinding FontFamily}"
-                                   FontSize="{TemplateBinding FontSize}"
-                                   Foreground="{DynamicResource AppTextSecondary}"
-                                   VerticalAlignment="Center"
-                                   IsHitTestVisible="False"
-                                   Visibility="Collapsed"/>
+                        <!-- The glyph belongs to the placeholder, not to the field: it goes when
+                             the first character arrives, along with the words beside it. Keeping it
+                             would mean indenting what is typed past it, and this field is laid over
+                             the spot where the selected language was — text that starts anywhere
+                             else makes the label appear to jump when the list opens. -->
+                        <StackPanel x:Name="Placeholder"
+                                    Orientation="Horizontal"
+                                    VerticalAlignment="Center"
+                                    IsHitTestVisible="False"
+                                    Visibility="Collapsed">
+                            <TextBlock Text="&#xE721;"
+                                       FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                       FontSize="{TemplateBinding FontSize}"
+                                       Foreground="{DynamicResource AppTextSecondary}"
+                                       Margin="0,0,6,0"
+                                       VerticalAlignment="Center"/>
+                            <TextBlock Text="{DynamicResource S.Common.SearchLanguage}"
+                                       FontFamily="{TemplateBinding FontFamily}"
+                                       FontSize="{TemplateBinding FontSize}"
+                                       Foreground="{DynamicResource AppTextSecondary}"
+                                       VerticalAlignment="Center"/>
+                        </StackPanel>
                         <ScrollViewer x:Name="PART_ContentHost"
                                       VerticalAlignment="Center"
                                       HorizontalScrollBarVisibility="Hidden"

--- a/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/TrayMenuWindow.xaml.cs
@@ -41,9 +41,23 @@ public partial class TrayMenuWindow : Window
         PreviewMouseDown += DismissOnNonButtonClick;
     }
 
+    /// <remarks>
+    /// The monitor's full bounds, deliberately not its work area. The work area is the screen minus
+    /// the taskbar, and the tray icon this menu belongs to is <i>on</i> the taskbar — so measured
+    /// against the work area the menu can never reach the thing that opened it. Its corner stops at
+    /// the taskbar's top edge and the menu reads as belonging to nothing, which is exactly what it
+    /// looked like for an icon dragged out of the overflow onto the taskbar. An icon inside the
+    /// overflow flyout sits in the work area instead, which is why the same menu looked correct
+    /// there and hid the problem.
+    ///
+    /// Crossing the taskbar is safe here: the window is topmost and activated, so it is drawn above
+    /// the taskbar rather than clipped by it (verified — a point inside the overlap belongs to this
+    /// window, not to Shell_TrayWnd), and it is gone on the next click either way. Bounds still
+    /// keeps the whole menu on the monitor, which is what the clamping is really for.
+    /// </remarks>
     private void PositionWindow()
     {
-        var area = System.Windows.Forms.Screen.FromPoint(_cursorPhys).WorkingArea;
+        var area = System.Windows.Forms.Screen.FromPoint(_cursorPhys).Bounds;
         var scale = ScreenGeometry.ScaleAt(_cursorPhys.X, _cursorPhys.Y);
         var (left, top) = TrayMenuPlacement.Place(
             new Point(_cursorPhys.X, _cursorPhys.Y),

--- a/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
+++ b/tests/OverTranslate.Tests/TrayMenuWindowTests.cs
@@ -30,6 +30,25 @@ public class TrayMenuWindowTests
         Assert.DoesNotContain("SystemParameters.WorkArea", source);
     }
 
+    /// <summary>
+    /// The menu is measured against the whole monitor, never against the work area.
+    /// </summary>
+    /// <remarks>
+    /// This is the whole of the bug it replaced, and it is one property long, so it is worth a test
+    /// of its own. The work area is the screen minus the taskbar; the tray icon is on the taskbar.
+    /// Measured against the work area the menu physically cannot reach the icon that opened it — it
+    /// stops at the taskbar edge and floats there. Only an icon inside the overflow flyout, which
+    /// does sit in the work area, looked right.
+    /// </remarks>
+    [Fact]
+    public void The_menu_is_kept_on_the_monitor_and_not_pushed_off_the_taskbar()
+    {
+        var source = Source("TrayMenuWindow.xaml.cs");
+
+        Assert.Contains("Screen.FromPoint(_cursorPhys).Bounds", source);
+        Assert.DoesNotContain("WorkingArea", source);
+    }
+
     [Fact]
     public void Showing_the_menu_activates_it_so_clicking_elsewhere_deactivates_and_closes_it()
     {
@@ -63,68 +82,99 @@ public class TrayMenuWindowTests
         });
     }
 
+    /// <remarks>
+    /// A tray icon on a left taskbar is at x=20, and the menu has to be able to start there. It
+    /// leans over the taskbar by an icon width and spends the rest of itself on the screen, which is
+    /// the same trade the bottom taskbar gets.
+    /// </remarks>
     [Fact]
-    public void A_left_taskbar_keeps_the_menu_inside_the_remaining_work_area()
+    public void A_left_taskbar_does_not_push_the_menu_away_from_the_pointer()
     {
-        var workArea = new Rect(48, 0, 1872, 1080);
+        var monitor = new Rect(0, 0, 1920, 1080);
+        var pointer = new Point(20, 600);
+        var window = new Size(240, 180);
 
-        var (left, top) = TrayMenuPlacement.Place(
-            new Point(20, 600), new Size(240, 180), workArea, 4, ShadowInset);
+        var (left, top) = TrayMenuPlacement.Place(pointer, window, monitor, 4, ShadowInset);
 
-        Assert.Equal(34, left);
-        Assert.Equal(438, top);
+        Assert.Equal(pointer.X, left + ShadowInset);
+        Assert.Equal(pointer.Y, top + window.Height - ShadowInset);
     }
 
     [Fact]
-    public void A_top_taskbar_puts_the_menu_below_it_when_there_is_no_room_above()
+    public void A_top_taskbar_hangs_the_menu_below_the_pointer_because_there_is_no_room_above()
     {
-        var workArea = new Rect(0, 48, 1920, 1032);
+        var monitor = new Rect(0, 0, 1920, 1080);
+        var pointer = new Point(900, 20);
+        var window = new Size(240, 180);
 
-        var (left, top) = TrayMenuPlacement.Place(
-            new Point(900, 20), new Size(240, 180), workArea, 4, ShadowInset);
+        var (left, top) = TrayMenuPlacement.Place(pointer, window, monitor, 4, ShadowInset);
 
-        Assert.Equal(882, left);
-        Assert.Equal(34, top);
+        Assert.Equal(pointer.X, left + ShadowInset);
+        Assert.Equal(pointer.Y, top + ShadowInset);
     }
 
     [Fact]
     public void A_right_taskbar_uses_the_visible_bottom_right_corner()
     {
-        var workArea = new Rect(0, 0, 1872, 1080);
+        var monitor = new Rect(0, 0, 1920, 1080);
         var window = new Size(240, 180);
         var pointer = new Point(1900, 600);
 
-        var (left, top) = TrayMenuPlacement.Place(
-            pointer, window, workArea, 4, ShadowInset);
+        var (left, top) = TrayMenuPlacement.Place(pointer, window, monitor, 4, ShadowInset);
 
-        Assert.Equal(workArea.Right - 4, left + window.Width - ShadowInset);
+        Assert.Equal(pointer.X, left + window.Width - ShadowInset);
         Assert.Equal(pointer.Y, top + window.Height - ShadowInset);
     }
 
     [Fact]
     public void A_pointer_on_a_negative_coordinate_monitor_stays_on_that_monitor()
     {
-        var workArea = new Rect(-1920, 0, 1920, 1040);
+        var monitor = new Rect(-1920, 0, 1920, 1080);
+        var window = new Size(240, 180);
+        var pointer = new Point(-10, 1060);
 
-        var (left, top) = TrayMenuPlacement.Place(
-            new Point(-10, 1030), new Size(240, 180), workArea, 4, ShadowInset);
+        var (left, top) = TrayMenuPlacement.Place(pointer, window, monitor, 4, ShadowInset);
 
-        Assert.Equal(-232, left);
-        Assert.Equal(868, top);
+        Assert.Equal(pointer.X, left + window.Width - ShadowInset);
+        Assert.Equal(pointer.Y, top + window.Height - ShadowInset);
+        Assert.True(left + ShadowInset >= monitor.Left, "the menu never leaves the monitor it was opened on");
     }
 
+    /// <summary>
+    /// The reported case: an icon dragged out of the overflow onto the taskbar itself, so the
+    /// pointer is inside the taskbar band rather than above it.
+    /// </summary>
+    /// <remarks>
+    /// The menu leans over the taskbar to get there, which it is allowed to do — it is topmost, so
+    /// it is drawn above the taskbar rather than clipped by it, and it is gone on the next click.
+    /// </remarks>
     [Fact]
-    public void The_visible_corner_nearest_a_bottom_tray_icon_is_as_close_as_the_work_area_allows()
+    public void A_pointer_inside_the_taskbar_still_gets_the_corner_put_on_it()
     {
-        var workArea = new Rect(0, 0, 1920, 1040);
+        var monitor = new Rect(0, 0, 1920, 1080);      // taskbar occupies 1040..1080
         var window = new Size(276, 216);
         var pointer = new Point(400, 1060);
 
-        var (left, top) = TrayMenuPlacement.Place(
-            pointer, window, workArea, 4, ShadowInset);
+        var (left, top) = TrayMenuPlacement.Place(pointer, window, monitor, 4, ShadowInset);
 
         Assert.Equal(pointer.X, left + ShadowInset);
-        Assert.Equal(workArea.Bottom - 4, top + window.Height - ShadowInset);
+        Assert.Equal(pointer.Y, top + window.Height - ShadowInset);
+    }
+
+    /// <remarks>
+    /// The one thing the clamp is still for: a pointer at the very bottom of the screen would put
+    /// the menu edge off the monitor, and that is where it stops.
+    /// </remarks>
+    [Fact]
+    public void A_pointer_at_the_very_bottom_edge_keeps_the_menu_on_screen()
+    {
+        var monitor = new Rect(0, 0, 1920, 1080);
+        var window = new Size(276, 216);
+
+        var (_, top) = TrayMenuPlacement.Place(
+            new Point(400, 1079), window, monitor, 4, ShadowInset);
+
+        Assert.Equal(monitor.Bottom - 4, top + window.Height - ShadowInset);
     }
 
     private static void OnUiThread(Action action)


### PR DESCRIPTION
## 工具匣選單跨不過工具列

圖示被拖出溢位面板、釘在工具列上常駐顯示時，右鍵選單會浮在游標上方一段距離，看起來不屬於任何東西。

原因是 `TrayMenuWindow.PositionWindow` 拿 `Screen.FromPoint(...).WorkingArea` 當夾制範圍，而**工作區的定義就是「螢幕扣掉工具列」**。圖示收在溢位面板裡時，面板浮在工作區內、游標也在工作區內，選單的角可以精準貼上去 —— 所以那條路徑一直是好的，也因此掩蓋了問題。圖示一旦釘在工具列上，游標就落在工作區外，選單底緣被夾在工具列上緣，再也跨不過去。

定位演算法本身沒錯，是夾制範圍把它擋住了。以實機數字（2560x1440、工具列 60px、125%）：

```
游標在釘住的圖示上 y=1410
改之前：maxY = 1380(工作區底) - 156 - 5 = 1219 → 選單底緣 1375，差游標 35px
改之後：maxY = 1440(螢幕底)  - 156 - 5 = 1279 → 選單底緣 1410，正好貼上游標
```

改動是 `WorkingArea` → `Bounds` 一個屬性。夾制範圍變成整個螢幕（含工具列），選單得以壓在工具列上把角貼到游標；夾制原本真正的用途 —— 不讓選單跑出螢幕 —— 完全保留。

動手前先驗證了「置頂視窗蓋不蓋得過 Win11 工具列」，因為蓋不過的話選單下半截會被裁掉、比原本更糟。用與工具匣選單完全相同的視窗旗標（`WindowStyle.None` + `AllowsTransparency` + `Topmost` + `ShowInTaskbar=false`）實測：

```
taskbar  = top 1380, height 60
probe window = (400,1260)-(650,1460), overlaps taskbar by 80px
point (500,1390) inside the overlap belongs to hwnd 4591006, probe hwnd is 4591006
PASS  a topmost window does cover the taskbar
Shell_TrayWnd = 65808, ours = 4591006
```

重疊區的點屬於探針視窗而不是 `Shell_TrayWnd`，確認是蓋在上面而非被裁切。壓住的那塊工具列點下去會落在選單上，而選單非按鈕區域本來就是點了即關。

## 語言搜尋框加上搜尋圖示

放大鏡（Segoe Fluent Icons `E721`）放在提示文字左側，同色同字級（跟著 `FontSize` 走，工具列與取詞翻譯那些 12px 的選單會等比縮），間距 6px。

圖示屬於提示文字而不是欄位，打第一個字就跟提示一起消失。這個輸入框是疊在「原本顯示選取語言的位置」上的，圖示若常駐，打進去的字得往右縮排讓開，展開下拉的瞬間標籤會看起來跳一下 —— 而「原地把標籤換成插入點」正是這個設計成立的基礎。

## 測試

- 新增一行守門測試：`TrayMenuWindow` 原始碼必須用 `Screen.FromPoint(_cursorPhys).Bounds`、不得出現 `WorkingArea`。整個 bug 就這一個屬性
- 原有四個定位測試的合約由「留在工作區內」改為「留在螢幕上、且角要貼到游標」，逐一改寫；另補兩個：游標落在工具列帶內仍要貼齊、游標在螢幕最底緣時仍不得跑出螢幕
- 全套 716 個測試通過
- 另以拋棄式探針實測：置頂視窗覆蓋工具列的 z-order；搜尋框提示的圖示在空白時顯示、輸入後與提示一起消失、清空後回來
