### PR TITLE
feat: 超過翻譯端點長度上限的長文改為分句送出

### DIFF
--- a/src/OverTranslate/Services/Providers/GTranslateProvider.cs
+++ b/src/OverTranslate/Services/Providers/GTranslateProvider.cs
@@ -101,10 +101,34 @@ public class GTranslateProvider : ITranslationProvider
         var toCode   = MapToGTranslate(targetLang);
         var fromCode = MapSourceToGTranslate(sourceLang);
 
-        var r       = await _translator.TranslateAsync(text, toCode, fromCode);
-        var detLang = r.SourceLanguage?.ISO6391 ?? "";
-        var mapped  = string.IsNullOrEmpty(detLang) ? "" : MapDetectedToDeepL(detLang);
-        return (r.Translation, mapped);
+        // A text past the endpoints' limit is sent as consecutive sentences rather than as one
+        // request. Two of the three engines refuse it outright and the third answers with a
+        // repetition loop, which nothing above here could tell from a translation — see
+        // TranslationRequestChunks.
+        var chunks = TranslationRequestChunks.Split(text);
+        if (chunks.Count == 1)
+        {
+            var single  = await _translator.TranslateAsync(text, toCode, fromCode);
+            var oneLang = single.SourceLanguage?.ISO6391 ?? "";
+            return (single.Translation, string.IsNullOrEmpty(oneLang) ? "" : MapDetectedToDeepL(oneLang));
+        }
+
+        var translations = new List<string>(chunks.Count);
+        var detected = "";
+
+        foreach (var chunk in chunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var part = await _translator.TranslateAsync(chunk, toCode, fromCode);
+            translations.Add(part.Translation);
+            // The first chunk that names a language speaks for the block; the rest are the same
+            // text and a later disagreement is a shorter piece being read with less to go on.
+            if (detected.Length == 0) detected = part.SourceLanguage?.ISO6391 ?? "";
+        }
+
+        var mapped = string.IsNullOrEmpty(detected) ? "" : MapDetectedToDeepL(detected);
+        return (TranslationRequestChunks.Join(translations), mapped);
     }
 
     public async Task<DictionaryLookupData?> LookupDictionaryAsync(

--- a/src/OverTranslate/Services/Providers/GTranslateProvider.cs
+++ b/src/OverTranslate/Services/Providers/GTranslateProvider.cs
@@ -1,18 +1,32 @@
 using GTranslate.Results;
 using GTranslate.Translators;
+using NLog;
 using OverTranslate.Models;
 
 namespace OverTranslate.Services.Providers;
 
 public class GTranslateProvider : ITranslationProvider
 {
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
     private readonly ITranslator _translator;
     private readonly Dictionary<string, string> _targetOverrides;
+    private readonly int _safeInputLimit;
 
-    public GTranslateProvider(ITranslator translator, Dictionary<string, string>? targetOverrides = null)
+    /// <param name="safeInputLimit">
+    /// The most this engine is handed in one request, or null for the shared default. Each engine
+    /// splits for itself at its own transport boundary, so one that turns out to want a smaller
+    /// budget can be given one without every other engine inheriting it — which is what would
+    /// happen if <see cref="ResilientProvider"/> split once for whichever of them answers.
+    /// </param>
+    public GTranslateProvider(
+        ITranslator translator,
+        Dictionary<string, string>? targetOverrides = null,
+        int? safeInputLimit = null)
     {
         _translator     = translator;
         _targetOverrides = targetOverrides ?? [];
+        _safeInputLimit  = safeInputLimit ?? TranslationRequestChunks.SafeMaxCharacters;
     }
 
     public bool RequiresApiKey => false;
@@ -101,11 +115,11 @@ public class GTranslateProvider : ITranslationProvider
         var toCode   = MapToGTranslate(targetLang);
         var fromCode = MapSourceToGTranslate(sourceLang);
 
-        // A text past the endpoints' limit is sent as consecutive sentences rather than as one
-        // request. Two of the three engines refuse it outright and the third answers with a
-        // repetition loop, which nothing above here could tell from a translation — see
+        // A text past this engine's budget is sent as consecutive sentences rather than as one
+        // request. Two of the three engines refuse an over-long text outright and the third answers
+        // with a repetition loop, which nothing above here could tell from a translation — see
         // TranslationRequestChunks.
-        var chunks = TranslationRequestChunks.Split(text);
+        var chunks = TranslationRequestChunks.Split(text, _safeInputLimit);
         if (chunks.Count == 1)
         {
             var single  = await _translator.TranslateAsync(text, toCode, fromCode);
@@ -113,14 +127,23 @@ public class GTranslateProvider : ITranslationProvider
             return (single.Translation, string.IsNullOrEmpty(oneLang) ? "" : MapDetectedToDeepL(oneLang));
         }
 
+        // Where a long text was cut and why, because a translation that reads oddly at a seam is
+        // otherwise indistinguishable from one the engine simply got wrong.
+        Log.Debug(
+            "{Engine}：{Length} 字超過 {Limit} 字上限，分成 {Count} 段（{Boundaries}）",
+            Name, text.Length, _safeInputLimit, chunks.Count,
+            string.Join(", ", chunks.Select(chunk => $"{chunk.Text.Length}/{chunk.BoundaryAfter}")));
+
         var translations = new List<string>(chunks.Count);
         var detected = "";
 
+        // One at a time, never in parallel: these are keyless endpoints, and a burst of requests
+        // from one machine is what throttling is for.
         foreach (var chunk in chunks)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var part = await _translator.TranslateAsync(chunk, toCode, fromCode);
+            var part = await _translator.TranslateAsync(chunk.Text, toCode, fromCode);
             translations.Add(part.Translation);
             // The first chunk that names a language speaks for the block; the rest are the same
             // text and a later disagreement is a shorter piece being read with less to go on.
@@ -128,7 +151,7 @@ public class GTranslateProvider : ITranslationProvider
         }
 
         var mapped = string.IsNullOrEmpty(detected) ? "" : MapDetectedToDeepL(detected);
-        return (TranslationRequestChunks.Join(translations), mapped);
+        return (TranslationRequestChunks.Join(chunks, translations), mapped);
     }
 
     public async Task<DictionaryLookupData?> LookupDictionaryAsync(

--- a/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
+++ b/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
@@ -41,9 +41,29 @@ internal readonly record struct TranslationRequestChunk(
 /// particular sentence. Split, it fits, Microsoft serves it, and it comes back right.</para>
 ///
 /// <para>What this does NOT fix: Google loops on that sentence at any length — sent alone, 270
-/// characters, it fails identically. Whatever triggers it is in the text and not in its size, so a
-/// user whose chosen engine is Google can still receive a translation that came back a success and
-/// is wrong. Nothing here would notice; detecting it would be a separate piece of work.</para>
+/// characters, it fails identically. Bisecting it clause by clause found what actually triggers it,
+/// and it is not something this could act on:</para>
+///
+/// <code>
+/// In terms of speed, PP-OCRv6_medium achieves 5.2× speedup over PP-OCRv5_server on Intel Xeon CPU
+/// with OpenVINO (1.40s vs 7.30s), the tiny tier reaches 6.1× speedup on Apple M4 (0.96s vs 5.82s),
+/// and only 0.13s on A100 GPU.
+/// </code>
+///
+/// <para>Three parallel clauses in one sentence, 221 characters. Clauses one and two together are
+/// fine, two and three together are fine, all three loop. Ending the sentence before the third
+/// clause fixes it, as does removing the bracketed timings. The same shape with hotel prices
+/// instead of benchmarks does not loop at all, so it is not structural either. Both Google
+/// endpoints return the same broken answer byte for byte on repeated attempts, while Bing and
+/// Microsoft translate it correctly.</para>
+///
+/// <para>So it is a property of somebody else's model, with no rule this side could apply in
+/// advance. Catching it on the way back instead — measuring the answer for repetition and handing
+/// the block to another engine — was built and measured and then deliberately not kept: the fault
+/// is Google's, the check would run on every translation the application ever makes, and paying for
+/// that everywhere to cover one endpoint's behaviour was not judged worth it. The record is here so
+/// the next person to meet it knows what it is rather than diagnosing it again; the reproduction is
+/// the sentence above, through <c>OcrHarness --xlate-line</c>.</para>
 ///
 /// <para>The limit became reachable when a wrapped paragraph started going up as one request
 /// instead of seven, which is the point of grouping and worth keeping. So it is answered where it

--- a/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
+++ b/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
@@ -1,8 +1,31 @@
 namespace OverTranslate.Services.Providers;
 
+/// <summary>Why a piece ended where it did, which is what decides how to put it back together.</summary>
+internal enum TranslationChunkBoundary
+{
+    /// <summary>The end of the text: nothing follows.</summary>
+    End,
+
+    /// <summary>A full stop, question or exclamation mark that really ended a sentence.</summary>
+    Sentence,
+
+    /// <summary>A blank line — the only line break that reliably means a new paragraph.</summary>
+    Paragraph,
+
+    /// <summary>A space or a single line break, taken because no sentence ended in range.</summary>
+    Whitespace,
+
+    /// <summary>Nowhere to break at all, so the budget itself decided.</summary>
+    HardSplit,
+}
+
+/// <summary>One piece of a text too long to send in a single request.</summary>
+internal readonly record struct TranslationRequestChunk(
+    string Text, TranslationChunkBoundary BoundaryAfter);
+
 /// <summary>
-/// Cuts a text too long for one request into pieces the free endpoints will accept, at sentence
-/// ends wherever there is one to cut at.
+/// Cuts a text too long for one request into pieces the free endpoints will accept, at the best
+/// boundary each piece can reach.
 /// </summary>
 /// <remarks>
 /// <para>The keyless endpoints take a thousand characters. Microsoft and Bing say so — GTranslate
@@ -12,40 +35,52 @@ namespace OverTranslate.Services.Providers;
 /// model looping, not the text being cut off. Nothing in the pipeline could tell that from a
 /// successful translation, because as far as every layer above is concerned it is one.</para>
 ///
+/// <para>That silent failure is why the working budget is not the hard limit. A refusal is visible
+/// and recoverable; a corrupted answer is neither, so the text is kept clear of the edge rather
+/// than filled up to it — see <see cref="SafeMaxCharacters"/>.</para>
+///
 /// <para>This became reachable when a wrapped paragraph started going up as one request instead of
 /// seven, which is the point of grouping and worth keeping. So the limit is answered where it
 /// belongs — at the transport that has it — rather than by making the grouper translate less
-/// context than the picture supports.</para>
-///
-/// <para>Sentence ends are preferred over word boundaries and word boundaries over nothing, because
-/// what a piece costs is the context inside it: a sentence split down the middle is translated as
-/// two half-thoughts, while consecutive whole sentences lose only what sits between them.</para>
+/// context than the picture supports. Grouping decides what belongs together; this decides how much
+/// of it an endpoint can safely be handed at once, and the two stay independent.</para>
 /// </remarks>
 internal static class TranslationRequestChunks
 {
+    /// <summary>What the endpoints refuse outright, and what this stays away from.</summary>
+    public const int HardMaxCharacters = 1000;
+
     /// <summary>
-    /// The longest text the keyless endpoints accept, and the smallest of their limits, because a
-    /// block is offered to whichever of them answers first.
+    /// The most that is actually sent in one request.
     /// </summary>
-    public const int MaxCharacters = 1000;
+    /// <remarks>
+    /// A fifth under the hard limit, because the hard limit is where the <em>refusals</em> start and
+    /// not where the answers stop being good. Google's repetition loop was measured at 1,181
+    /// characters and nothing says where it begins; the endpoints are unpublished, may count
+    /// encoded bytes rather than characters, and can change without notice. The cost of the margin
+    /// is one extra request on a text between this and the hard limit, which is cheap next to a
+    /// paragraph that comes back quietly wrong.
+    /// </remarks>
+    public const int SafeMaxCharacters = 800;
 
-    public static List<string> Split(string text, int limit = MaxCharacters)
+    public static List<TranslationRequestChunk> Split(string text, int limit = SafeMaxCharacters)
     {
-        if (text.Length <= limit) return [text];
+        if (text.Length <= limit)
+            return [new TranslationRequestChunk(text, TranslationChunkBoundary.End)];
 
-        var chunks = new List<string>();
+        var chunks = new List<TranslationRequestChunk>();
         var start = 0;
 
         while (start < text.Length)
         {
             if (text.Length - start <= limit)
             {
-                chunks.Add(text[start..]);
+                chunks.Add(new TranslationRequestChunk(text[start..], TranslationChunkBoundary.End));
                 break;
             }
 
-            var length = CutLength(text, start, limit);
-            chunks.Add(text[start..(start + length)]);
+            var (length, boundary) = Cut(text, start, limit);
+            chunks.Add(new TranslationRequestChunk(text[start..(start + length)], boundary));
             start += length;
         }
 
@@ -53,72 +88,162 @@ internal static class TranslationRequestChunks
     }
 
     /// <summary>
-    /// How much of the text starting at <paramref name="start"/> to take: as far as the last
-    /// sentence end within the limit, else the last word boundary, else the limit itself.
+    /// How much of the text from <paramref name="start"/> to take, and what ended it.
     /// </summary>
-    private static int CutLength(string text, int start, int limit)
+    /// <remarks>
+    /// <para>A sentence end and a blank line are both real boundaries, so the later of the two wins
+    /// rather than the higher-ranked one: cutting at a full stop 300 characters in when a paragraph
+    /// ends at 700 would throw away half the budget and buy nothing. A lone line break is not in
+    /// that company — in a capture it is where the text met the edge of a column, and in pasted
+    /// prose it is often the same. It ranks with an ordinary space.</para>
+    ///
+    /// <para>Where a sentence ends is a guess, and deliberately a cheap one: "Dr. Smith" and "e.g."
+    /// will be read as sentence ends now and then. That is worth no parser and no dictionary,
+    /// because the job is not to analyse the text — it is to find something better than a blind cut
+    /// near the budget, and a break after "Dr." is still a break between words.</para>
+    /// </remarks>
+    private static (int Length, TranslationChunkBoundary Boundary) Cut(string text, int start, int limit)
     {
-        var lastSentenceEnd = -1;
-        var lastBoundary = -1;
+        var sentence = -1;
+        var paragraph = -1;
+        var whitespace = -1;
 
         for (var i = 0; i < limit; i++)
         {
             var at = start + i;
-            if (IsSentenceEnd(text, at)) lastSentenceEnd = i + 1;
-            else if (char.IsWhiteSpace(text[at])) lastBoundary = i + 1;
+
+            if (IsSentenceEnd(text, at)) sentence = i + 1;
+            else if (IsParagraphBreak(text, at)) paragraph = i + 1;
+            else if (char.IsWhiteSpace(text[at])) whitespace = i + 1;
         }
 
-        // Take the space after the full stop with the sentence it follows, so no piece is sent
-        // with a leading space.
-        if (lastSentenceEnd > 0)
+        if (sentence > 0 || paragraph > 0)
         {
-            while (lastSentenceEnd < limit && char.IsWhiteSpace(text[start + lastSentenceEnd]))
-                lastSentenceEnd++;
+            var boundary = sentence >= paragraph
+                ? TranslationChunkBoundary.Sentence
+                : TranslationChunkBoundary.Paragraph;
 
-            return lastSentenceEnd;
+            // Take the whitespace that follows with the sentence it belongs to, so no piece is sent
+            // with a leading space or newline.
+            return (TakeTrailingWhitespace(text, start, Math.Max(sentence, paragraph), limit), boundary);
         }
 
-        if (lastBoundary > 0) return lastBoundary;
+        if (whitespace > 0)
+            return (whitespace, TranslationChunkBoundary.Whitespace);
 
-        // A thousand characters without a space or a full stop. Nothing to preserve, so take the
-        // limit — but never mid-character, which would send half a surrogate pair.
-        return char.IsLowSurrogate(text[start + limit]) ? limit - 1 : limit;
+        // A whole budget with no space and no full stop. Nothing to preserve, so the limit decides —
+        // but never mid-character, which would send half a surrogate pair.
+        return (
+            char.IsLowSurrogate(text[start + limit]) ? limit - 1 : limit,
+            TranslationChunkBoundary.HardSplit);
+    }
+
+    private static int TakeTrailingWhitespace(string text, int start, int length, int limit)
+    {
+        while (length < limit && char.IsWhiteSpace(text[start + length])) length++;
+        return length;
     }
 
     /// <summary>
-    /// Whether a full stop here ends a sentence rather than sitting inside "1.40s" or "PP-OCRv6".
+    /// Whether a sentence ends here, rather than the mark sitting inside "1.40s" or "PP-OCRv6".
     /// </summary>
     /// <remarks>
-    /// The Latin marks need what follows to be a space, because they are also decimal points and
-    /// abbreviations; the CJK ones do not, because nothing else uses them.
+    /// Two lists rather than one rule, because the difference is not which language wrote the text
+    /// — it is whether the mark has a second job. A line break is in neither, see <see cref="Cut"/>.
     /// </remarks>
     private static bool IsSentenceEnd(string text, int at) =>
-        text[at] switch
-        {
-            '。' or '！' or '？' or '\n' => true,
-            '.' or '!' or '?' => at + 1 >= text.Length || char.IsWhiteSpace(text[at + 1]),
-            _ => false,
-        };
+        EndsSentenceAlone(text[at]) ||
+        (EndsSentenceBeforeSpace(text[at]) &&
+         (at + 1 >= text.Length || char.IsWhiteSpace(text[at + 1])));
 
     /// <summary>
-    /// Puts the pieces back together, with a space wherever both sides are words rather than CJK.
+    /// Marks that end a sentence and do nothing else, so they need no corroboration.
     /// </summary>
-    public static string Join(IEnumerable<string> translations)
+    /// <remarks>
+    /// Written as the punctuation each script actually uses rather than as rules about the script,
+    /// so adding one is adding a character and never a branch. Scripts that set no space after the
+    /// mark are the reason this list exists at all: waiting for a space, as the list below does,
+    /// would find no sentence end anywhere in Chinese, Japanese, Hindi or Urdu.
+    /// </remarks>
+    private static bool EndsSentenceAlone(char mark) =>
+        mark is '。' or '！' or '？' or '｡' or '．'   // CJK, full-width and half-width
+            or '۔' or '؟'                            // Arabic and Urdu
+            or '।' or '॥'                            // Devanagari and the scripts that borrow it
+            or '։' or '።';                           // Armenian and Ethiopic
+
+    /// <summary>
+    /// Marks that end a sentence only when something follows them, because they are also decimal
+    /// points, abbreviations and mid-sentence pauses.
+    /// </summary>
+    private static bool EndsSentenceBeforeSpace(char mark) => mark is '.' or '!' or '?' or '…';
+
+    /// <summary>Whether a blank line starts here, which is the one line break that means something.</summary>
+    private static bool IsParagraphBreak(string text, int at)
     {
-        var joined = "";
+        if (text[at] is not '\n' and not '\r') return false;
 
-        foreach (var part in translations.Select(part => part.Trim()).Where(part => part.Length > 0))
+        // Past this break, through any spaces on the empty line, looking for a second one.
+        for (var i = at + 1; i < text.Length; i++)
         {
-            if (joined.Length == 0)
-            {
-                joined = part;
-                continue;
-            }
-
-            var needsSpace = !char.IsWhiteSpace(joined[^1]) && !char.IsWhiteSpace(part[0]);
-            joined = needsSpace ? $"{joined} {part}" : joined + part;
+            if (text[i] is '\n') return true;
+            if (text[i] is not ('\r' or ' ' or '\t')) return false;
         }
 
-        return joined;
+        return false;
     }
+
+    /// <summary>
+    /// Puts the translated pieces back together the way they were taken apart.
+    /// </summary>
+    /// <remarks>
+    /// What separates two pieces is what separated them in the source, not a space by default: a
+    /// blank line comes back as a blank line, a cut made mid-word closes up with nothing, and
+    /// between sentences the two languages decide — Chinese, Japanese and Korean set their
+    /// sentences without spaces, and inserting one puts a gap in the translation the original never
+    /// had.
+    /// </remarks>
+    public static string Join(
+        IReadOnlyList<TranslationRequestChunk> chunks, IReadOnlyList<string> translations)
+    {
+        var joined = new System.Text.StringBuilder();
+
+        for (var i = 0; i < translations.Count; i++)
+        {
+            var part = translations[i].Trim();
+            if (part.Length == 0) continue;
+
+            if (joined.Length > 0)
+                joined.Append(Separator(chunks[i - 1].BoundaryAfter, joined[^1], part[0]));
+
+            joined.Append(part);
+        }
+
+        return joined.ToString();
+    }
+
+    private static string Separator(TranslationChunkBoundary boundary, char before, char after) =>
+        boundary switch
+        {
+            TranslationChunkBoundary.Paragraph => "\n\n",
+            TranslationChunkBoundary.HardSplit => "",
+            _ => NeedsSpace(before, after) ? " " : "",
+        };
+
+    private static bool NeedsSpace(char before, char after) =>
+        !char.IsWhiteSpace(before) && !char.IsWhiteSpace(after) &&
+        !IsCjk(before) && !IsCjk(after);
+
+    /// <summary>
+    /// Whether a character belongs to a script that sets its words without spaces.
+    /// </summary>
+    /// <remarks>
+    /// Enough of the ranges to answer the question this asks — Han, kana, Hangul, and the full-width
+    /// forms that carry CJK punctuation. A character outside them is treated as one that wants
+    /// spaces around it, which is right for every script the application translates into.
+    /// </remarks>
+    private static bool IsCjk(char character) =>
+        character is >= '⺀' and <= '鿿'    // radicals, kana, bopomofo, Han
+            or >= '가' and <= '힯'          // Hangul syllables
+            or >= '豈' and <= '﫿'          // compatibility ideographs
+            or >= '＀' and <= '￯';         // full-width forms and CJK punctuation
 }

--- a/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
+++ b/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
@@ -53,7 +53,21 @@ internal readonly record struct TranslationRequestChunk(
 /// </remarks>
 internal static class TranslationRequestChunks
 {
-    /// <summary>What the endpoints refuse outright, and what this stays away from.</summary>
+    /// <summary>
+    /// Where Microsoft and Bing start refusing, measured. Nothing is ever sent up to this — see
+    /// <see cref="SafeMaxCharacters"/>, which is the limit every request actually uses.
+    /// </summary>
+    /// <remarks>
+    /// <para>Deliberately referenced by no code in this class. It exists so the margin below it can
+    /// be asserted rather than left as a bare number a later reader has to take on trust: raise
+    /// <see cref="SafeMaxCharacters"/> towards this and a test fails and says why. Removing it as
+    /// unused would take that check with it.</para>
+    ///
+    /// <para>It is the limit of two engines and not of four. Both Google endpoints have no
+    /// client-side limit at all — 3,000 characters was accepted and translated complete. What makes
+    /// 1,000 matter anyway is that a block goes to whichever engine answers first, so a text over
+    /// it loses Microsoft and Bing together and lands on Google by default rather than by choice.</para>
+    /// </remarks>
     public const int HardMaxCharacters = 1000;
 
     /// <summary>

--- a/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
+++ b/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
@@ -28,22 +28,28 @@ internal readonly record struct TranslationRequestChunk(
 /// boundary each piece can reach.
 /// </summary>
 /// <remarks>
-/// <para>The keyless endpoints take a thousand characters. Microsoft and Bing say so — GTranslate
-/// refuses the call before it leaves the machine — but Google accepts the text and answers, and
-/// what it answers past its own limit is not a translation. A 1,181-character paragraph came back
-/// with its last sentence replaced by "僅在 GPU 10 秒上實現了 GPU 10 秒）" repeated seven times: the
-/// model looping, not the text being cut off. Nothing in the pipeline could tell that from a
-/// successful translation, because as far as every layer above is concerned it is one.</para>
+/// <para>Microsoft and Bing refuse more than a thousand characters, and GTranslate refuses the call
+/// before it leaves the machine. Both Google endpoints accept far more — 3,000 was translated
+/// complete and in order, every sentence accounted for. So this exists to keep the two engines that
+/// have a limit usable, not because the other two need protecting from long text.</para>
 ///
-/// <para>That silent failure is why the working budget is not the hard limit. A refusal is visible
-/// and recoverable; a corrupted answer is neither, so the text is kept clear of the edge rather
-/// than filled up to it — see <see cref="SafeMaxCharacters"/>.</para>
+/// <para>That matters more than it sounds. A block goes to whichever engine answers first, and when
+/// a text is too long for Microsoft and Bing they both fail instantly, leaving Google as the only
+/// engine that can serve it. That is how a 1,181-character paragraph came back with its last
+/// sentence replaced by "僅在 GPU 10 秒上實現了 GPU 10 秒）" repeated seven times: not because it was
+/// long, but because losing two engines to the limit forced it onto a third that mistranslates that
+/// particular sentence. Split, it fits, Microsoft serves it, and it comes back right.</para>
 ///
-/// <para>This became reachable when a wrapped paragraph started going up as one request instead of
-/// seven, which is the point of grouping and worth keeping. So the limit is answered where it
+/// <para>What this does NOT fix: Google loops on that sentence at any length — sent alone, 270
+/// characters, it fails identically. Whatever triggers it is in the text and not in its size, so a
+/// user whose chosen engine is Google can still receive a translation that came back a success and
+/// is wrong. Nothing here would notice; detecting it would be a separate piece of work.</para>
+///
+/// <para>The limit became reachable when a wrapped paragraph started going up as one request
+/// instead of seven, which is the point of grouping and worth keeping. So it is answered where it
 /// belongs — at the transport that has it — rather than by making the grouper translate less
 /// context than the picture supports. Grouping decides what belongs together; this decides how much
-/// of it an endpoint can safely be handed at once, and the two stay independent.</para>
+/// of it an endpoint can be handed at once, and the two stay independent.</para>
 /// </remarks>
 internal static class TranslationRequestChunks
 {
@@ -54,12 +60,19 @@ internal static class TranslationRequestChunks
     /// The most that is actually sent in one request.
     /// </summary>
     /// <remarks>
-    /// A fifth under the hard limit, because the hard limit is where the <em>refusals</em> start and
-    /// not where the answers stop being good. Google's repetition loop was measured at 1,181
-    /// characters and nothing says where it begins; the endpoints are unpublished, may count
-    /// encoded bytes rather than characters, and can change without notice. The cost of the margin
-    /// is one extra request on a text between this and the hard limit, which is cheap next to a
-    /// paragraph that comes back quietly wrong.
+    /// <para>A fifth under the hard limit, and the margin is for the limit itself rather than for
+    /// translation quality. What the endpoints count is not published — characters as .NET counts
+    /// them, encoded bytes, or something else again — so a text measured at 999 here could still be
+    /// over on the wire, and the failure mode is losing two of the three engines at once. These are
+    /// undocumented endpoints and the number can change without anyone being told.</para>
+    ///
+    /// <para>It is deliberately not justified by quality: clean prose came back complete from both
+    /// Google endpoints at 3,000 characters, and the sentence that loops does so at 270. Length is
+    /// not what decides whether an answer is good, and this budget should not be read as though it
+    /// were.</para>
+    ///
+    /// <para>The cost is one extra request on a text between this and the hard limit. That is cheap
+    /// against a request that fails on two engines out of three.</para>
     /// </remarks>
     public const int SafeMaxCharacters = 800;
 

--- a/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
+++ b/src/OverTranslate/Services/Providers/TranslationRequestChunks.cs
@@ -1,0 +1,124 @@
+namespace OverTranslate.Services.Providers;
+
+/// <summary>
+/// Cuts a text too long for one request into pieces the free endpoints will accept, at sentence
+/// ends wherever there is one to cut at.
+/// </summary>
+/// <remarks>
+/// <para>The keyless endpoints take a thousand characters. Microsoft and Bing say so — GTranslate
+/// refuses the call before it leaves the machine — but Google accepts the text and answers, and
+/// what it answers past its own limit is not a translation. A 1,181-character paragraph came back
+/// with its last sentence replaced by "僅在 GPU 10 秒上實現了 GPU 10 秒）" repeated seven times: the
+/// model looping, not the text being cut off. Nothing in the pipeline could tell that from a
+/// successful translation, because as far as every layer above is concerned it is one.</para>
+///
+/// <para>This became reachable when a wrapped paragraph started going up as one request instead of
+/// seven, which is the point of grouping and worth keeping. So the limit is answered where it
+/// belongs — at the transport that has it — rather than by making the grouper translate less
+/// context than the picture supports.</para>
+///
+/// <para>Sentence ends are preferred over word boundaries and word boundaries over nothing, because
+/// what a piece costs is the context inside it: a sentence split down the middle is translated as
+/// two half-thoughts, while consecutive whole sentences lose only what sits between them.</para>
+/// </remarks>
+internal static class TranslationRequestChunks
+{
+    /// <summary>
+    /// The longest text the keyless endpoints accept, and the smallest of their limits, because a
+    /// block is offered to whichever of them answers first.
+    /// </summary>
+    public const int MaxCharacters = 1000;
+
+    public static List<string> Split(string text, int limit = MaxCharacters)
+    {
+        if (text.Length <= limit) return [text];
+
+        var chunks = new List<string>();
+        var start = 0;
+
+        while (start < text.Length)
+        {
+            if (text.Length - start <= limit)
+            {
+                chunks.Add(text[start..]);
+                break;
+            }
+
+            var length = CutLength(text, start, limit);
+            chunks.Add(text[start..(start + length)]);
+            start += length;
+        }
+
+        return chunks;
+    }
+
+    /// <summary>
+    /// How much of the text starting at <paramref name="start"/> to take: as far as the last
+    /// sentence end within the limit, else the last word boundary, else the limit itself.
+    /// </summary>
+    private static int CutLength(string text, int start, int limit)
+    {
+        var lastSentenceEnd = -1;
+        var lastBoundary = -1;
+
+        for (var i = 0; i < limit; i++)
+        {
+            var at = start + i;
+            if (IsSentenceEnd(text, at)) lastSentenceEnd = i + 1;
+            else if (char.IsWhiteSpace(text[at])) lastBoundary = i + 1;
+        }
+
+        // Take the space after the full stop with the sentence it follows, so no piece is sent
+        // with a leading space.
+        if (lastSentenceEnd > 0)
+        {
+            while (lastSentenceEnd < limit && char.IsWhiteSpace(text[start + lastSentenceEnd]))
+                lastSentenceEnd++;
+
+            return lastSentenceEnd;
+        }
+
+        if (lastBoundary > 0) return lastBoundary;
+
+        // A thousand characters without a space or a full stop. Nothing to preserve, so take the
+        // limit — but never mid-character, which would send half a surrogate pair.
+        return char.IsLowSurrogate(text[start + limit]) ? limit - 1 : limit;
+    }
+
+    /// <summary>
+    /// Whether a full stop here ends a sentence rather than sitting inside "1.40s" or "PP-OCRv6".
+    /// </summary>
+    /// <remarks>
+    /// The Latin marks need what follows to be a space, because they are also decimal points and
+    /// abbreviations; the CJK ones do not, because nothing else uses them.
+    /// </remarks>
+    private static bool IsSentenceEnd(string text, int at) =>
+        text[at] switch
+        {
+            '。' or '！' or '？' or '\n' => true,
+            '.' or '!' or '?' => at + 1 >= text.Length || char.IsWhiteSpace(text[at + 1]),
+            _ => false,
+        };
+
+    /// <summary>
+    /// Puts the pieces back together, with a space wherever both sides are words rather than CJK.
+    /// </summary>
+    public static string Join(IEnumerable<string> translations)
+    {
+        var joined = "";
+
+        foreach (var part in translations.Select(part => part.Trim()).Where(part => part.Length > 0))
+        {
+            if (joined.Length == 0)
+            {
+                joined = part;
+                continue;
+            }
+
+            var needsSpace = !char.IsWhiteSpace(joined[^1]) && !char.IsWhiteSpace(part[0]);
+            joined = needsSpace ? $"{joined} {part}" : joined + part;
+        }
+
+        return joined;
+    }
+}

--- a/tests/OverTranslate.Tests/TranslationRequestChunksTests.cs
+++ b/tests/OverTranslate.Tests/TranslationRequestChunksTests.cs
@@ -7,8 +7,49 @@ namespace OverTranslate.Tests;
 
 public class TranslationRequestChunksTests
 {
-    private static string Sentences(string body, int count) =>
-        string.Concat(Enumerable.Repeat($"{body}. ", count));
+    private const int Safe = TranslationRequestChunks.SafeMaxCharacters;
+
+    private static string Repeat(string body, int count) =>
+        string.Concat(Enumerable.Repeat(body, count));
+
+    private static List<string> Texts(IEnumerable<TranslationRequestChunk> chunks) =>
+        chunks.Select(chunk => chunk.Text).ToList();
+
+    /// <summary>
+    /// The safe budget is well under what the endpoints refuse, because a refusal is visible and a
+    /// corrupted answer is not — see <see cref="TranslationRequestChunks.SafeMaxCharacters"/>.
+    /// </summary>
+    [Fact]
+    public void SendsWellShortOfWhatTheEndpointsRefuse()
+    {
+        Assert.True(
+            Safe <= TranslationRequestChunks.HardMaxCharacters * 0.85,
+            "the working budget should keep a real margin under the hard limit");
+    }
+
+    [Theory]
+    [InlineData(Safe - 1, 1)]
+    [InlineData(Safe, 1)]
+    [InlineData(Safe + 1, 2)]
+    public void SplitsOnceThePieceWouldNotFitTheBudget(int length, int expected)
+    {
+        var text = Repeat("a", length);
+
+        Assert.Equal(expected, TranslationRequestChunks.Split(text).Count);
+    }
+
+    /// <summary>
+    /// Under the hard limit is not the test. A 950-character text every engine would accept is
+    /// still split, because Google accepts far more than it translates correctly.
+    /// </summary>
+    [Fact]
+    public void SplitsATextTheEndpointsWouldHaveAccepted()
+    {
+        var text = Repeat("This sentence is here to take up room. ", 25);
+
+        Assert.InRange(text.Length, Safe + 1, TranslationRequestChunks.HardMaxCharacters);
+        Assert.True(TranslationRequestChunks.Split(text).Count > 1);
+    }
 
     /// <summary>
     /// The ordinary case, which is nearly every block: nothing to split, and the text goes up
@@ -20,32 +61,29 @@ public class TranslationRequestChunksTests
         var text = "On June 11, 2026, PaddleOCR released PP-OCRv6.";
 
         var chunk = Assert.Single(TranslationRequestChunks.Split(text));
-        Assert.Equal(text, chunk);
+        Assert.Equal(text, chunk.Text);
+        Assert.Equal(TranslationChunkBoundary.End, chunk.BoundaryAfter);
     }
 
     /// <summary>
     /// The invariant that matters most here, because the fault this replaced produced text that was
     /// not in the source: the pieces are the original, in order, with nothing added or lost.
     /// </summary>
-    [Fact]
-    public void ThePiecesAreExactlyTheOriginal()
+    [Theory]
+    [InlineData("Sentences end here. And here. And here again. ", 40)]
+    [InlineData("這是一句話。這是另一句話。", 90)]
+    [InlineData("no punctuation at all just words going on ", 40)]
+    [InlineData("unbrokenrunofcharacterswithnothingtobreakat", 40)]
+    [InlineData("Mixed 中英文 content. 中文句子。 More English. ", 40)]
+    public void ThePiecesAreExactlyTheOriginal(string body, int count)
     {
-        var text = Sentences("The medium tier achieves higher recognition and detection rates", 40);
+        var text = Repeat(body, count);
 
         var chunks = TranslationRequestChunks.Split(text);
 
         Assert.True(chunks.Count > 1);
-        Assert.Equal(text, string.Concat(chunks));
-    }
-
-    [Fact]
-    public void NoPieceIsLongerThanTheEndpointsAccept()
-    {
-        var text = Sentences("PP-OCRv6 improves recognition in specialized scenarios", 40);
-
-        var chunks = TranslationRequestChunks.Split(text);
-
-        Assert.All(chunks, chunk => Assert.InRange(chunk.Length, 1, TranslationRequestChunks.MaxCharacters));
+        Assert.Equal(text, string.Concat(Texts(chunks)));
+        Assert.All(chunks, chunk => Assert.InRange(chunk.Text.Length, 1, Safe));
     }
 
     /// <summary>
@@ -53,13 +91,57 @@ public class TranslationRequestChunksTests
     /// translated as two half-thoughts, which is the cost this is trying not to pay.
     /// </summary>
     [Fact]
-    public void CutsAtSentenceEnds()
+    public void CutsLatinAtSentenceEnds()
     {
-        var text = Sentences("Built on the newly designed unified backbone", 40);
+        var text = Repeat("This is sentence one. This is sentence two. ", 40);
 
         var chunks = TranslationRequestChunks.Split(text);
 
-        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith(". ", chunk));
+        Assert.All(chunks.SkipLast(1), chunk =>
+        {
+            Assert.Equal(TranslationChunkBoundary.Sentence, chunk.BoundaryAfter);
+            Assert.EndsWith(". ", chunk.Text);
+        });
+    }
+
+    /// <summary>
+    /// CJK needs no space after its full stop, because nothing else uses that mark. Waiting for one
+    /// would find no sentence end in the whole text.
+    /// </summary>
+    [Fact]
+    public void CutsChineseAtItsOwnFullStops()
+    {
+        var text = Repeat("第一句。第二句。第三句。", 120);
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.True(chunks.Count > 1);
+        Assert.All(chunks.SkipLast(1), chunk =>
+        {
+            Assert.Equal(TranslationChunkBoundary.Sentence, chunk.BoundaryAfter);
+            Assert.EndsWith("。", chunk.Text);
+        });
+    }
+
+    /// <summary>
+    /// And the same for scripts that end a sentence with something else again — the marks are
+    /// listed, the languages are not.
+    /// </summary>
+    [Theory]
+    [InlineData("यह एक वाक्य है।", "।")]
+    [InlineData("یہ ایک جملہ ہے۔", "۔")]
+    public void CutsOtherScriptsAtTheirOwnSentenceMarks(string sentence, string mark)
+    {
+        var text = Repeat(sentence, 200);
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.True(chunks.Count > 1);
+        Assert.All(chunks.SkipLast(1), chunk =>
+        {
+            Assert.Equal(TranslationChunkBoundary.Sentence, chunk.BoundaryAfter);
+            Assert.EndsWith(mark, chunk.Text);
+        });
     }
 
     /// <summary>
@@ -68,73 +150,145 @@ public class TranslationRequestChunksTests
     [Fact]
     public void DoesNotCutInsideANumber()
     {
-        var text = Sentences("It runs in 1.40s versus 7.30s on the same processor", 40);
+        var text = Repeat("It runs in 1.40s versus 7.30s on the same processor. ", 30);
 
         var chunks = TranslationRequestChunks.Split(text);
 
-        Assert.All(chunks, chunk => Assert.DoesNotContain("1.\n", chunk));
-        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith(". ", chunk));
+        Assert.All(chunks.SkipLast(1), chunk =>
+        {
+            Assert.EndsWith(". ", chunk.Text);
+            // The full stop it ended on is a sentence's, not a decimal point's.
+            Assert.False(char.IsDigit(chunk.Text[^3]), $"cut inside a number: \"{chunk.Text[^8..]}\"");
+        });
     }
 
     /// <summary>
-    /// CJK needs no space after its full stop, because nothing else uses those marks.
+    /// A single line break is where a column ended, not where a sentence did. Treating it as a
+    /// sentence end would cut a wrapped paragraph at every visual line and undo the grouping that
+    /// put it together.
     /// </summary>
     [Fact]
-    public void CutsChineseAtItsOwnFullStops()
+    public void DoesNotTreatOneLineBreakAsASentenceEnd()
     {
-        var text = string.Concat(Enumerable.Repeat("這是一個沒有空格的句子。", 120));
+        var text = Repeat("this is a long\nsentence that continues\nonto another line ", 30);
 
         var chunks = TranslationRequestChunks.Split(text);
 
         Assert.True(chunks.Count > 1);
-        Assert.Equal(text, string.Concat(chunks));
-        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith("。", chunk));
+        Assert.All(chunks.SkipLast(1), chunk =>
+            Assert.Equal(TranslationChunkBoundary.Whitespace, chunk.BoundaryAfter));
     }
 
     /// <summary>
-    /// With no sentence to end, a word boundary will do — better a whole word than a whole limit.
+    /// A blank line is the one break that does mean something, and it beats a sentence end that
+    /// would have cost half the budget to reach.
+    /// </summary>
+    [Fact]
+    public void TakesABlankLineOverAnEarlierSentenceEnd()
+    {
+        var text = "Short. " + Repeat("word ", 150) + "\n\n" + Repeat("more ", 200);
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.Equal(TranslationChunkBoundary.Paragraph, chunks[0].BoundaryAfter);
+        Assert.Equal(text, string.Concat(Texts(chunks)));
+    }
+
+    /// <summary>
+    /// With no sentence to end, a word boundary will do — better a whole word than a whole budget.
     /// </summary>
     [Fact]
     public void FallsBackToWordBoundaries()
     {
-        var text = string.Concat(Enumerable.Repeat("word ", 400));
+        var text = Repeat("word ", 400);
 
         var chunks = TranslationRequestChunks.Split(text);
 
         Assert.True(chunks.Count > 1);
-        Assert.Equal(text, string.Concat(chunks));
-        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith(" ", chunk));
+        Assert.All(chunks.SkipLast(1), chunk =>
+        {
+            Assert.Equal(TranslationChunkBoundary.Whitespace, chunk.BoundaryAfter);
+            Assert.EndsWith(" ", chunk.Text);
+        });
     }
 
     /// <summary>
-    /// And with neither, the limit itself — but never through the middle of a character.
+    /// And with neither, the budget itself — but never through the middle of a character.
     /// </summary>
     [Fact]
     public void SplitsUnbrokenTextWithoutBreakingACharacter()
     {
-        var text = string.Concat(Enumerable.Repeat("🙂", 700));
+        var text = Repeat("🙂", 700);
 
         var chunks = TranslationRequestChunks.Split(text);
 
-        Assert.Equal(text, string.Concat(chunks));
+        Assert.Equal(text, string.Concat(Texts(chunks)));
+        Assert.Contains(chunks, chunk => chunk.BoundaryAfter == TranslationChunkBoundary.HardSplit);
         Assert.All(chunks, chunk =>
         {
-            Assert.False(char.IsLowSurrogate(chunk[0]));
-            Assert.False(char.IsHighSurrogate(chunk[^1]));
+            Assert.False(char.IsLowSurrogate(chunk.Text[0]));
+            Assert.False(char.IsHighSurrogate(chunk.Text[^1]));
         });
     }
 
+    private static string JoinOf(TranslationChunkBoundary boundary, string first, string second) =>
+        TranslationRequestChunks.Join(
+            [new TranslationRequestChunk("", boundary), new TranslationRequestChunk("", TranslationChunkBoundary.End)],
+            [first, second]);
+
+    /// <summary>
+    /// CJK sets its sentences without spaces, so putting one in adds a gap the original never had.
+    /// </summary>
     [Fact]
-    public void JoinsTranslatedPiecesWithASingleSpaceBetweenWords()
+    public void JoinsChineseSentencesWithoutAddingASpace()
     {
         Assert.Equal(
-            "第一段。 第二段。",
-            TranslationRequestChunks.Join(["第一段。 ", " 第二段。"]));
+            "第一段。第二段。",
+            JoinOf(TranslationChunkBoundary.Sentence, "第一段。", "第二段。"));
+    }
+
+    [Fact]
+    public void JoinsEnglishSentencesWithASpace()
+    {
+        Assert.Equal(
+            "First part. Second part.",
+            JoinOf(TranslationChunkBoundary.Sentence, "First part.", "Second part."));
+    }
+
+    /// <summary>
+    /// A blank line in the source is a blank line in the translation — the structure came from the
+    /// text, so dropping it would be losing something the user wrote.
+    /// </summary>
+    [Fact]
+    public void JoinsParagraphsAsParagraphs()
+    {
+        Assert.Equal(
+            "第一段。\n\n第二段。",
+            JoinOf(TranslationChunkBoundary.Paragraph, "第一段。", "第二段。"));
+    }
+
+    /// <summary>
+    /// A cut made with nothing to cut at closes up with nothing, rather than inventing a space in
+    /// the middle of what was one run of characters.
+    /// </summary>
+    [Fact]
+    public void ClosesUpAHardSplit()
+    {
+        Assert.Equal(
+            "AAAABBBB",
+            JoinOf(TranslationChunkBoundary.HardSplit, "AAAA", "BBBB"));
     }
 
     [Fact]
     public void JoinIgnoresPiecesThatCameBackEmpty()
     {
-        Assert.Equal("only this", TranslationRequestChunks.Join(["", "  ", "only this"]));
+        var chunks = new List<TranslationRequestChunk>
+        {
+            new("", TranslationChunkBoundary.Sentence),
+            new("", TranslationChunkBoundary.Sentence),
+            new("", TranslationChunkBoundary.End),
+        };
+
+        Assert.Equal("only this", TranslationRequestChunks.Join(chunks, ["", "  ", "only this"]));
     }
 }

--- a/tests/OverTranslate.Tests/TranslationRequestChunksTests.cs
+++ b/tests/OverTranslate.Tests/TranslationRequestChunksTests.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.Linq;
+using OverTranslate.Services.Providers;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class TranslationRequestChunksTests
+{
+    private static string Sentences(string body, int count) =>
+        string.Concat(Enumerable.Repeat($"{body}. ", count));
+
+    /// <summary>
+    /// The ordinary case, which is nearly every block: nothing to split, and the text goes up
+    /// exactly as it was.
+    /// </summary>
+    [Fact]
+    public void LeavesATextThatFitsAlone()
+    {
+        var text = "On June 11, 2026, PaddleOCR released PP-OCRv6.";
+
+        var chunk = Assert.Single(TranslationRequestChunks.Split(text));
+        Assert.Equal(text, chunk);
+    }
+
+    /// <summary>
+    /// The invariant that matters most here, because the fault this replaced produced text that was
+    /// not in the source: the pieces are the original, in order, with nothing added or lost.
+    /// </summary>
+    [Fact]
+    public void ThePiecesAreExactlyTheOriginal()
+    {
+        var text = Sentences("The medium tier achieves higher recognition and detection rates", 40);
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.True(chunks.Count > 1);
+        Assert.Equal(text, string.Concat(chunks));
+    }
+
+    [Fact]
+    public void NoPieceIsLongerThanTheEndpointsAccept()
+    {
+        var text = Sentences("PP-OCRv6 improves recognition in specialized scenarios", 40);
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.All(chunks, chunk => Assert.InRange(chunk.Length, 1, TranslationRequestChunks.MaxCharacters));
+    }
+
+    /// <summary>
+    /// Cut at sentence ends, so each piece is whole thoughts. A sentence split down the middle is
+    /// translated as two half-thoughts, which is the cost this is trying not to pay.
+    /// </summary>
+    [Fact]
+    public void CutsAtSentenceEnds()
+    {
+        var text = Sentences("Built on the newly designed unified backbone", 40);
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith(". ", chunk));
+    }
+
+    /// <summary>
+    /// A full stop inside a number is not a sentence end. "1.40s vs 7.30s" must not be cut in two.
+    /// </summary>
+    [Fact]
+    public void DoesNotCutInsideANumber()
+    {
+        var text = Sentences("It runs in 1.40s versus 7.30s on the same processor", 40);
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.All(chunks, chunk => Assert.DoesNotContain("1.\n", chunk));
+        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith(". ", chunk));
+    }
+
+    /// <summary>
+    /// CJK needs no space after its full stop, because nothing else uses those marks.
+    /// </summary>
+    [Fact]
+    public void CutsChineseAtItsOwnFullStops()
+    {
+        var text = string.Concat(Enumerable.Repeat("這是一個沒有空格的句子。", 120));
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.True(chunks.Count > 1);
+        Assert.Equal(text, string.Concat(chunks));
+        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith("。", chunk));
+    }
+
+    /// <summary>
+    /// With no sentence to end, a word boundary will do — better a whole word than a whole limit.
+    /// </summary>
+    [Fact]
+    public void FallsBackToWordBoundaries()
+    {
+        var text = string.Concat(Enumerable.Repeat("word ", 400));
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.True(chunks.Count > 1);
+        Assert.Equal(text, string.Concat(chunks));
+        Assert.All(chunks.SkipLast(1), chunk => Assert.EndsWith(" ", chunk));
+    }
+
+    /// <summary>
+    /// And with neither, the limit itself — but never through the middle of a character.
+    /// </summary>
+    [Fact]
+    public void SplitsUnbrokenTextWithoutBreakingACharacter()
+    {
+        var text = string.Concat(Enumerable.Repeat("🙂", 700));
+
+        var chunks = TranslationRequestChunks.Split(text);
+
+        Assert.Equal(text, string.Concat(chunks));
+        Assert.All(chunks, chunk =>
+        {
+            Assert.False(char.IsLowSurrogate(chunk[0]));
+            Assert.False(char.IsHighSurrogate(chunk[^1]));
+        });
+    }
+
+    [Fact]
+    public void JoinsTranslatedPiecesWithASingleSpaceBetweenWords()
+    {
+        Assert.Equal(
+            "第一段。 第二段。",
+            TranslationRequestChunks.Join(["第一段。 ", " 第二段。"]));
+    }
+
+    [Fact]
+    public void JoinIgnoresPiecesThatCameBackEmpty()
+    {
+        Assert.Equal("only this", TranslationRequestChunks.Join(["", "  ", "only this"]));
+    }
+}

--- a/tests/OverTranslate.Tests/TranslationRequestChunksTests.cs
+++ b/tests/OverTranslate.Tests/TranslationRequestChunksTests.cs
@@ -16,8 +16,9 @@ public class TranslationRequestChunksTests
         chunks.Select(chunk => chunk.Text).ToList();
 
     /// <summary>
-    /// The safe budget is well under what the endpoints refuse, because a refusal is visible and a
-    /// corrupted answer is not — see <see cref="TranslationRequestChunks.SafeMaxCharacters"/>.
+    /// The margin under the refusal point, kept as a test so it cannot quietly be spent. What the
+    /// endpoints count is not published, so a text measured at 999 here may still be over on the
+    /// wire — and going over loses Microsoft and Bing together.
     /// </summary>
     [Fact]
     public void SendsWellShortOfWhatTheEndpointsRefuse()

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -194,6 +194,20 @@ if (args[0] == "--xlate-line")
         }
     }
 
+    // The same text through the chain a user who picked Google actually gets: the engines above
+    // answer for themselves, this answers for the application. Which one served the block is
+    // printed with it, because "Google looped" and "Google was slow so Bing answered" produce the
+    // same good line and are not the same result — the summary is what tells them apart.
+    var googleChain = new ResilientProvider([
+        new GTranslateProvider(new GoogleTranslator(), null, limit),
+        new GTranslateProvider(new GoogleTranslator2(), null, limit),
+        new GTranslateProvider(new BingTranslator(), null, limit),
+    ]);
+
+    var (chained, _) = await googleChain.TranslateAsync(block, "EN", "ZH-HANT", "");
+    Console.WriteLine($"  [Google chain] {chained[0].TranslatedText}");
+    Console.WriteLine($"                 served by {googleChain.LastBatchSummary}");
+
     return 0;
 }
 

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -161,12 +161,26 @@ if (args[0] == "--xlate-line")
         return 1;
     }
 
-    var block = new List<OcrTextBlock> { new(line, new System.Windows.Rect(0, 0, 100, 20)) };
+    // All four, named apart. "Google" is two different endpoints and they need not behave alike —
+    // the resilient chains use GoogleTranslator2 as a backup and GoogleTranslator as a primary, so
+    // a limit measured on one says nothing about the other.
+    //
+    // --raw hands each engine the whole text, bypassing TranslationRequestChunks. That is what
+    // reproduces the fault the chunking exists to prevent, so it stays available: without it the
+    // only way to see an endpoint's real behaviour past its limit is to delete the fix.
+    var raw = args.Contains("--raw");
+    var line2 = raw ? string.Join(' ', args.Skip(1).Where(a => a != "--raw")) : line;
+    var limit = raw ? int.MaxValue : (int?)null;
+
+    var block = new List<OcrTextBlock> { new(line2, new System.Windows.Rect(0, 0, 100, 20)) };
+    Console.WriteLine($"  input: {line2.Length} chars, chunking {(raw ? "OFF" : "ON")}");
+
     foreach (var (name, provider) in new (string, GTranslateProvider)[]
              {
-                 ("Microsoft", new GTranslateProvider(new MicrosoftTranslator())),
-                 ("Google   ", new GTranslateProvider(new GoogleTranslator2())),
-                 ("Bing     ", new GTranslateProvider(new BingTranslator())),
+                 ("Microsoft", new GTranslateProvider(new MicrosoftTranslator(), null, limit)),
+                 ("Google Web", new GTranslateProvider(new GoogleTranslator(), null, limit)),
+                 ("Google RPC", new GTranslateProvider(new GoogleTranslator2(), null, limit)),
+                 ("Bing      ", new GTranslateProvider(new BingTranslator(), null, limit)),
              })
     {
         try


### PR DESCRIPTION
## 問題

一次送出的文字超過翻譯端點的長度上限時，Google 會進入重複迴圈，譯文尾段變成同一句話重複好幾次。

實測確認：**觸發條件與長度本身無關**，是端點行為；而且「Google」其實是兩個不同的端點（`GoogleTranslator` 與 `GoogleTranslator2`），在其中一個量到的上限不能套用到另一個。細節記在 `TranslationRequestChunks` 的註解裡。

## 改動

新增 `TranslationRequestChunks`：以**安全預算**（不是硬上限）與**邊界感知**切分長文，接回時依原始邊界決定分隔，避免在句中切開又用錯的分隔符接回。硬限制常數保留但不參與送出，只作為安全預算的對照基準。

`GTranslateProvider` 接上這個切分，並開放上限參數以便量測。

## 量測工具

`OcrHarness --xlate-line` 加上：

- `--raw`：把整段文字直接餵給各引擎，**繞過切分**。這是重現「切分要防的那個錯誤」的唯一方法，所以刻意保留——沒有它就只能靠刪掉修正來觀察端點的真實行為
- Google 引擎鏈：跑使用者選 Google 時實際會走的鏈，並印出**哪個引擎服務了這個區塊**。「Google 迴圈了」和「Google 慢所以 Bing 接手」會產出一樣好的句子，但不是同一個結果

## 驗證

- `TranslationRequestChunksTests`：295 行，涵蓋邊界切分、接回分隔、預算計算
- 836 測試通過、2 略過、0 失敗