### PR TITLE
feat: 主視窗標題列加入釘選按鈕，可讓視窗常駐置頂

### DIFF
--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -30,6 +30,8 @@
     <sys:String x:Key="S.Shell.Settings">Settings</sys:String>
     <sys:String x:Key="S.Shell.HideSidebar">Hide sidebar</sys:String>
     <sys:String x:Key="S.Shell.ShowSidebar">Show sidebar</sys:String>
+    <sys:String x:Key="S.Shell.Pin">Pin the window on top of other windows</sys:String>
+    <sys:String x:Key="S.Shell.Unpin">Unpin</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">Realtime translation is running — stop it before using screen capture</sys:String>
     <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">Realtime translation is running — stop it before using quick lookup</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">Update to v{0}</sys:String>

--- a/src/OverTranslate/Resources/Strings.ja.xaml
+++ b/src/OverTranslate/Resources/Strings.ja.xaml
@@ -31,6 +31,8 @@
     <sys:String x:Key="S.Shell.Settings">設定</sys:String>
     <sys:String x:Key="S.Shell.HideSidebar">サイドバーを閉じる</sys:String>
     <sys:String x:Key="S.Shell.ShowSidebar">サイドバーを開く</sys:String>
+    <sys:String x:Key="S.Shell.Pin">ウィンドウを常に手前に表示します</sys:String>
+    <sys:String x:Key="S.Shell.Unpin">ピン留めを解除</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">リアルタイム翻訳の実行中です。終了してからキャプチャ翻訳をご利用ください</sys:String>
     <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">リアルタイム翻訳の実行中です。終了してからクイック辞書をご利用ください</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">v{0} にアップデート</sys:String>

--- a/src/OverTranslate/Resources/Strings.ko.xaml
+++ b/src/OverTranslate/Resources/Strings.ko.xaml
@@ -31,6 +31,8 @@
     <sys:String x:Key="S.Shell.Settings">설정</sys:String>
     <sys:String x:Key="S.Shell.HideSidebar">사이드바 접기</sys:String>
     <sys:String x:Key="S.Shell.ShowSidebar">사이드바 펼치기</sys:String>
+    <sys:String x:Key="S.Shell.Pin">창을 항상 위에 표시합니다</sys:String>
+    <sys:String x:Key="S.Shell.Unpin">고정 해제</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">실시간 번역이 실행 중입니다. 종료한 뒤 캡처 번역을 사용하세요</sys:String>
     <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">실시간 번역이 실행 중입니다. 종료한 뒤 빠른 조회를 사용하세요</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">v{0}(으)로 업데이트</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hans.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hans.xaml
@@ -30,6 +30,8 @@
     <sys:String x:Key="S.Shell.Settings">设置</sys:String>
     <sys:String x:Key="S.Shell.HideSidebar">收起侧边栏</sys:String>
     <sys:String x:Key="S.Shell.ShowSidebar">展开侧边栏</sys:String>
+    <sys:String x:Key="S.Shell.Pin">固定后，窗口会常驻最上层</sys:String>
+    <sys:String x:Key="S.Shell.Unpin">取消固定</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">实时翻译进行中，请先结束后再使用截图翻译</sys:String>
     <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">实时翻译进行中，请先结束后再使用取词翻译</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">可更新至 v{0}</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -26,6 +26,8 @@
     <sys:String x:Key="S.Shell.Settings">設定</sys:String>
     <sys:String x:Key="S.Shell.HideSidebar">收起側邊欄</sys:String>
     <sys:String x:Key="S.Shell.ShowSidebar">展開側邊欄</sys:String>
+    <sys:String x:Key="S.Shell.Pin">釘選後，視窗會常駐最上層</sys:String>
+    <sys:String x:Key="S.Shell.Unpin">取消釘選</sys:String>
     <sys:String x:Key="S.Shell.CaptureBlockedByRealtime">即時翻譯進行中，請先結束後再使用截圖翻譯</sys:String>
     <sys:String x:Key="S.Shell.QuickLookupBlockedByRealtime">即時翻譯進行中，請先結束後再使用取詞翻譯</sys:String>
     <sys:String x:Key="S.Shell.UpdateAvailable">可更新至 v{0}</sys:String>

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml
@@ -91,6 +91,21 @@
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
                         WindowChrome.IsHitTestVisibleInChrome="True">
+                <!-- Not one of the three the system strip is otherwise made of, and placed
+                     before them on purpose: the leading edge of that group is where a window's own
+                     caption action goes, and putting it after would break the minimise/restore/close
+                     order that muscle memory is older than this application.
+
+                     Drawn the way 取詞翻譯's pin is — the glyph is the action and the accent is the
+                     state — so the two pins in the app are recognisably the same control, even
+                     though they hold against different things: that one keeps a popup from closing
+                     itself, this one only keeps the window on top. Quieter than the caption glyphs
+                     until it is on, because it is a preference this window carries, not one of the
+                     three things every window does. Content and tooltip come from RefreshPinButton. -->
+                <Button x:Name="PinBtn"
+                        Style="{StaticResource WindowCaptionButton}"
+                        FontSize="12"
+                        Click="PinBtn_Click"/>
                 <Button x:Name="MinimizeBtn"
                         Style="{StaticResource WindowCaptionButton}"
                         Content="&#xE921;"

--- a/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
+++ b/src/OverTranslate/Views/Shell/ShellWindow.xaml.cs
@@ -61,6 +61,19 @@ public partial class ShellWindow : Window
     private static bool _lastRailCollapsed;
 
     /// <summary>
+    /// Whether the pin was on the last time the shell was open, for as long as the process lives.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not in the settings file, and this is the whole of the pin's memory: it is a
+    /// choice about the sitting the user is in — reading something beside a window they are typing
+    /// into — not a preference about the application, so a restart starts unpinned. Remembered
+    /// across a close and reopen for the same reason the size and the page are: closing this window
+    /// is how it is put away, and a user who pinned it should not have to pin it again every time
+    /// it comes back within the same sitting.
+    /// </remarks>
+    private static bool _lastPinned;
+
+    /// <summary>
     /// The page the shell was last showing, so opening it again lands where the user left off
     /// rather than always on 文字翻譯.
     /// </summary>
@@ -181,6 +194,8 @@ public partial class ShellWindow : Window
         _railCollapsed = _lastRailCollapsed;
         SetRailWidth(_railCollapsed ? 0 : RailWidth);
         RefreshSidebarToggle();
+
+        SetPinned(_lastPinned);
     }
 
     // The window's outer edge is the compositor's, not this window's, so it is the one colour in
@@ -192,6 +207,7 @@ public partial class ShellWindow : Window
         RefreshQuickToolAvailability();
         RefreshUpdateAvailability();
         RefreshSidebarToggle();
+        RefreshPinButton();
     }
 
     /// <summary>
@@ -445,6 +461,54 @@ public partial class ShellWindow : Window
         AutomationProperties.SetName(SidebarToggleBtn, label);
     }
 
+    /// <summary>Whether the user has asked for this window to stay above the others.</summary>
+    private bool _pinned;
+
+    private void PinBtn_Click(object sender, RoutedEventArgs e) => SetPinned(!_pinned);
+
+    /// <summary>
+    /// Turns the pin on or off, which is only ever the window's z-order.
+    /// </summary>
+    /// <remarks>
+    /// Topmost and nothing else, on purpose. Everything that already takes this window off the
+    /// screen goes on doing it while pinned — the shortcut that closes the shell when it is the
+    /// window in front, 截圖翻譯 hiding it so it is not baked into the shot, a realtime session
+    /// putting it away for the duration. A pin that also held against those would be a second,
+    /// invisible rule about when the window may close, and the user asked for one thing: that it
+    /// stop going behind whatever they click next.
+    /// </remarks>
+    private void SetPinned(bool pinned)
+    {
+        _pinned = pinned;
+        Topmost = pinned;
+        RefreshPinButton();
+    }
+
+    /// <summary>
+    /// Draws the pin: the glyph is the action, the accent is the state.
+    /// </summary>
+    /// <remarks>
+    /// The same two glyphs and the same accent as 取詞翻譯's pin, so the two read as one control
+    /// even though they hold against different things. Segoe MDL2 codepoints so they survive
+    /// Windows 10, where Segoe Fluent Icons is not installed; see Views/Controls/TtsGlyphs.
+    ///
+    /// Off, it is quieter than the caption glyphs beside it: unpinned is the state every session
+    /// starts in, and a strip where four buttons are equally loud says the pin is as ordinary as
+    /// closing the window. The tooltip is the accessible name too — there is nothing else on a
+    /// glyph-only button for a screen reader to read out.
+    /// </remarks>
+    private void RefreshPinButton()
+    {
+        PinBtn.Content = _pinned ? "" : "";
+
+        var label = LocalizationService.Get(_pinned ? "S.Shell.Unpin" : "S.Shell.Pin");
+        PinBtn.ToolTip = label;
+        AutomationProperties.SetName(PinBtn, label);
+
+        PinBtn.SetResourceReference(
+            ForegroundProperty, _pinned ? "AppAccent" : "AppTextSecondary");
+    }
+
     private void CaptureBtn_Click(object sender, RoutedEventArgs e)
     {
         // MainWindow owns the whole capture session (hotkey, screenshot, overlay, teardown), so
@@ -632,6 +696,7 @@ public partial class ShellWindow : Window
         // Minimised is a state to reopen out of, not into.
         _lastWindowState = WindowState == WindowState.Minimized ? WindowState.Normal : WindowState;
         _lastRailCollapsed = _railCollapsed;
+        _lastPinned = _pinned;
 
         base.OnClosing(e);
     }


### PR DESCRIPTION
@
## 這個 PR 做了什麼

主翻譯視窗（ShellWindow）標題列右側、最小化按鈕左邊新增一顆釘選按鈕，按下後視窗常駐置頂。

## 設計

- **只做置頂，不改任何既有行為**：`SetPinned()` 唯一做的事是 `Topmost = pinned`。快捷鍵關閉主視窗、截圖翻譯隱藏主視窗、即時翻譯把主視窗收起來，全部維持原本邏輯。
- **切換樣式沿用選詞翻譯的釘選**：圖示 `E718` ↔ `E77A` 互換（圖示代表「按下去會做什麼」），釘選時前景 `AppAccent`、未釘選 `AppTextSecondary`，兩處的釘選看起來是同一顆控制項。
- **無狀態，只活在行程生命週期內**：釘選狀態存在 `static _lastPinned`，`OnClosing` 寫入、`RestoreSessionLayout` 讀回，機制與既有的 `_lastSize`／`_lastRailCollapsed` 一致——關掉再開還記得，程式重啟回到未釘選，不寫入 appsettings.json。
- tooltip 同時作為 AutomationProperties.Name，語言切換時一併重繪。

## 變更檔案

- `src/OverTranslate/Views/Shell/ShellWindow.xaml`：新增 `PinBtn`
- `src/OverTranslate/Views/Shell/ShellWindow.xaml.cs`：`SetPinned` / `RefreshPinButton` / 狀態記憶
- `src/OverTranslate/Resources/Strings.*.xaml`：五份語系各補 `S.Shell.Pin` / `S.Shell.Unpin`

功能很小，README 未做任何補充。

## 驗證

- `dotnet build`：成功（僅既有的 CA1416 警告）
- `dotnet test`：772 通過 / 0 失敗 / 2 略過

## 已知邊界

釘選狀態下用**快捷鍵**截圖時主視窗不會被隱藏，有機會蓋在譯文疊圖上方。這符合「釘選就只是置頂」的設計，本 PR 未特別處理。
@