### PR TITLE
截圖層的逃生機制：Esc 換執行緒、工作管理員讓位

### DIFF
--- a/src/OverTranslate/Services/AlwaysOnTop.cs
+++ b/src/OverTranslate/Services/AlwaysOnTop.cs
@@ -43,19 +43,23 @@ internal static class AlwaysOnTop
     }
 
     /// <summary>
-    /// Puts a window directly behind another one, wherever that one is.
+    /// Puts a window directly behind another one, wherever that one is. False when it did not take.
     /// </summary>
     /// <remarks>
     /// The counterpart to <see cref="Reassert"/>, for stepping aside rather than coming forward.
     /// Clearing Topmost alone does not do it: a window leaving the topmost band arrives at the
     /// front of the ordinary band, which is still in front of the window it was making room for.
+    ///
+    /// The result is worth reading for that reason. Stepping aside is those two moves together, and
+    /// the window this one is aiming behind can be gone by the time it gets here — half of it done
+    /// is worse than none of it: out of the topmost band and still covering what it made room for.
     /// </remarks>
-    public static void PlaceBehind(Window window, IntPtr other)
+    public static bool PlaceBehind(Window window, IntPtr other)
     {
         var hwnd = new WindowInteropHelper(window).Handle;
-        if (hwnd == IntPtr.Zero || other == IntPtr.Zero) return;
+        if (hwnd == IntPtr.Zero || other == IntPtr.Zero) return false;
 
-        SetWindowPos(hwnd, other, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        return SetWindowPos(hwnd, other, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     }
 
     [DllImport("user32.dll", SetLastError = true)]

--- a/src/OverTranslate/Services/AlwaysOnTop.cs
+++ b/src/OverTranslate/Services/AlwaysOnTop.cs
@@ -42,6 +42,22 @@ internal static class AlwaysOnTop
         SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
     }
 
+    /// <summary>
+    /// Puts a window directly behind another one, wherever that one is.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart to <see cref="Reassert"/>, for stepping aside rather than coming forward.
+    /// Clearing Topmost alone does not do it: a window leaving the topmost band arrives at the
+    /// front of the ordinary band, which is still in front of the window it was making room for.
+    /// </remarks>
+    public static void PlaceBehind(Window window, IntPtr other)
+    {
+        var hwnd = new WindowInteropHelper(window).Handle;
+        if (hwnd == IntPtr.Zero || other == IntPtr.Zero) return;
+
+        SetWindowPos(hwnd, other, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    }
+
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool SetWindowPos(

--- a/src/OverTranslate/Services/GlobalAuxiliaryHotkeys.cs
+++ b/src/OverTranslate/Services/GlobalAuxiliaryHotkeys.cs
@@ -19,11 +19,8 @@ namespace OverTranslate.Services;
 ///
 /// Running the action inside the callback is what made that reachable rather than theoretical: the
 /// realtime shortcut builds a control bar and one overlay window per region before it returns.
-/// Posting the action to the dispatcher answers that, but a hook installed FROM the dispatcher is
-/// only serviced while the interface is idle — so a busy UI thread would go on delaying the whole
-/// system's mouse for as long as it was busy, which is exactly the moment this feature exists for.
-/// Its own thread is what decouples the two, and the controller poll comes off the dispatcher with
-/// it.
+/// Posting the action to the dispatcher answers that; keeping the hook itself off the dispatcher is
+/// <see cref="HookThread"/>'s job, and the controller poll comes off the dispatcher with it.
 /// </remarks>
 internal sealed class GlobalAuxiliaryHotkeys : IDisposable
 {
@@ -41,10 +38,6 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
     // game. On the hook thread, so it neither waits for the interface nor holds it up.
     private static readonly TimeSpan GamepadPollInterval = TimeSpan.FromMilliseconds(35);
 
-    // How long Dispose waits for the hook thread to finish pumping. Bounded rather than infinite: a
-    // shortcut listener is not worth hanging the application's close on.
-    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(2);
-
     // Replaced wholesale rather than mutated, so the hook thread can read it without a lock while
     // the interface is saving new settings.
     private Dictionary<ShortcutTrigger, HotkeyAction> _bindings = [];
@@ -55,8 +48,7 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
     private LowLevelMouseProc? _mouseProc;
     private IntPtr _mouseHook;
 
-    private Thread? _hookThread;
-    private Dispatcher? _hookDispatcher;
+    private readonly HookThread _hookThread = new("OverTranslate auxiliary shortcuts");
 
     public event Action<HotkeyAction>? ShortcutPressed;
 
@@ -83,11 +75,11 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
             return;
         }
 
-        StartHookThread();
+        _hookThread.Start();
 
         // Invoke rather than BeginInvoke: this runs when settings are saved, at human pace, and the
         // caller is entitled to have the shortcuts live by the time it returns.
-        _hookDispatcher?.Invoke(() => ApplyOnHookThread(needsMouse, needsGamepad));
+        _hookThread.Invoke(() => ApplyOnHookThread(needsMouse, needsGamepad));
     }
 
     public void Dispose()
@@ -96,58 +88,15 @@ internal sealed class GlobalAuxiliaryHotkeys : IDisposable
         Volatile.Write(ref _bindings, []);
     }
 
-    private void StartHookThread()
-    {
-        if (_hookDispatcher is { HasShutdownStarted: false }) return;
-
-        // Waited on rather than assumed: the dispatcher belongs to the new thread and does not exist
-        // until that thread reaches for it, and Register goes on to post work to it immediately.
-        using var ready = new ManualResetEventSlim();
-
-        var thread = new Thread(() =>
-        {
-            _hookDispatcher = Dispatcher.CurrentDispatcher;
-            ready.Set();
-
-            // The message loop the hook needs. A low-level hook is delivered to the thread that
-            // installed it, and only while that thread is pumping messages — without this the
-            // callback would simply never be called.
-            Dispatcher.Run();
-        })
-        {
-            IsBackground = true,
-            Name = "OverTranslate auxiliary shortcuts",
-        };
-
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        ready.Wait();
-
-        _hookThread = thread;
-    }
-
     private void StopHookThread()
     {
-        if (_hookDispatcher is not { } dispatcher) return;
-
-        if (!dispatcher.HasShutdownStarted)
+        _hookThread.Stop(() =>
         {
-            // On the hook thread, because that is where the hook was installed and where the timer
-            // belongs.
-            dispatcher.Invoke(() =>
-            {
-                UninstallMouseHook();
-                _gamepadTimer?.Stop();
-                _gamepadTimer = null;
-                Array.Clear(_previousGamepadButtons, 0, _previousGamepadButtons.Length);
-            });
-
-            dispatcher.InvokeShutdown();
-        }
-
-        _hookThread?.Join(ShutdownTimeout);
-        _hookThread = null;
-        _hookDispatcher = null;
+            UninstallMouseHook();
+            _gamepadTimer?.Stop();
+            _gamepadTimer = null;
+            Array.Clear(_previousGamepadButtons, 0, _previousGamepadButtons.Length);
+        });
     }
 
     /// <summary>Brings the hooks into line with the bindings. Runs on the hook thread.</summary>

--- a/src/OverTranslate/Services/GlobalEscapeHook.cs
+++ b/src/OverTranslate/Services/GlobalEscapeHook.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Windows.Threading;
 using NLog;
 
 namespace OverTranslate.Services;
@@ -10,6 +11,14 @@ namespace OverTranslate.Services;
 // that window holds the keyboard focus — which it cannot count on (the tray menu closing right
 // after it opens, full-screen games, elevated foreground windows). Owning the hook for the whole
 // session is what makes Esc behave identically before and after the selection is drawn.
+//
+// The hook lives on its own message-pumping thread (see HookThread), and that is what makes Esc
+// an escape hatch rather than one more thing that stops working. The capture layers are Topmost
+// and cover the whole virtual desktop, so nothing — Task Manager included — can be raised over
+// them; Esc is the way out. Installed from the dispatcher, the callback would be delivered to the
+// dispatcher too, so any UI thread that stopped pumping would take Esc down with it at exactly the
+// moment it was needed, and would stall the entire desktop's keyboard until LowLevelHooksTimeout
+// on every key besides.
 internal sealed class GlobalEscapeHook : IDisposable
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
@@ -36,6 +45,7 @@ internal sealed class GlobalEscapeHook : IDisposable
     // would corrupt the hook chain.
     private readonly LowLevelKeyboardProc _proc;
     private readonly Action _onEscape;
+    private readonly HookThread _thread = new("OverTranslate escape hook");
     private IntPtr _hookId;
 
     private GlobalEscapeHook(Action onEscape)
@@ -48,19 +58,29 @@ internal sealed class GlobalEscapeHook : IDisposable
     {
         var hook = new GlobalEscapeHook(onEscape);
 
+        hook._thread.Start();
+
+        // Invoke rather than BeginInvoke: the caller is entitled to have Esc live by the time this
+        // returns, and installing a hook is a single syscall.
+        hook._thread.Invoke(hook.InstallOnHookThread);
+
+        return hook;
+    }
+
+    /// <summary>Runs on the hook thread, which is the only thread the hook can be installed from.</summary>
+    private void InstallOnHookThread()
+    {
         // GetModuleHandle(null) returns this process's own module handle directly. Resolving it via
         // Process.GetCurrentProcess().MainModule enumerates the process module list and costs
         // milliseconds on a path that runs while the capture window is being presented.
-        hook._hookId = SetWindowsHookEx(WH_KEYBOARD_LL, hook._proc, GetModuleHandle(null), 0);
+        _hookId = SetWindowsHookEx(WH_KEYBOARD_LL, _proc, GetModuleHandle(null), 0);
 
-        if (hook._hookId == IntPtr.Zero)
+        if (_hookId == IntPtr.Zero)
         {
             int error = Marshal.GetLastWin32Error();
             Log.Warn("Esc hook install failed (win32 error {Error}) — Esc will only cancel while the capture window has focus",
                 error);
         }
-
-        return hook;
     }
 
     private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
@@ -70,7 +90,12 @@ internal sealed class GlobalEscapeHook : IDisposable
             // Post, never wait. A low-level hook callback that runs longer than
             // LowLevelHooksTimeout (5s by default) gets silently dropped from the hook chain by
             // Windows, and from then on Esc would stop cancelling for the rest of the session.
-            System.Windows.Application.Current?.Dispatcher.BeginInvoke(_onEscape);
+            //
+            // Send priority, not the default: a UI thread busy enough to be worth escaping from
+            // has a queue of pointer events behind it, and cancelling has to jump that queue
+            // rather than take its place at the back of it. Everything the interface queues for
+            // itself is Normal or below.
+            System.Windows.Application.Current?.Dispatcher.BeginInvoke(DispatcherPriority.Send, _onEscape);
             return (IntPtr)1; // swallow, so Esc does not also reach the app being translated
         }
 
@@ -79,8 +104,12 @@ internal sealed class GlobalEscapeHook : IDisposable
 
     public void Dispose()
     {
-        if (_hookId == IntPtr.Zero) return;
-        UnhookWindowsHookEx(_hookId);
-        _hookId = IntPtr.Zero;
+        // On the hook thread: a hook can only be removed from the thread that installed it.
+        _thread.Stop(() =>
+        {
+            if (_hookId == IntPtr.Zero) return;
+            UnhookWindowsHookEx(_hookId);
+            _hookId = IntPtr.Zero;
+        });
     }
 }

--- a/src/OverTranslate/Services/HookThread.cs
+++ b/src/OverTranslate/Services/HookThread.cs
@@ -1,4 +1,5 @@
 using System.Windows.Threading;
+using NLog;
 
 namespace OverTranslate.Services;
 
@@ -22,8 +23,10 @@ namespace OverTranslate.Services;
 /// </remarks>
 internal sealed class HookThread : IDisposable
 {
-    // How long Stop waits for the thread to finish pumping. Bounded rather than infinite: a hook
-    // listener is not worth hanging the application's close on.
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    // How long each step of Stop waits. Bounded rather than infinite: a hook listener is not worth
+    // hanging the application's close on.
     private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(2);
 
     private readonly string _name;
@@ -78,11 +81,25 @@ internal sealed class HookThread : IDisposable
 
         if (!dispatcher.HasShutdownStarted)
         {
-            if (teardown is not null) dispatcher.Invoke(teardown);
+            // Bounded, not a plain Invoke. This thread exists precisely because it can be sitting
+            // inside an OS callback that nobody controls the length of, and waiting on it without a
+            // limit would hang the application's close on exactly that — the hang this class is
+            // here to keep off the interface thread in the first place.
+            if (teardown is not null &&
+                dispatcher.InvokeAsync(teardown).Wait(ShutdownTimeout) != DispatcherOperationStatus.Completed)
+            {
+                Log.Warn("Hook thread '{Name}' did not run its teardown within {Timeout}", _name, ShutdownTimeout);
+            }
+
             dispatcher.InvokeShutdown();
         }
 
-        _thread?.Join(ShutdownTimeout);
+        // Said out loud rather than assumed: the fields are cleared either way, so a later Start
+        // would quietly build a second thread beside a first one that is still pumping, and two
+        // threads under the same name is not something anyone would work out from a stack list.
+        if (_thread?.Join(ShutdownTimeout) == false)
+            Log.Warn("Hook thread '{Name}' still running after {Timeout}", _name, ShutdownTimeout);
+
         _thread = null;
         _dispatcher = null;
     }

--- a/src/OverTranslate/Services/HookThread.cs
+++ b/src/OverTranslate/Services/HookThread.cs
@@ -1,0 +1,91 @@
+using System.Windows.Threading;
+
+namespace OverTranslate.Services;
+
+/// <summary>
+/// A private message-pumping thread for the low-level hooks to live on.
+/// </summary>
+/// <remarks>
+/// <para>A low-level hook is delivered to the thread that installed it, and only while that thread
+/// is pumping messages. Installing one from the dispatcher therefore ties every callback to the
+/// interface being idle — and a callback that outstays <c>LowLevelHooksTimeout</c> (5s by default)
+/// is silently dropped from the hook chain by Windows, after which that hook is dead for the rest
+/// of the session and nothing says why.</para>
+///
+/// <para>Worse than losing the hook: Windows holds every keyboard and mouse event in the system
+/// until the callback returns, so a busy UI thread delays the whole desktop's input for as long as
+/// it is busy. That is exactly the moment Esc exists for, and exactly the moment a UI-thread hook
+/// stops answering it.</para>
+///
+/// <para>Its own thread decouples the two. Nothing here runs the hook's <em>action</em> — the
+/// callback should still hand that to the dispatcher and return at once.</para>
+/// </remarks>
+internal sealed class HookThread : IDisposable
+{
+    // How long Stop waits for the thread to finish pumping. Bounded rather than infinite: a hook
+    // listener is not worth hanging the application's close on.
+    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly string _name;
+    private Thread? _thread;
+    private Dispatcher? _dispatcher;
+
+    public HookThread(string name) => _name = name;
+
+    /// <summary>The thread's dispatcher, or null while it is not running.</summary>
+    public Dispatcher? Dispatcher => _dispatcher is { HasShutdownStarted: false } d ? d : null;
+
+    /// <summary>Starts the thread if it is not already pumping. Safe to call repeatedly.</summary>
+    public void Start()
+    {
+        if (Dispatcher is not null) return;
+
+        // Waited on rather than assumed: the dispatcher belongs to the new thread and does not
+        // exist until that thread reaches for it, and callers post work to it immediately.
+        using var ready = new ManualResetEventSlim();
+
+        var thread = new Thread(() =>
+        {
+            _dispatcher = Dispatcher.CurrentDispatcher;
+            ready.Set();
+            Dispatcher.Run();
+        })
+        {
+            IsBackground = true,
+            Name = _name,
+        };
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        ready.Wait();
+
+        _thread = thread;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="work"/> on the hook thread and waits for it, or does nothing when the
+    /// thread is not running.
+    /// </summary>
+    public void Invoke(Action work) => Dispatcher?.Invoke(work);
+
+    /// <summary>
+    /// Ends the thread, running <paramref name="teardown"/> on it first — hooks have to be removed
+    /// from the thread that installed them.
+    /// </summary>
+    public void Stop(Action? teardown = null)
+    {
+        if (_dispatcher is not { } dispatcher) return;
+
+        if (!dispatcher.HasShutdownStarted)
+        {
+            if (teardown is not null) dispatcher.Invoke(teardown);
+            dispatcher.InvokeShutdown();
+        }
+
+        _thread?.Join(ShutdownTimeout);
+        _thread = null;
+        _dispatcher = null;
+    }
+
+    public void Dispose() => Stop();
+}

--- a/src/OverTranslate/Services/SystemRecoveryYield.cs
+++ b/src/OverTranslate/Services/SystemRecoveryYield.cs
@@ -1,0 +1,163 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Windows.Threading;
+using NLog;
+
+namespace OverTranslate.Services;
+
+/// <summary>
+/// Lets the system's own recovery interface — Task Manager — come out above the capture layers,
+/// and takes the top back once the user returns to this application.
+/// </summary>
+/// <remarks>
+/// <para>The capture layers are Topmost and cover the whole virtual desktop, which means that when
+/// something goes wrong behind them there is nothing the user can raise over them to deal with it.
+/// Ctrl+Alt+Del still appears — winlogon draws it on its own desktop and no application can cover
+/// that — but choosing 工作管理員 from it drops back to the ordinary desktop and starts Task Manager
+/// there, underneath this application's Topmost windows. The user is then looking at the overlay
+/// with the one tool that could end it hidden behind it.</para>
+///
+/// <para>The narrow answer, rather than dropping Topmost generally: Topmost is what keeps the
+/// capture layer over the window being captured, and giving that up for every window would change
+/// the feature during ordinary use. Only Task Manager gets past, and only while it is in front.</para>
+///
+/// <para>This is not a substitute for <see cref="GlobalEscapeHook"/>. Both the foreground callback
+/// and the Topmost change need the interface thread eventually — a thread wedged solid answers
+/// neither, and Esc is what covers that. What this covers is the interface that is merely slow, or
+/// misbehaving in a way that leaves it pumping: there the window the user reaches for actually
+/// appears.</para>
+///
+/// <para>Task Manager only, matched by process name. Widening it — Process Explorer, another shell
+/// tool — is a line in <see cref="RecoveryProcessNames"/>; it is deliberately not a guess about what
+/// "system" means, because everything let past this can cover the screenshot the user is taking.</para>
+/// </remarks>
+internal sealed class SystemRecoveryYield : IDisposable
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    /// <summary>Process names (no extension, as Windows reports them) allowed above the capture layer.</summary>
+    private static readonly string[] RecoveryProcessNames = ["Taskmgr"];
+
+    private const uint EVENT_SYSTEM_FOREGROUND = 0x0003;
+    private const uint WINEVENT_OUTOFCONTEXT = 0x0000;
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr SetWinEventHook(
+        uint eventMin, uint eventMax, IntPtr hmodWinEventProc, WinEventProc lpfnWinEventProc,
+        uint idProcess, uint idThread, uint dwFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool UnhookWinEvent(IntPtr hWinEventHook);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+
+    private delegate void WinEventProc(
+        IntPtr hook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint thread, uint time);
+
+    // Kept in a field: Windows holds a raw pointer to this delegate, so letting the GC collect it
+    // would corrupt the hook chain.
+    private readonly WinEventProc _proc;
+    private readonly Action _onChanged;
+
+    // Its own thread for the same reason the Esc hook has one: a WinEvent hook is delivered to the
+    // thread that installed it, and only while that thread pumps messages.
+    private readonly HookThread _thread = new("OverTranslate recovery watch");
+
+    private IntPtr _hookId;
+    private int _yielded; // 0/1 rather than bool: written on the hook thread, read on the dispatcher
+
+    /// <summary>True while Task Manager is the one that should be on top.</summary>
+    public bool HasYielded => Volatile.Read(ref _yielded) != 0;
+
+    private SystemRecoveryYield(Action onChanged)
+    {
+        _onChanged = onChanged;
+        _proc = OnForegroundChanged;
+    }
+
+    /// <summary>
+    /// Starts watching. <paramref name="onChanged"/> is raised on the dispatcher whenever
+    /// <see cref="HasYielded"/> flips, and is expected to bring the session's windows into line.
+    /// </summary>
+    public static SystemRecoveryYield Install(Action onChanged)
+    {
+        var watch = new SystemRecoveryYield(onChanged);
+
+        watch._thread.Start();
+        watch._thread.Invoke(watch.InstallOnHookThread);
+
+        return watch;
+    }
+
+    private void InstallOnHookThread()
+    {
+        // Foreground changes only: nothing here needs to know about anything else that moves, and
+        // a wider range would put this callback on the path of events the whole desktop raises.
+        _hookId = SetWinEventHook(
+            EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND,
+            IntPtr.Zero, _proc, 0, 0, WINEVENT_OUTOFCONTEXT);
+
+        if (_hookId == IntPtr.Zero)
+            Log.Warn("Foreground watch install failed — Task Manager will stay behind the capture layer");
+    }
+
+    private void OnForegroundChanged(
+        IntPtr hook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint thread, uint time)
+    {
+        if (hwnd == IntPtr.Zero) return;
+
+        bool? yield = ClassifyForeground(hwnd);
+        if (yield is not { } wanted) return; // some third application: leave the decision as it is
+
+        if (Interlocked.Exchange(ref _yielded, wanted ? 1 : 0) == (wanted ? 1 : 0)) return;
+
+        Log.Info("Capture layer {Action} the top for the system recovery interface", wanted ? "yields" : "takes back");
+
+        // Send priority, and posted rather than run here: this is an OS callback on a hook thread,
+        // and Topmost belongs to the thread that owns the windows.
+        System.Windows.Application.Current?.Dispatcher.BeginInvoke(DispatcherPriority.Send, _onChanged);
+    }
+
+    /// <summary>
+    /// True to hand the top over, false to take it back, null for a window that is neither — this
+    /// application's own or the recovery interface.
+    /// </summary>
+    private static bool? ClassifyForeground(IntPtr hwnd)
+    {
+        GetWindowThreadProcessId(hwnd, out uint pid);
+        if (pid == 0) return null;
+
+        if (pid == Environment.ProcessId) return false;
+
+        try
+        {
+            using var process = Process.GetProcessById((int)pid);
+            return IsRecoveryProcess(process.ProcessName) ? true : null;
+        }
+        catch (ArgumentException)
+        {
+            return null; // already gone between the event and this lookup
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Whether a process is one this application steps aside for.</summary>
+    internal static bool IsRecoveryProcess(string processName) =>
+        RecoveryProcessNames.Contains(processName, StringComparer.OrdinalIgnoreCase);
+
+    public void Dispose()
+    {
+        _thread.Stop(() =>
+        {
+            if (_hookId == IntPtr.Zero) return;
+            UnhookWinEvent(_hookId);
+            _hookId = IntPtr.Zero;
+        });
+
+        Volatile.Write(ref _yielded, 0);
+    }
+}

--- a/src/OverTranslate/Services/SystemRecoveryYield.cs
+++ b/src/OverTranslate/Services/SystemRecoveryYield.cs
@@ -52,6 +52,9 @@ internal sealed class SystemRecoveryYield : IDisposable
     private static extern bool UnhookWinEvent(IntPtr hWinEventHook);
 
     [DllImport("user32.dll")]
+    private static extern bool IsWindow(IntPtr hwnd);
+
+    [DllImport("user32.dll")]
     private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
 
     private delegate void WinEventProc(
@@ -116,10 +119,36 @@ internal sealed class SystemRecoveryYield : IDisposable
     private void OnForegroundChanged(
         IntPtr hook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint thread, uint time)
     {
+        // Nothing may leave this method. It is an OS callback on a thread with no other frame above
+        // it, so an exception here is not a failed step-aside — it is the whole application gone,
+        // in the middle of a capture, over a question about somebody else's window.
+        try
+        {
+            Decide(hwnd);
+        }
+        catch (Exception ex)
+        {
+            Log.Warn(ex, "Foreground change could not be classified — the capture layer stays where it is");
+        }
+    }
+
+    private void Decide(IntPtr hwnd)
+    {
         if (hwnd == IntPtr.Zero) return;
 
         bool? yield = ClassifyForeground(hwnd);
-        if (yield is not { } wanted) return; // some third application: leave the decision as it is
+
+        if (yield is null)
+        {
+            // Some third application. Normally not an answer to this question — but if the window
+            // that was being made room for has since been closed, it is: otherwise the layers stay
+            // out of the topmost band for the rest of the session, buried under whatever the user
+            // switched to next, with the thing they stepped aside for no longer even on screen.
+            if (!HasYielded || IsWindow(RecoveryWindow)) return;
+            yield = false;
+        }
+
+        bool wanted = yield.Value;
 
         Volatile.Write(ref _recoveryWindow, wanted ? hwnd : IntPtr.Zero);
 
@@ -155,12 +184,11 @@ internal sealed class SystemRecoveryYield : IDisposable
             using var process = Process.GetProcessById((int)pid);
             return IsRecoveryProcess(process.ProcessName) ? true : null;
         }
-        catch (ArgumentException)
+        catch (Exception)
         {
-            return null; // already gone between the event and this lookup
-        }
-        catch (InvalidOperationException)
-        {
+            // Every kind of "cannot answer" is the same answer here: the process ended between the
+            // event and this lookup, or it is one this one is not allowed to ask about. Neither is
+            // Task Manager as far as anything downstream is concerned.
             return null;
         }
     }

--- a/src/OverTranslate/Services/SystemRecoveryYield.cs
+++ b/src/OverTranslate/Services/SystemRecoveryYield.cs
@@ -19,7 +19,9 @@ namespace OverTranslate.Services;
 ///
 /// <para>The narrow answer, rather than dropping Topmost generally: Topmost is what keeps the
 /// capture layer over the window being captured, and giving that up for every window would change
-/// the feature during ordinary use. Only Task Manager gets past, and only while it is in front.</para>
+/// the feature during ordinary use. Only Task Manager sets it off, and returning to this
+/// application puts it back. In between the layer is an ordinary window and anything can cover it —
+/// which is the point, since by then the user has gone looking for a way to end the session.</para>
 ///
 /// <para>This is not a substitute for <see cref="GlobalEscapeHook"/>. Both the foreground callback
 /// and the Topmost change need the interface thread eventually — a thread wedged solid answers
@@ -137,8 +139,9 @@ internal sealed class SystemRecoveryYield : IDisposable
     }
 
     /// <summary>
-    /// True to hand the top over, false to take it back, null for a window that is neither — this
-    /// application's own or the recovery interface.
+    /// True for the recovery interface, false for one of this application's own windows, and null
+    /// for everything else — a third application coming forward is not an answer to this question,
+    /// so whatever was decided last stands.
     /// </summary>
     private static bool? ClassifyForeground(IntPtr hwnd)
     {

--- a/src/OverTranslate/Services/SystemRecoveryYield.cs
+++ b/src/OverTranslate/Services/SystemRecoveryYield.cs
@@ -65,10 +65,19 @@ internal sealed class SystemRecoveryYield : IDisposable
     private readonly HookThread _thread = new("OverTranslate recovery watch");
 
     private IntPtr _hookId;
-    private int _yielded; // 0/1 rather than bool: written on the hook thread, read on the dispatcher
+    private int _yielded;         // 0/1 rather than bool: written on the hook thread, read on the dispatcher
+    private IntPtr _recoveryWindow; // the window to sit directly behind while yielded
 
     /// <summary>True while Task Manager is the one that should be on top.</summary>
     public bool HasYielded => Volatile.Read(ref _yielded) != 0;
+
+    /// <summary>
+    /// The recovery window to sit behind, or zero. Leaving the topmost band is not enough on its
+    /// own: it puts a window at the front of the ordinary band, which is still above the Task
+    /// Manager the user just brought up. Measured — the layer stayed in front until it was
+    /// explicitly placed behind this handle.
+    /// </summary>
+    public IntPtr RecoveryWindow => Volatile.Read(ref _recoveryWindow);
 
     private SystemRecoveryYield(Action onChanged)
     {
@@ -110,9 +119,17 @@ internal sealed class SystemRecoveryYield : IDisposable
         bool? yield = ClassifyForeground(hwnd);
         if (yield is not { } wanted) return; // some third application: leave the decision as it is
 
-        if (Interlocked.Exchange(ref _yielded, wanted ? 1 : 0) == (wanted ? 1 : 0)) return;
+        Volatile.Write(ref _recoveryWindow, wanted ? hwnd : IntPtr.Zero);
 
-        Log.Info("Capture layer {Action} the top for the system recovery interface", wanted ? "yields" : "takes back");
+        // Raised again even when the answer has not changed. Task Manager coming forward a second
+        // time — from the taskbar, from Ctrl+Alt+Del, after its window was rebuilt — has to put the
+        // layer behind whatever window it is now, and a handle from the first time it appeared may
+        // no longer exist.
+        bool changed = Interlocked.Exchange(ref _yielded, wanted ? 1 : 0) != (wanted ? 1 : 0);
+        if (!changed && !wanted) return;
+
+        if (changed)
+            Log.Info("Capture layer {Action} the top for the system recovery interface", wanted ? "yields" : "takes back");
 
         // Send priority, and posted rather than run here: this is an OS callback on a hook thread,
         // and Topmost belongs to the thread that owns the windows.

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -1312,9 +1312,14 @@ public partial class MainWindow : Window
     {
         bool onTop = _recoveryYield?.HasYielded != true;
 
+        // Bottom of the stack first: each one steps in directly behind the recovery window, so the
+        // last one placed ends up highest and the layers keep their own order among themselves.
         foreach (var window in new Window?[] { _captureWindow, _overlayWindow, _toolbarWindow })
         {
-            if (window is not null && window.Topmost != onTop) window.Topmost = onTop;
+            if (window is null) continue;
+
+            window.Topmost = onTop;
+            if (!onTop) AlwaysOnTop.PlaceBehind(window, _recoveryYield!.RecoveryWindow);
         }
     }
 

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -1319,7 +1319,12 @@ public partial class MainWindow : Window
             if (window is null) continue;
 
             window.Topmost = onTop;
-            if (!onTop) AlwaysOnTop.PlaceBehind(window, _recoveryYield!.RecoveryWindow);
+
+            // Both halves or neither. A step-aside that could not be completed — Task Manager gone
+            // between the event and here — would otherwise leave the layer out of the topmost band
+            // and still in front of it, which is worse than never having moved.
+            if (!onTop && !AlwaysOnTop.PlaceBehind(window, _recoveryYield!.RecoveryWindow))
+                window.Topmost = true;
         }
     }
 

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ public partial class MainWindow : Window
     private ScreenCaptureWindow? _captureWindow;
     private ToolbarWindow? _toolbarWindow;
     private GlobalEscapeHook? _escapeHook; // lives for the whole capture session, see CloseAll
+    private SystemRecoveryYield? _recoveryYield; // same lifetime; lets Task Manager out from under the layers
     private CancellationTokenSource? _sessionCts; // cancelled on teardown so abandoned work stops
     private EventHandler? _overlayClosedHandler; // tracked so we can detach before re-translate
     // Recognition and translation are not owned here — see AppServices. This window is one of two
@@ -610,8 +611,12 @@ public partial class MainWindow : Window
             // Release any previous one first — this hook swallows Esc process-wide, so an
             // orphaned instance would break Esc across the entire desktop, which is far worse
             // than the stuck overlay it exists to prevent.
-            DisposeEscapeHook();
+            DisposeSessionHooks();
             _escapeHook = GlobalEscapeHook.Install(CloseAll);
+
+            // Paired with the Esc hook and for the same reason: these windows cover the screen, so
+            // both ways out of a session that has gone wrong have to be set up before it can.
+            _recoveryYield = SystemRecoveryYield.Install(ApplyCaptureTopmost);
 
             CancelSession();
             _sessionCts = new CancellationTokenSource();
@@ -621,7 +626,7 @@ public partial class MainWindow : Window
             {
                 // Also reached when the capture window cancelled itself (its own Esc fallback),
                 // which never goes through CloseAll — so the session is torn down here too.
-                DisposeEscapeHook();
+                DisposeSessionHooks();
                 CancelSession();
                 captureWindow.Close();
                 _captureWindow = null;
@@ -693,6 +698,8 @@ public partial class MainWindow : Window
         toolbar.SetToggleEnabled(blocks.Count > 0);
         toolbar.SetSpeakableText(SourceTextForSpeech().Length > 0);
         toolbar.Show();
+
+        ApplyCaptureTopmost();
     }
 
     // On re-translate: update the existing overlay in-place to avoid z-order fights with
@@ -739,7 +746,7 @@ public partial class MainWindow : Window
         _overlayClosedHandler = (_, _) =>
         {
             _selectionSessionId++;
-            DisposeEscapeHook();
+            DisposeSessionHooks();
             CancelSession();
             ToastWindow.Dismiss();
             CloseWindow(_toolbarWindow, w => w.Close(), nameof(ToolbarWindow));
@@ -1252,7 +1259,7 @@ public partial class MainWindow : Window
         Log.Info("Tearing down capture session (overlay={Overlay}, toolbar={Toolbar}, capture={Capture})",
             _overlayWindow != null, _toolbarWindow != null, _captureWindow != null);
         _selectionSessionId++;
-        DisposeEscapeHook();
+        DisposeSessionHooks();
         CancelSession();
 
         // A voice reading a selection that is no longer on screen has nothing left to be about, and
@@ -1287,11 +1294,28 @@ public partial class MainWindow : Window
         RestoreShellAfterCapture();
     }
 
-    // The hook is process-wide and swallows Esc, so it must never outlive the session that owns it.
-    private void DisposeEscapeHook()
+    // The Esc hook is process-wide and swallows Esc, so it must never outlive the session that owns
+    // it; the recovery watch goes with it because there is nothing left to yield the top to.
+    private void DisposeSessionHooks()
     {
         _escapeHook?.Dispose();
         _escapeHook = null;
+
+        _recoveryYield?.Dispose();
+        _recoveryYield = null;
+    }
+
+    // Puts the session's windows where the recovery watch says they belong. Called both when it
+    // changes its mind and after a window is created, since the overlay and the toolbar are built
+    // after the selection is drawn and would otherwise come up on top of a Task Manager already out.
+    private void ApplyCaptureTopmost()
+    {
+        bool onTop = _recoveryYield?.HasYielded != true;
+
+        foreach (var window in new Window?[] { _captureWindow, _overlayWindow, _toolbarWindow })
+        {
+            if (window is not null && window.Topmost != onTop) window.Topmost = onTop;
+        }
     }
 
     // Signals recognition/translation started by this session to stop. The source is not disposed
@@ -1389,7 +1413,7 @@ public partial class MainWindow : Window
         // Its overlays are Topmost and click-through; left behind by a shutdown they would be
         // painted onto the desktop with no process left to close them.
         RealtimeSessionController.Instance.Stop();
-        DisposeEscapeHook();
+        DisposeSessionHooks();
         _hotkey?.Dispose();
         _windowHotkey?.Dispose();
         _realtimePauseHotkey?.Dispose();

--- a/tests/OverTranslate.Tests/HookThreadTests.cs
+++ b/tests/OverTranslate.Tests/HookThreadTests.cs
@@ -1,0 +1,81 @@
+using OverTranslate.Services;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The one property the escape hatch rests on: the hooks do not run on the caller's thread.
+/// </summary>
+/// <remarks>
+/// A low-level hook is delivered to the thread that installed it, so a hook installed from the
+/// dispatcher stops being serviced the moment the dispatcher stops pumping — which is exactly when
+/// Esc has to still work. These tests pin the thread being a separate, pumping, STA one; the hook
+/// itself is Windows' side of the arrangement and cannot be asserted on without real key input.
+/// </remarks>
+public class HookThreadTests
+{
+    [Fact]
+    public void WorkRunsOnItsOwnStaThread_NotTheCallersThread()
+    {
+        using var hookThread = new HookThread("test hook thread");
+        hookThread.Start();
+
+        int threadId = 0;
+        ApartmentState apartment = ApartmentState.Unknown;
+        hookThread.Invoke(() =>
+        {
+            threadId = Environment.CurrentManagedThreadId;
+            apartment = Thread.CurrentThread.GetApartmentState();
+        });
+
+        Assert.NotEqual(Environment.CurrentManagedThreadId, threadId);
+
+        // STA because the thread pumps messages and hosts window-adjacent OS callbacks.
+        Assert.Equal(ApartmentState.STA, apartment);
+    }
+
+    [Fact]
+    public void StartIsIdempotent_SoRepeatedInstallsDoNotLeakThreads()
+    {
+        using var hookThread = new HookThread("test hook thread");
+        hookThread.Start();
+
+        int first = 0, second = 0;
+        hookThread.Invoke(() => first = Environment.CurrentManagedThreadId);
+        hookThread.Start();
+        hookThread.Invoke(() => second = Environment.CurrentManagedThreadId);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void StopRunsTeardownOnTheHookThread_BecauseAHookOnlyComesOffWhereItWentOn()
+    {
+        var hookThread = new HookThread("test hook thread");
+        hookThread.Start();
+
+        int installedOn = 0;
+        hookThread.Invoke(() => installedOn = Environment.CurrentManagedThreadId);
+
+        int tornDownOn = 0;
+        hookThread.Stop(() => tornDownOn = Environment.CurrentManagedThreadId);
+
+        Assert.Equal(installedOn, tornDownOn);
+
+        // Stopped means stopped: nothing is left pumping, so Invoke has nowhere to run.
+        bool ran = false;
+        hookThread.Invoke(() => ran = true);
+        Assert.False(ran);
+    }
+
+    [Fact]
+    public void StopWithoutStartDoesNothing()
+    {
+        var hookThread = new HookThread("test hook thread");
+
+        bool ran = false;
+        hookThread.Stop(() => ran = true);
+
+        Assert.False(ran);
+    }
+}

--- a/tests/OverTranslate.Tests/SystemRecoveryYieldTests.cs
+++ b/tests/OverTranslate.Tests/SystemRecoveryYieldTests.cs
@@ -1,0 +1,28 @@
+using OverTranslate.Services;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// Pins how narrow the exception to Topmost is. Everything that gets past this can cover the
+/// screenshot the user is in the middle of taking, so widening the list is a decision, not a tidy-up.
+/// </summary>
+public class SystemRecoveryYieldTests
+{
+    [Fact]
+    public void TaskManagerIsLetPast_WhateverCaseWindowsReportsItIn()
+    {
+        Assert.True(SystemRecoveryYield.IsRecoveryProcess("Taskmgr"));
+        Assert.True(SystemRecoveryYield.IsRecoveryProcess("taskmgr"));
+        Assert.True(SystemRecoveryYield.IsRecoveryProcess("TASKMGR"));
+    }
+
+    [Theory]
+    [InlineData("explorer")]
+    [InlineData("chrome")]
+    [InlineData("OverTranslate")]
+    [InlineData("Taskmgr.exe")] // Windows reports process names without the extension
+    [InlineData("")]
+    public void EverythingElseStaysUnderTheCaptureLayer(string processName) =>
+        Assert.False(SystemRecoveryYield.IsRecoveryProcess(processName));
+}


### PR DESCRIPTION
截圖選取進行中若 UI 執行緒被卡住，使用者會沒有辦法離開截圖層。這條分支補上兩條逃生路徑。

## 內容

- **Esc 一定按得到**：低階鍵盤 hook 改到自己的執行緒上跑，UI 執行緒卡住時仍然收得到取消。
- **工作管理員優先**：工作管理員出現在前景時，截圖層主動讓出最上層；光是取消 Topmost 還是會蓋在它上面，所以是退到它後面。
- **讓位失敗要看得見**：讓位服務不吞例外、關窗不等待，失敗就退回原狀而不是留在半途的狀態。
- 低階 hook 用的私有訊息迴圈執行緒抽成共用的 `HookThread`。

## 驗證

已在測試版實際操作驗收：UI 卡住時 Esc 可離開、工作管理員可蓋過截圖層、讓位失敗會退回原狀。
