### PR TITLE
fix: 只有一個漢字的區塊不再被當成圖示雜訊刪除

### DIFF
--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -765,7 +765,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         {
             var text = StripLoneIdeographs(block.Text);
             if (text.Length == 0)
-                continue; // the whole block was a single ideograph (an icon) -> drop it
+                continue; // nothing but the stripped ideograph and whitespace was there
             cleaned.Add(text == block.Text ? block : block with { Text = text });
         }
 
@@ -843,18 +843,23 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         c is >= 'À' and <= 'ɏ'    // Latin-1 Supplement, Latin Extended-A and -B
         or >= 'Ḁ' and <= 'ỿ';     // Latin Extended Additional
 
-    // Strips a single isolated Han ideograph when it is clearly icon noise: either the block is
-    // exactly one ideograph, or one is glued to the start/end of a Latin word. The letter-adjacency
-    // guard preserves date glyphs like the 年/月/日 in "2026年5月8日" (those sit next to digits), and
-    // multi-ideograph runs (真實中文 such as 翻譯這個網頁 / 免費) are never single, so are kept.
+    // Strips a single isolated Han ideograph glued to the start or end of a Latin word, which is
+    // what an icon misread on a Latin page looks like. The letter-adjacency guard preserves date
+    // glyphs like the 年/月/日 in "2026年5月8日" (those sit next to digits), and multi-ideograph runs
+    // (真實中文 such as 翻譯這個網頁 / 免費) are never single, so are kept.
+    //
+    // A block that is nothing BUT one ideograph is deliberately not touched. It used to be dropped
+    // outright, on the reasoning that a lone ideograph on an English page is an icon — and that is
+    // sometimes true, but 攻 防 技 火 水 光 闇 標準 are how a Chinese or Japanese interface labels
+    // things, and a screenshot is not required to be in one language just because the user named
+    // one. The old rule deleted them under 英文 and under 自動 alike, silently and with nothing in
+    // the log. Keeping a piece of OCR rubbish costs the reader one wrong word; deleting a real
+    // label costs them the one thing they pointed the tool at.
     internal static string StripLoneIdeographs(string text)
     {
         text = text.Trim();
         if (text.Length == 0)
             return text;
-
-        if (text.Length == 1 && IsHanIdeograph(text[0]))
-            return string.Empty;
 
         if (text.Length >= 2 && IsHanIdeograph(text[0]) && !IsHanIdeograph(text[1]) && char.IsAsciiLetter(text[1]))
             text = text[1..].TrimStart();

--- a/tests/OverTranslate.Tests/OcrServiceTests.cs
+++ b/tests/OverTranslate.Tests/OcrServiceTests.cs
@@ -64,7 +64,7 @@ public class OcrServiceTests
     }
 
     [Fact]
-    public void AutomaticLayout_NormalizesEachBlockAndKeepsLatinIconFiltering()
+    public void AutomaticLayout_NormalizesEachBlockAndKeepsLoneIdeographs()
     {
         var bounds = new System.Windows.Rect(0, 0, 120, 20);
         var blocks = new List<OcrTextBlock>
@@ -76,13 +76,20 @@ public class OcrServiceTests
 
         var normalized = OnnxOcrEngine.NormalizeAutomaticBlocks(blocks);
 
-        Assert.Equal(2, normalized.Count);
+        Assert.Equal(3, normalized.Count);
         Assert.Equal("Settings", normalized[0].Text);
         Assert.NotNull(normalized[0].SourceGlyphHeight);
         Assert.Equal(bounds.Height, normalized[0].Bounds.Height);
         Assert.Equal("設定", normalized[1].Text);
         Assert.Null(normalized[1].SourceGlyphHeight);
         Assert.True(normalized[1].Bounds.Height < bounds.Height);
+
+        // Kept, where it used to be deleted. It is still measured on the Latin path — one Han
+        // character does not satisfy UsesCjkLayoutForText — which is wrong for a full-width glyph
+        // and is pinned here so the geometry work that fixes it has to come past this test rather
+        // than change it by accident. Wrong geometry is a smaller fault than a missing label.
+        Assert.Equal("白", normalized[2].Text);
+        Assert.NotNull(normalized[2].SourceGlyphHeight);
     }
 
     [Fact]
@@ -103,9 +110,16 @@ public class OcrServiceTests
     }
 
     [Theory]
-    // Whole-block lone ideographs are icon misreads on a Latin page -> dropped (empty).
-    [InlineData("白", "")]
-    [InlineData("品", "")]
+    // A block that is nothing but one ideograph is kept. These are how a Chinese or Japanese
+    // interface labels things — a game's 攻/防/技, a colour, a difficulty — and a screenshot is not
+    // required to be in one language just because the user named one. They used to be dropped.
+    [InlineData("白", "白")]
+    [InlineData("品", "品")]
+    [InlineData("攻", "攻")]
+    [InlineData("防", "防")]
+    [InlineData("技", "技")]
+    [InlineData("火", "火")]
+    [InlineData("水", "水")]
     // A lone ideograph glued to the start/end of a Latin word is icon noise -> stripped.
     [InlineData("甲Glossaries", "Glossaries")]
     [InlineData("业spoken terms", "spoken terms")]


### PR DESCRIPTION
## 問題

`StripLoneIdeographs` 的第一條規則是「整個區塊只有一個漢字 → 視為圖示雜訊，刪掉」。這條規則會在兩條路徑上生效：

- **明確英文**：`RemoveIconIdeographNoise`
- **自動**：`NormalizeAutomaticBlocks` 內部（自動雖然跳過前者，但自己呼叫了同一個函式）

也就是說 `攻` `防` `技` `火` `水` `光` `闇` 這類單字標籤，只要來源語言不是明確的日文／中文，就會**無聲消失**，log 裡也不會留下任何紀錄。而自動是預設值。

來源語言只代表使用者希望翻譯端如何理解主要語言，不代表整張截圖的每個區塊都是那個文字系統。遊戲介面、OS UI、網頁很容易同時存在多種語言。

## 改動

移除「整塊只有一個漢字就刪除」這一條。**保留**黏在拉丁字詞頭尾的單漢字剝除（`甲Glossaries` → `Glossaries`），那確實是拉丁頁面上的圖示誤讀。

## 已知且刻意不在本次處理

留下來的單漢字仍然走拉丁版面路徑（`UsesCjkLayoutForText` 要求兩個以上漢字）。對全形字來說那是錯的幾何，但影響有限——單一字元不滿足 pitch 修正的條件（需要字數下限且 `Width > Height * 2`），所以只是「整個框當覆蓋區、字高另計」，不會算出壞尺寸。

這件事已在測試中以斷言釘住，讓後續的版面幾何重構必須正面處理它，而不是順手改掉。

## 驗證

- `StripLoneIdeographs_RemovesIconNoiseButKeepsRealText`：`白`/`品` 由預期空字串改為原樣保留，並補上 `攻`/`防`/`技`/`火`/`水`
- `AutomaticLayout_NormalizesEachBlockAndKeepsLoneIdeographs`（原 `...KeepsLatinIconFiltering`）：改為斷言三個區塊全部保留
- 816 測試通過、2 略過、0 失敗