### PR TITLE
feat: 設定頁新增偵錯工具，截圖翻譯可疊加 OCR 辨識框與文字分組框

### DIFF
--- a/src/OverTranslate/Layout/OcrDebugBoxes.cs
+++ b/src/OverTranslate/Layout/OcrDebugBoxes.cs
@@ -1,0 +1,30 @@
+using System.Windows;
+using OverTranslate.Services;
+
+namespace OverTranslate.Layout;
+
+/// <summary>
+/// The two sets of boxes the OCR debug overlay draws: what the recogniser returned, and what the
+/// grouper joined those into.
+/// </summary>
+/// <remarks>
+/// Both can be shown at once, and they nest — a group is made of its lines, and a group of one line
+/// is that line. Drawn at the same rectangle the pair would be unreadable exactly where reading it
+/// matters, so the group box is pushed out to enclose its lines rather than coincide with them.
+/// That is also what it means: everything inside this went to the translator as one request.
+/// </remarks>
+internal static class OcrDebugBoxes
+{
+    /// <summary>
+    /// How far a group box sits outside the lines it holds, in the physical pixels every other
+    /// block coordinate is measured in. Enough to stay a separate edge at any scale the overlay
+    /// runs at, small enough not to reach a neighbouring group.
+    /// </summary>
+    public const double GroupOutset = 3;
+
+    public static List<Rect> LineBoxes(IReadOnlyList<OcrTextBlock> blocks) =>
+        blocks.SelectMany(block => block.Lines).ToList();
+
+    public static List<Rect> GroupBoxes(IReadOnlyList<OcrTextBlock> blocks) =>
+        blocks.Select(block => Rect.Inflate(block.Bounds, GroupOutset, GroupOutset)).ToList();
+}

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -193,19 +193,6 @@ public class AppSettings
     public bool VerboseLogging { get; set; } = false;
 
     /// <summary>
-    /// Draws the OCR geometry over a screenshot translation, so it can be seen why a capture was
-    /// read and grouped the way it was.
-    /// </summary>
-    /// <remarks>
-    /// The two boxes below are what gets drawn, and both are on because someone who has just turned
-    /// this on wants to see the relationship between them — a line and the group that took it. They
-    /// are remembered, unlike the card that holds them, which opens closed every time: this is not
-    /// something to leave running, and the settings page should not look as though it is.
-    /// </remarks>
-    public bool ShowOcrDebugOverlay { get; set; } = false;
-    public bool ShowOcrLineBoxes { get; set; } = true;
-    public bool ShowTextGroupBoxes { get; set; } = true;
-    /// <summary>
     /// The newest version the user has told us to stop interrupting them about, or empty for none.
     /// </summary>
     /// <remarks>
@@ -229,6 +216,9 @@ public class AppSettings
 
     /// <summary>What 即時翻譯 keeps between sittings, grouped.</summary>
     public RealtimeSettings Realtime { get; set; } = new();
+
+    /// <summary>What the OCR debug overlay draws, grouped.</summary>
+    public OcrDebugSettings OcrDebug { get; set; } = new();
 
     /// <summary>The OpenAI-compatible provider's prompt library, grouped.</summary>
     /// <remarks>

--- a/src/OverTranslate/Models/AppSettings.cs
+++ b/src/OverTranslate/Models/AppSettings.cs
@@ -191,6 +191,20 @@ public class AppSettings
     public string ScreenshotSavePath { get; set; } = "";
     /// <summary>Off by default: Debug records the recognised text, i.e. the user's screen contents.</summary>
     public bool VerboseLogging { get; set; } = false;
+
+    /// <summary>
+    /// Draws the OCR geometry over a screenshot translation, so it can be seen why a capture was
+    /// read and grouped the way it was.
+    /// </summary>
+    /// <remarks>
+    /// The two boxes below are what gets drawn, and both are on because someone who has just turned
+    /// this on wants to see the relationship between them — a line and the group that took it. They
+    /// are remembered, unlike the card that holds them, which opens closed every time: this is not
+    /// something to leave running, and the settings page should not look as though it is.
+    /// </remarks>
+    public bool ShowOcrDebugOverlay { get; set; } = false;
+    public bool ShowOcrLineBoxes { get; set; } = true;
+    public bool ShowTextGroupBoxes { get; set; } = true;
     /// <summary>
     /// The newest version the user has told us to stop interrupting them about, or empty for none.
     /// </summary>

--- a/src/OverTranslate/Models/OcrDebugSettings.cs
+++ b/src/OverTranslate/Models/OcrDebugSettings.cs
@@ -1,0 +1,26 @@
+namespace OverTranslate.Models;
+
+/// <summary>
+/// What the OCR debug overlay draws over a screenshot translation, so it can be seen why a capture
+/// was read and grouped the way it was.
+/// </summary>
+/// <remarks>
+/// <para>Both off, and there is no third key switching the pair on: two boxes that draw nothing when
+/// neither is ticked need no master, and a master is a way to end up with a feature that is on but
+/// invisible. Off matters here beyond taste — this ships into existing installs, and nobody should
+/// update the app and find boxes drawn over their translations.</para>
+///
+/// <para>Grouped rather than left loose in <see cref="AppSettings"/> for the reason
+/// <see cref="RealtimeSettings"/> gives: the flat keys there are flat because they shipped that way,
+/// and anything new belongs under the thing that owns it. Whether the card in 設定 is open is not
+/// here on purpose — it opens shut on every visit, because this is not something to leave running
+/// and the page should not look as though it is.</para>
+/// </remarks>
+public class OcrDebugSettings
+{
+    /// <summary>Outlines each box the recogniser returned.</summary>
+    public bool ShowLineBoxes { get; set; } = false;
+
+    /// <summary>Outlines each group those boxes were joined into — one translation request each.</summary>
+    public bool ShowGroupBoxes { get; set; } = false;
+}

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -465,9 +465,7 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.LoggingCheck">Record detailed information</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">Records more information about the app; only recommended while troubleshooting.</sys:String>
     <sys:String x:Key="S.Settings.DebugTools">Debug tools</sys:String>
-    <sys:String x:Key="S.Settings.DebugToolsHint">Shows how the capture was recognised and grouped</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">Show OCR debug information</sys:String>
-    <sys:String x:Key="S.Settings.OcrDebugHint">Draws the OCR and text-group boxes over a screenshot translation.</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR boxes</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxesHint">Outlines each box the recogniser returned.</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">Text group boxes</sys:String>

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -464,6 +464,14 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.Logging">Logging</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">Record detailed information</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">Records more information about the app; only recommended while troubleshooting.</sys:String>
+    <sys:String x:Key="S.Settings.DebugTools">Debug tools</sys:String>
+    <sys:String x:Key="S.Settings.DebugToolsHint">Shows how the capture was recognised and grouped</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebug">Show OCR debug information</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebugHint">Draws the OCR and text-group boxes over a screenshot translation.</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxes">OCR boxes</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">Outlines each box the recogniser returned.</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxes">Text group boxes</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">Outlines each group those boxes were joined into.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open folder</sys:String>

--- a/src/OverTranslate/Resources/Strings.ja.xaml
+++ b/src/OverTranslate/Resources/Strings.ja.xaml
@@ -466,9 +466,7 @@
     <sys:String x:Key="S.Settings.LoggingCheck">詳細な情報を記録する</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">アプリの情報をより多く記録します。問題を調べるときだけ有効にすることをおすすめします。</sys:String>
     <sys:String x:Key="S.Settings.DebugTools">デバッグツール</sys:String>
-    <sys:String x:Key="S.Settings.DebugToolsHint">OCR の認識と文字ブロックの解析結果を表示します</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">OCR デバッグ情報を表示</sys:String>
-    <sys:String x:Key="S.Settings.OcrDebugHint">スクリーンショット翻訳時に OCR 認識枠と文字グループ枠を表示します。</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 認識枠</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR の認識結果の境界枠を表示します。</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">文字グループ枠</sys:String>

--- a/src/OverTranslate/Resources/Strings.ja.xaml
+++ b/src/OverTranslate/Resources/Strings.ja.xaml
@@ -465,6 +465,14 @@
     <sys:String x:Key="S.Settings.Logging">アプリのログ</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">詳細な情報を記録する</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">アプリの情報をより多く記録します。問題を調べるときだけ有効にすることをおすすめします。</sys:String>
+    <sys:String x:Key="S.Settings.DebugTools">デバッグツール</sys:String>
+    <sys:String x:Key="S.Settings.DebugToolsHint">OCR の認識と文字ブロックの解析結果を表示します</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebug">OCR デバッグ情報を表示</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebugHint">スクリーンショット翻訳時に OCR 認識枠と文字グループ枠を表示します。</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 認識枠</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR の認識結果の境界枠を表示します。</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxes">文字グループ枠</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">文字グループごとの境界枠を表示します。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">書き出すと、ログファイル・システム情報・現在の設定を 1 つの診断ファイルにまとめ、問題の報告に添付できます。API キーなどの機微な情報は含まれず、データが自動で送信されることもありません。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">診断情報を書き出す</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">フォルダーを開く</sys:String>

--- a/src/OverTranslate/Resources/Strings.ko.xaml
+++ b/src/OverTranslate/Resources/Strings.ko.xaml
@@ -465,6 +465,14 @@
     <sys:String x:Key="S.Settings.Logging">앱 로그</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">자세한 정보 기록</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">앱의 정보를 더 많이 기록합니다. 문제를 확인할 때만 켜는 것을 권장합니다.</sys:String>
+    <sys:String x:Key="S.Settings.DebugTools">디버그 도구</sys:String>
+    <sys:String x:Key="S.Settings.DebugToolsHint">OCR 인식과 텍스트 블록 분석 정보를 표시합니다</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebug">OCR 디버그 정보 표시</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebugHint">스크린샷 번역 시 OCR 인식 상자와 텍스트 그룹 상자를 표시합니다.</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 인식 상자</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR 인식 결과의 경계 상자를 표시합니다.</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxes">텍스트 그룹 상자</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">텍스트 그룹 블록의 경계 상자를 표시합니다.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">내보내면 로그 파일, 시스템 정보, 현재 설정을 하나의 진단 파일로 모아 문제 신고에 첨부할 수 있습니다. API 키 같은 민감한 정보는 포함되지 않으며, 어떤 데이터도 자동으로 업로드되지 않습니다.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">진단 정보 내보내기</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">폴더 열기</sys:String>

--- a/src/OverTranslate/Resources/Strings.ko.xaml
+++ b/src/OverTranslate/Resources/Strings.ko.xaml
@@ -466,9 +466,7 @@
     <sys:String x:Key="S.Settings.LoggingCheck">자세한 정보 기록</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">앱의 정보를 더 많이 기록합니다. 문제를 확인할 때만 켜는 것을 권장합니다.</sys:String>
     <sys:String x:Key="S.Settings.DebugTools">디버그 도구</sys:String>
-    <sys:String x:Key="S.Settings.DebugToolsHint">OCR 인식과 텍스트 블록 분석 정보를 표시합니다</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">OCR 디버그 정보 표시</sys:String>
-    <sys:String x:Key="S.Settings.OcrDebugHint">스크린샷 번역 시 OCR 인식 상자와 텍스트 그룹 상자를 표시합니다.</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 인식 상자</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR 인식 결과의 경계 상자를 표시합니다.</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">텍스트 그룹 상자</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hans.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hans.xaml
@@ -464,6 +464,14 @@
     <sys:String x:Key="S.Settings.Logging">应用日志</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">记录详细信息</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">启用后会记录更多应用程序信息，仅建议在排查问题时开启。</sys:String>
+    <sys:String x:Key="S.Settings.DebugTools">调试工具</sys:String>
+    <sys:String x:Key="S.Settings.DebugToolsHint">显示 OCR 识别与文字区块分析信息</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebug">显示 OCR 调试信息</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebugHint">截图翻译时显示 OCR 识别框与文字分组框。</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 识别框</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">显示 OCR 识别结果的边界框。</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxes">文字分组框</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">显示 OCR 文字分组区块的边界框。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">导出时会将日志文件、系统信息与当前设置整理成诊断文件，方便附在问题反馈中。API 密钥等敏感信息不会包含在内，也不会自动上传任何数据。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">导出诊断信息</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">打开文件夹</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hans.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hans.xaml
@@ -465,9 +465,7 @@
     <sys:String x:Key="S.Settings.LoggingCheck">记录详细信息</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">启用后会记录更多应用程序信息，仅建议在排查问题时开启。</sys:String>
     <sys:String x:Key="S.Settings.DebugTools">调试工具</sys:String>
-    <sys:String x:Key="S.Settings.DebugToolsHint">显示 OCR 识别与文字区块分析信息</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">显示 OCR 调试信息</sys:String>
-    <sys:String x:Key="S.Settings.OcrDebugHint">截图翻译时显示 OCR 识别框与文字分组框。</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 识别框</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxesHint">显示 OCR 识别结果的边界框。</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">文字分组框</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -486,6 +486,14 @@
     <sys:String x:Key="S.Settings.Logging">應用紀錄</sys:String>
     <sys:String x:Key="S.Settings.LoggingCheck">記錄詳細資訊</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">啟用後會記錄更多應用程式資訊，僅建議於問題排查時開啟。</sys:String>
+    <sys:String x:Key="S.Settings.DebugTools">偵錯工具</sys:String>
+    <sys:String x:Key="S.Settings.DebugToolsHint">顯示 OCR 辨識與文字區塊分析資訊</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebug">顯示 OCR 偵錯資訊</sys:String>
+    <sys:String x:Key="S.Settings.OcrDebugHint">截圖翻譯時顯示 OCR 辨識框與文字分組框。</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 辨識框</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">顯示 OCR 辨識結果的邊界框。</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxes">文字分組框</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">顯示 OCR 文字分組區塊的邊界框。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟資料夾</sys:String>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -487,9 +487,7 @@
     <sys:String x:Key="S.Settings.LoggingCheck">記錄詳細資訊</sys:String>
     <sys:String x:Key="S.Settings.LoggingHint">啟用後會記錄更多應用程式資訊，僅建議於問題排查時開啟。</sys:String>
     <sys:String x:Key="S.Settings.DebugTools">偵錯工具</sys:String>
-    <sys:String x:Key="S.Settings.DebugToolsHint">顯示 OCR 辨識與文字區塊分析資訊</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">顯示 OCR 偵錯資訊</sys:String>
-    <sys:String x:Key="S.Settings.OcrDebugHint">截圖翻譯時顯示 OCR 辨識框與文字分組框。</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 辨識框</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxesHint">顯示 OCR 辨識結果的邊界框。</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">文字分組框</sys:String>

--- a/src/OverTranslate/Views/Controls/SmoothScroll.cs
+++ b/src/OverTranslate/Views/Controls/SmoothScroll.cs
@@ -1,0 +1,54 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Animation;
+
+namespace OverTranslate.Views.Controls;
+
+/// <summary>
+/// Scrolls a <see cref="ScrollViewer"/> to an offset over time instead of jumping to it.
+/// </summary>
+/// <remarks>
+/// <para><see cref="ScrollViewer.VerticalOffset"/> is read-only, so it cannot be animated and
+/// <see cref="ScrollViewer.ScrollToVerticalOffset"/> arrives instantly. This attaches an animatable
+/// property that forwards each value on, which is the standard way round it.</para>
+///
+/// <para>The offset asked for does not have to be reachable yet. ScrollToVerticalOffset clamps to
+/// whatever the content allows at that moment, so an animation aimed past the current bottom simply
+/// follows the content as it grows — which is exactly the case this exists for: revealing a panel
+/// that is still opening.</para>
+/// </remarks>
+internal static class SmoothScroll
+{
+    private static readonly DependencyProperty VerticalOffsetProperty =
+        DependencyProperty.RegisterAttached(
+            "VerticalOffset",
+            typeof(double),
+            typeof(SmoothScroll),
+            new PropertyMetadata(0.0, OnVerticalOffsetChanged));
+
+    private static void OnVerticalOffsetChanged(DependencyObject target, DependencyPropertyChangedEventArgs e)
+    {
+        if (target is ScrollViewer viewer) viewer.ScrollToVerticalOffset((double)e.NewValue);
+    }
+
+    /// <summary>
+    /// Eases <paramref name="viewer"/> to <paramref name="offset"/>, or jumps there when the user
+    /// has animations off.
+    /// </summary>
+    public static void To(ScrollViewer viewer, double offset, Duration duration, IEasingFunction easing)
+    {
+        viewer.BeginAnimation(VerticalOffsetProperty, null);
+
+        if (!SystemParameters.ClientAreaAnimation)
+        {
+            viewer.ScrollToVerticalOffset(offset);
+            return;
+        }
+
+        // Seeded with where the viewer actually is, so an animation started mid-scroll carries on
+        // from there rather than from wherever the last one was aimed.
+        viewer.SetValue(VerticalOffsetProperty, viewer.VerticalOffset);
+        viewer.BeginAnimation(
+            VerticalOffsetProperty, new DoubleAnimation(offset, duration) { EasingFunction = easing });
+    }
+}

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -700,6 +700,7 @@ public partial class MainWindow : Window
         var settings = SettingsService.Instance.Current;
         ShowOverlay(
             blocks,
+            ocrBlocks,
             selection.Left,
             selection.Top,
             selection.Width,
@@ -738,6 +739,7 @@ public partial class MainWindow : Window
     // On first call: create a new overlay and wire its Closed handler.
     private void ShowOverlay(
         List<TranslatedBlock> blocks,
+        IReadOnlyList<OcrTextBlock> ocrBlocks,
         double selPhysLeft,
         double selPhysTop,
         double selPhysWidth,
@@ -750,6 +752,7 @@ public partial class MainWindow : Window
         {
             _overlayWindow.UpdateBlocks(
                 blocks,
+                ocrBlocks,
                 selPhysLeft,
                 selPhysTop,
                 selPhysWidth,
@@ -762,6 +765,7 @@ public partial class MainWindow : Window
 
         _overlayWindow = new OverlayWindow(
             blocks,
+            ocrBlocks,
             selPhysLeft,
             selPhysTop,
             selPhysWidth,
@@ -941,6 +945,7 @@ public partial class MainWindow : Window
             _lastVerticalText = req.IsVerticalText;
             ShowOverlay(
                 coloredTranslated,
+                _lastOcrBlocks,
                 _lastSelPhysLeft,
                 _lastSelPhysTop,
                 _lastSelPhysWidth,
@@ -980,6 +985,7 @@ public partial class MainWindow : Window
             // On failure, restore old bubbles so the overlay isn't left blank
             _overlayWindow?.UpdateBlocks(
                 _lastColoredBlocks,
+                _lastOcrBlocks,
                 _lastSelPhysLeft,
                 _lastSelPhysTop,
                 _lastSelPhysWidth,

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -895,6 +895,10 @@ public partial class MainWindow : Window
                 _lastSelPhysHeight,
                 LocalizationService.Get("S.Main.Translating"));
 
+            // The reading is known now, and the debug boxes describe the reading — so they go up
+            // here rather than with the translation, and stay up if the translation never arrives.
+            _overlayWindow?.ShowOcrDebug(_lastOcrBlocks, _lastSelPhysLeft, _lastSelPhysTop);
+
             var (translated, _) = await AppServices.Translation.TranslateAsync(
                 _lastOcrBlocks, req.SourceLang, req.TargetLang, settings.ApiKey,
                 cancellationToken: cancellationToken);

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml
@@ -15,6 +15,9 @@
 
         <!-- Translation backgrounds and text are separated so no later bubble background can cover prior text. -->
         <Canvas x:Name="BubbleBackgroundCanvas" IsHitTestVisible="False"/>
+        <!-- OCR geometry, when the debug setting asks for it: above the bubble backgrounds so the
+             boxes are visible against them, below the text so a translation is never obscured. -->
+        <Canvas x:Name="DebugCanvas" IsHitTestVisible="False"/>
         <Canvas x:Name="BubbleTextCanvas" IsHitTestVisible="False"/>
 
         <!-- What a drag inside the selection is drawn onto. A rectangle rather than the canvas

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
@@ -167,6 +167,22 @@ public partial class OverlayWindow : Window
         ProcessingBorder.Visibility = Visibility.Visible;
     }
 
+    /// <summary>
+    /// Takes the reading of a capture, before any translation of it exists.
+    /// </summary>
+    /// <remarks>
+    /// The debug boxes describe the source, not the answer, so they are shown from the moment the
+    /// recogniser has finished — through the translating indicator, and on a capture whose
+    /// translation failed or was never asked for.
+    /// </remarks>
+    public void ShowOcrDebug(
+        IReadOnlyList<OcrTextBlock> ocrBlocks, double selScreenX, double selScreenY)
+    {
+        _currentOcrBlocks = ocrBlocks;
+        if (_isLoaded)
+            BuildDebugBoxes(selScreenX, selScreenY);
+    }
+
     public void UpdateBlocks(
         List<TranslatedBlock> blocks,
         IReadOnlyList<OcrTextBlock> ocrBlocks,
@@ -753,10 +769,10 @@ public partial class OverlayWindow : Window
     {
         var visibility = visible ? Visibility.Visible : Visibility.Collapsed;
         BubbleBackgroundCanvas.Visibility = visibility;
-        // With the bubbles, not on its own switch: 顯示原文 is for looking at the capture, and boxes
-        // over a picture the user asked to see unobstructed would be the same obstruction again.
-        DebugCanvas.Visibility = visibility;
         BubbleTextCanvas.Visibility = visibility;
+        // DebugCanvas is deliberately not switched with them. These boxes are drawn around the
+        // source text, so 顯示原文 is the moment they are most worth seeing — the boxes and the words
+        // they were measured from, together.
     }
 
     /// <summary>
@@ -770,15 +786,15 @@ public partial class OverlayWindow : Window
     {
         DebugCanvas.Children.Clear();
 
-        var settings = SettingsService.Instance.Current;
-        if (!settings.ShowOcrDebugOverlay || _currentOcrBlocks.Count == 0) return;
+        var debug = SettingsService.Instance.Current.OcrDebug;
+        if (_currentOcrBlocks.Count == 0) return;
 
-        if (settings.ShowTextGroupBoxes)
+        if (debug.ShowGroupBoxes)
             foreach (var box in OcrDebugBoxes.GroupBoxes(_currentOcrBlocks))
                 DebugCanvas.Children.Add(
                     CreateDebugBox(box, selScreenX, selScreenY, TextGroupBoxColor, dashed: true));
 
-        if (settings.ShowOcrLineBoxes)
+        if (debug.ShowLineBoxes)
             foreach (var box in OcrDebugBoxes.LineBoxes(_currentOcrBlocks))
                 DebugCanvas.Children.Add(
                     CreateDebugBox(box, selScreenX, selScreenY, OcrLineBoxColor, dashed: false));

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
@@ -244,6 +244,11 @@ public partial class OverlayWindow : Window
     {
         if (!_isLoaded) return null;
 
+        // Null only when there is nothing over the capture at all, which is not the same as "no
+        // bubbles": under 顯示原文 the debug boxes are still up, and that combination — the original
+        // words with the boxes drawn round them — is the one worth sending to somebody. Nobody is
+        // in this state by accident. Marks count for the same reason: someone can draw before any
+        // translation has run.
         bool hasBubbles = BubbleBackgroundCanvas.Visibility == Visibility.Visible
             && (BubbleBackgroundCanvas.Children.Count > 0 || BubbleTextCanvas.Children.Count > 0);
         bool hasMarks = AnnotationCanvas.Children.Count > 0 || HasInk;

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
@@ -247,7 +247,8 @@ public partial class OverlayWindow : Window
         bool hasBubbles = BubbleBackgroundCanvas.Visibility == Visibility.Visible
             && (BubbleBackgroundCanvas.Children.Count > 0 || BubbleTextCanvas.Children.Count > 0);
         bool hasMarks = AnnotationCanvas.Children.Count > 0 || HasInk;
-        if (!hasBubbles && !hasMarks) return null;
+        bool hasDebugBoxes = DebugCanvas.Visibility == Visibility.Visible && DebugCanvas.Children.Count > 0;
+        if (!hasBubbles && !hasMarks && !hasDebugBoxes) return null;
 
         int fullW = Math.Max(1, _physBounds.Width);
         int fullH = Math.Max(1, _physBounds.Height);
@@ -257,6 +258,13 @@ public partial class OverlayWindow : Window
         var full = new System.Windows.Media.Imaging.RenderTargetBitmap(
             fullW, fullH, 96 * _dpiX, 96 * _dpiY, System.Windows.Media.PixelFormats.Pbgra32);
         full.Render(BubbleBackgroundCanvas);
+
+        // The debug boxes are included, deliberately. Someone with them switched on is looking at
+        // how a capture was read, and the copy is how they show that to somebody else — a picture
+        // of the problem without the boxes is a picture of nothing in particular. Between the two
+        // bubble layers, which is where they sit on screen.
+        full.Render(DebugCanvas);
+
         full.Render(BubbleTextCanvas);
 
         // Drawn here rather than left to a canvas, because the finished marks are shown by the
@@ -273,10 +281,6 @@ public partial class OverlayWindow : Window
         full.Render(marks);
 
         full.Render(AnnotationCanvas);
-
-        // DebugCanvas is deliberately not among them. The boxes are for looking at this
-        // screen, not for what gets pasted somewhere else: a copied image should be the
-        // translation, whatever the person who copied it happens to have switched on.
 
         // The overlay window spans the whole virtual screen; the selection sits at this physical
         // offset within it.

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
@@ -30,8 +30,17 @@ public partial class OverlayWindow : Window
     // (physical pixels) are measured in.
     private readonly System.Drawing.Rectangle _physBounds = ScreenGeometry.VirtualDesktopBounds();
 
+    // Debug geometry, drawn only when the setting asks for it. The two layers nest, so they are
+    // given different weights as well as different colours: the recogniser's lines are a thin solid
+    // box, and the group that owns them a dashed one just outside. Alpha low enough that the
+    // capture underneath still reads, which is the whole point of looking at it.
+    private const byte DebugFillAlpha = 0x26;
+    private static readonly System.Windows.Media.Color OcrLineBoxColor = System.Windows.Media.Color.FromRgb(0x4D, 0xA3, 0xFF);
+    private static readonly System.Windows.Media.Color TextGroupBoxColor = System.Windows.Media.Color.FromRgb(0xFF, 0xB4, 0x54);
+
     private bool _isLoaded;
     private List<TranslatedBlock> _currentBlocks;
+    private IReadOnlyList<OcrTextBlock> _currentOcrBlocks;
     private double _currentSelectionScreenX;
     private double _currentSelectionScreenY;
     private double _currentSelectionScreenWidth;
@@ -42,6 +51,7 @@ public partial class OverlayWindow : Window
 
     public OverlayWindow(
         List<TranslatedBlock> blocks,
+        IReadOnlyList<OcrTextBlock> ocrBlocks,
         double selectionScreenX,
         double selectionScreenY,
         double selectionScreenWidth,
@@ -52,6 +62,7 @@ public partial class OverlayWindow : Window
     {
         InitializeComponent();
         _currentBlocks = blocks;
+        _currentOcrBlocks = ocrBlocks;
         _currentSelectionScreenX = selectionScreenX;
         _currentSelectionScreenY = selectionScreenY;
         _currentSelectionScreenWidth = selectionScreenWidth;
@@ -130,6 +141,7 @@ public partial class OverlayWindow : Window
     {
         BubbleBackgroundCanvas.Children.Clear();
         BubbleTextCanvas.Children.Clear();
+        DebugCanvas.Children.Clear();
 
         double winPhysLeft = _physBounds.Left;
         double winPhysTop  = _physBounds.Top;
@@ -157,6 +169,7 @@ public partial class OverlayWindow : Window
 
     public void UpdateBlocks(
         List<TranslatedBlock> blocks,
+        IReadOnlyList<OcrTextBlock> ocrBlocks,
         double selScreenX,
         double selScreenY,
         double selScreenWidth,
@@ -166,6 +179,7 @@ public partial class OverlayWindow : Window
         bool verticalText)
     {
         _currentBlocks = blocks;
+        _currentOcrBlocks = ocrBlocks;
         _currentSelectionScreenX = selScreenX;
         _currentSelectionScreenY = selScreenY;
         _currentSelectionScreenWidth = selScreenWidth;
@@ -244,6 +258,10 @@ public partial class OverlayWindow : Window
 
         full.Render(AnnotationCanvas);
 
+        // DebugCanvas is deliberately not among them. The boxes are for looking at this
+        // screen, not for what gets pasted somewhere else: a copied image should be the
+        // translation, whatever the person who copied it happens to have switched on.
+
         // The overlay window spans the whole virtual screen; the selection sits at this physical
         // offset within it.
         int cropX = Math.Clamp((int)Math.Round(selPhysLeft - _physBounds.Left), 0, fullW - 1);
@@ -266,6 +284,7 @@ public partial class OverlayWindow : Window
     {
         BubbleBackgroundCanvas.Children.Clear();
         BubbleTextCanvas.Children.Clear();
+        BuildDebugBoxes(selScreenX, selScreenY);
 
         if (_currentVerticalText)
         {
@@ -734,7 +753,60 @@ public partial class OverlayWindow : Window
     {
         var visibility = visible ? Visibility.Visible : Visibility.Collapsed;
         BubbleBackgroundCanvas.Visibility = visibility;
+        // With the bubbles, not on its own switch: 顯示原文 is for looking at the capture, and boxes
+        // over a picture the user asked to see unobstructed would be the same obstruction again.
+        DebugCanvas.Visibility = visibility;
         BubbleTextCanvas.Visibility = visibility;
+    }
+
+    /// <summary>
+    /// Draws the OCR geometry the debug setting asks for, in the selection's own coordinates.
+    /// </summary>
+    /// <remarks>
+    /// Groups first so the lines land on top of them: where the two coincide the finer box is the
+    /// one worth reading, and it is the one that says what the recogniser actually returned.
+    /// </remarks>
+    private void BuildDebugBoxes(double selScreenX, double selScreenY)
+    {
+        DebugCanvas.Children.Clear();
+
+        var settings = SettingsService.Instance.Current;
+        if (!settings.ShowOcrDebugOverlay || _currentOcrBlocks.Count == 0) return;
+
+        if (settings.ShowTextGroupBoxes)
+            foreach (var box in OcrDebugBoxes.GroupBoxes(_currentOcrBlocks))
+                DebugCanvas.Children.Add(
+                    CreateDebugBox(box, selScreenX, selScreenY, TextGroupBoxColor, dashed: true));
+
+        if (settings.ShowOcrLineBoxes)
+            foreach (var box in OcrDebugBoxes.LineBoxes(_currentOcrBlocks))
+                DebugCanvas.Children.Add(
+                    CreateDebugBox(box, selScreenX, selScreenY, OcrLineBoxColor, dashed: false));
+    }
+
+    private System.Windows.Shapes.Rectangle CreateDebugBox(
+        Rect box, double selScreenX, double selScreenY, System.Windows.Media.Color color, bool dashed)
+    {
+        var fill = new SolidColorBrush(System.Windows.Media.Color.FromArgb(DebugFillAlpha, color.R, color.G, color.B));
+        var stroke = new SolidColorBrush(color);
+        fill.Freeze();
+        stroke.Freeze();
+
+        var shape = new System.Windows.Shapes.Rectangle
+        {
+            Width = Math.Max(1, box.Width / _dpiX),
+            Height = Math.Max(1, box.Height / _dpiY),
+            Fill = fill,
+            Stroke = stroke,
+            StrokeThickness = dashed ? 1.5 : 1,
+            StrokeDashArray = dashed ? new DoubleCollection([4, 3]) : null,
+            RadiusX = 3,
+            RadiusY = 3,
+        };
+
+        Canvas.SetLeft(shape, (selScreenX + box.X - _physBounds.Left) / _dpiX);
+        Canvas.SetTop(shape, (selScreenY + box.Y - _physBounds.Top) / _dpiY);
+        return shape;
     }
 
     private static bool HasLineBreak(string text) => text.Contains('\n') || text.Contains('\r');

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -1196,6 +1196,107 @@
                             </Border>
                         </StackPanel>
                     </Border>
+
+                    <!-- ══════════ 偵錯工具 ══════════
+                         Last on the page and shut, because it is for working out why a capture was
+                         read the way it was and for nothing else. The header opens it; the fold is
+                         deliberately not remembered, so nobody returns to this page and finds the
+                         app looking like a debugger because of a click weeks ago. What is inside
+                         the fold is remembered — that part is a preference. -->
+                    <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                        <StackPanel>
+                            <Border x:Name="DebugToolsHeader"
+                                    Background="Transparent"
+                                    Cursor="Hand"
+                                    MouseLeftButtonUp="DebugToolsHeader_Click">
+                                <StackPanel>
+                                    <StackPanel Style="{StaticResource CardHeaderRow}" Margin="0">
+                                        <TextBlock Text="&#xEBE8;" Style="{StaticResource CardHeaderIcon}"/>
+                                        <TextBlock Text="{DynamicResource S.Settings.DebugTools}"
+                                                   Style="{StaticResource CardTitle}"/>
+                                        <!-- Right-aligned in a card whose every other row is
+                                             left-packed, because it is the affordance and not a
+                                             label: it has to be findable without reading. -->
+                                        <TextBlock x:Name="DebugToolsChevron"
+                                                   Text="&#xE70D;"
+                                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                                   FontSize="12"
+                                                   Foreground="{DynamicResource AppTextSecondary}"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Right"
+                                                   Margin="10,1,0,0"/>
+                                    </StackPanel>
+                                    <TextBlock Text="{DynamicResource S.Settings.DebugToolsHint}"
+                                               Style="{StaticResource OptionDescription}"
+                                               Margin="27,4,0,0"/>
+                                </StackPanel>
+                            </Border>
+
+                            <Border x:Name="DebugToolsBody"
+                                    Style="{StaticResource ToggleRowBorder}"
+                                    Margin="0,12,0,0"
+                                    Visibility="Collapsed">
+                                <StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <CheckBox  Grid.Column="0" x:Name="OcrDebugOverlayCheckBox"
+                                                   Style="{StaticResource ModernCheckBox}"
+                                                   VerticalAlignment="Top"
+                                                   Checked="OcrDebugOverlay_Toggled"
+                                                   Unchecked="OcrDebugOverlay_Toggled"/>
+                                        <TextBlock Grid.Column="1" Text="&#xE890;" Style="{StaticResource OptionGlyph}"/>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Text="{DynamicResource S.Settings.OcrDebug}"
+                                                       Style="{StaticResource OptionTitle}"/>
+                                            <TextBlock Text="{DynamicResource S.Settings.OcrDebugHint}"
+                                                       Style="{StaticResource OptionDescription}"/>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <!-- Indented under the switch that turns them on, and greyed
+                                         with it: on their own they say nothing, and a tick that
+                                         changes nothing on screen is worse than one that is
+                                         plainly unavailable. -->
+                                    <Grid x:Name="OcrDebugBoxOptions" Margin="34,14,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <CheckBox  Grid.Row="0" Grid.Column="0" x:Name="OcrLineBoxesCheckBox"
+                                                   Style="{StaticResource ModernCheckBox}"
+                                                   VerticalAlignment="Top"
+                                                   Checked="OcrDebugBoxes_Toggled"
+                                                   Unchecked="OcrDebugBoxes_Toggled"/>
+                                        <StackPanel Grid.Row="0" Grid.Column="1" Margin="0,0,0,12">
+                                            <TextBlock Text="{DynamicResource S.Settings.OcrLineBoxes}"
+                                                       Style="{StaticResource OptionTitle}"/>
+                                            <TextBlock Text="{DynamicResource S.Settings.OcrLineBoxesHint}"
+                                                       Style="{StaticResource OptionDescription}"/>
+                                        </StackPanel>
+                                        <CheckBox  Grid.Row="1" Grid.Column="0" x:Name="TextGroupBoxesCheckBox"
+                                                   Style="{StaticResource ModernCheckBox}"
+                                                   VerticalAlignment="Top"
+                                                   Checked="OcrDebugBoxes_Toggled"
+                                                   Unchecked="OcrDebugBoxes_Toggled"/>
+                                        <StackPanel Grid.Row="1" Grid.Column="1">
+                                            <TextBlock Text="{DynamicResource S.Settings.TextGroupBoxes}"
+                                                       Style="{StaticResource OptionTitle}"/>
+                                            <TextBlock Text="{DynamicResource S.Settings.TextGroupBoxesHint}"
+                                                       Style="{StaticResource OptionDescription}"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </Border>
                 </Grid>
             </Grid>
         </ScrollViewer>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -24,6 +24,21 @@
             <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="Margin"            Value="10,1,10,0"/>
         </Style>
+        <Style x:Key="CardFoldFocusVisual">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle Stroke="{DynamicResource AppAccent}"
+                                   StrokeThickness="1"
+                                   StrokeDashArray="2 2"
+                                   RadiusX="6"
+                                   RadiusY="6"
+                                   Margin="-8,-6,-8,-6"
+                                   SnapsToDevicePixels="True"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
         <!-- A card heading that opens the card. Templated down to its content so it reads as the
              heading it replaces and not as a button sitting where one used to be; what the template
              adds is the part a heading cannot have — a hover, a pressed state that lands on the
@@ -33,6 +48,12 @@
         <Style x:Key="CardFoldToggle" TargetType="ToggleButton">
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="Cursor"     Value="Hand"/>
+            <!-- Not an IsKeyboardFocused trigger, which would ring the card after an ordinary
+                 click: clicking gives it keyboard focus too, and a heading that keeps a focus
+                 outline after being pressed looks stuck. FocusVisualStyle is WPF's answer to the
+                 same question — it is drawn only when the keyboard was the last thing used — so
+                 the ring appears for someone tabbing and never for someone clicking. -->
+            <Setter Property="FocusVisualStyle" Value="{StaticResource CardFoldFocusVisual}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="ToggleButton">
@@ -53,10 +74,6 @@
                             <Trigger Property="IsPressed" Value="True">
                                 <Setter TargetName="Hit" Property="Background"
                                         Value="{DynamicResource AppSubtleBorder}"/>
-                            </Trigger>
-                            <Trigger Property="IsKeyboardFocused" Value="True">
-                                <Setter TargetName="Hit" Property="BorderBrush"
-                                        Value="{DynamicResource AppAccent}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -1247,7 +1264,8 @@
                      The header opens it. The fold is deliberately not remembered, so nobody returns
                      to this page and finds the app looking like a debugger because of a click weeks
                      ago; what is inside the fold is remembered, because that part is a preference. -->
-                <Border Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="2"
+                <Border x:Name="DebugToolsCard"
+                        Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="2"
                         Style="{StaticResource CardBorder}">
                     <StackPanel>
                         <!-- A ToggleButton and not a clickable Border: the fold is a two-state
@@ -1292,9 +1310,6 @@
                                 ClipToBounds="True"
                                 Height="0"
                                 Visibility="Collapsed">
-                        <!-- The description is inside the fold with everything else: shut, this card
-                             is its own title and nothing more, which is what a card nobody needs
-                             should cost the page. -->
                         <StackPanel x:Name="DebugToolsBody" Opacity="0">
                             <!-- Rises the last few pixels into place as it fades, so the content
                                  arrives from behind the header it came out of rather than simply
@@ -1302,10 +1317,6 @@
                             <StackPanel.RenderTransform>
                                 <TranslateTransform x:Name="DebugToolsBodyRise" Y="-8"/>
                             </StackPanel.RenderTransform>
-                            <TextBlock Text="{DynamicResource S.Settings.DebugToolsHint}"
-                                       Style="{StaticResource OptionDescription}"
-                                       Margin="27,8,0,0"/>
-
                             <Border Style="{StaticResource ToggleRowBorder}" Margin="0,12,0,0">
                                 <StackPanel>
                                     <!-- No switch of its own: the two boxes below are the feature,
@@ -1320,12 +1331,9 @@
                                                    Text="&#xE890;"
                                                    Style="{StaticResource OptionGlyph}"
                                                    Margin="0,1,10,0"/>
-                                        <StackPanel Grid.Column="1">
-                                            <TextBlock Text="{DynamicResource S.Settings.OcrDebug}"
-                                                       Style="{StaticResource OptionTitle}"/>
-                                            <TextBlock Text="{DynamicResource S.Settings.OcrDebugHint}"
-                                                       Style="{StaticResource OptionDescription}"/>
-                                        </StackPanel>
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{DynamicResource S.Settings.OcrDebug}"
+                                                   Style="{StaticResource OptionTitle}"/>
                                     </Grid>
 
                                     <Grid Margin="25,14,0,0">

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -100,6 +100,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <!-- ══════════ 快捷鍵 ══════════
@@ -1197,59 +1198,62 @@
                         </StackPanel>
                     </Border>
 
-                    <!-- ══════════ 偵錯工具 ══════════
-                         Last on the page and shut, because it is for working out why a capture was
-                         read the way it was and for nothing else. The header opens it; the fold is
-                         deliberately not remembered, so nobody returns to this page and finds the
-                         app looking like a debugger because of a click weeks ago. What is inside
-                         the fold is remembered — that part is a preference. -->
-                    <Border Grid.Column="1" Style="{StaticResource CardBorder}">
-                        <StackPanel>
-                            <Border x:Name="DebugToolsHeader"
-                                    Background="Transparent"
-                                    Cursor="Hand"
-                                    MouseLeftButtonUp="DebugToolsHeader_Click">
-                                <StackPanel>
-                                    <StackPanel Style="{StaticResource CardHeaderRow}" Margin="0">
-                                        <TextBlock Text="&#xEBE8;" Style="{StaticResource CardHeaderIcon}"/>
-                                        <TextBlock Text="{DynamicResource S.Settings.DebugTools}"
-                                                   Style="{StaticResource CardTitle}"/>
-                                        <!-- Right-aligned in a card whose every other row is
-                                             left-packed, because it is the affordance and not a
-                                             label: it has to be findable without reading. -->
-                                        <TextBlock x:Name="DebugToolsChevron"
-                                                   Text="&#xE70D;"
-                                                   FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
-                                                   FontSize="12"
-                                                   Foreground="{DynamicResource AppTextSecondary}"
-                                                   VerticalAlignment="Center"
-                                                   HorizontalAlignment="Right"
-                                                   Margin="10,1,0,0"/>
-                                    </StackPanel>
-                                    <TextBlock Text="{DynamicResource S.Settings.DebugToolsHint}"
-                                               Style="{StaticResource OptionDescription}"
-                                               Margin="27,4,0,0"/>
-                                </StackPanel>
-                            </Border>
+                </Grid>
+                <!-- ══════════ 偵錯工具 ══════════
+                     Its own full-width row under 進階設定, and last on the page, because it is for
+                     working out why a capture was read the way it was and for nothing else. Full
+                     width because shut it is one line, while open it is three settings whose
+                     sentences would wrap twice in a half-width column.
 
-                            <Border x:Name="DebugToolsBody"
-                                    Style="{StaticResource ToggleRowBorder}"
-                                    Margin="0,12,0,0"
-                                    Visibility="Collapsed">
+                     The header opens it. The fold is deliberately not remembered, so nobody returns
+                     to this page and finds the app looking like a debugger because of a click weeks
+                     ago; what is inside the fold is remembered, because that part is a preference. -->
+                <Border Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="2"
+                        Style="{StaticResource CardBorder}">
+                    <StackPanel>
+                        <Border x:Name="DebugToolsHeader"
+                                Background="Transparent"
+                                Cursor="Hand"
+                                MouseLeftButtonUp="DebugToolsHeader_Click">
+                            <StackPanel Style="{StaticResource CardHeaderRow}" Margin="0">
+                                <TextBlock Text="&#xEBE8;" Style="{StaticResource CardHeaderIcon}"/>
+                                <TextBlock Text="{DynamicResource S.Settings.DebugTools}"
+                                           Style="{StaticResource CardTitle}"/>
+                                <!-- Beside the title rather than pushed to the far edge of a
+                                     full-width card, where it would read as belonging to nothing. -->
+                                <TextBlock x:Name="DebugToolsChevron"
+                                           Text="&#xE70D;"
+                                           FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
+                                           FontSize="12"
+                                           Foreground="{DynamicResource AppTextSecondary}"
+                                           VerticalAlignment="Center"
+                                           Margin="10,1,0,0"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- The description is inside the fold with everything else: shut, this card
+                             is its own title and nothing more, which is what a card nobody needs
+                             should cost the page. -->
+                        <StackPanel x:Name="DebugToolsBody" Visibility="Collapsed">
+                            <TextBlock Text="{DynamicResource S.Settings.DebugToolsHint}"
+                                       Style="{StaticResource OptionDescription}"
+                                       Margin="27,8,0,0"/>
+
+                            <Border Style="{StaticResource ToggleRowBorder}" Margin="0,12,0,0">
                                 <StackPanel>
+                                    <!-- No switch of its own: the two boxes below are the feature,
+                                         and neither ticked draws nothing. A master here would only
+                                         be a way to have this on and see nothing. -->
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="*"/>
                                         </Grid.ColumnDefinitions>
-                                        <CheckBox  Grid.Column="0" x:Name="OcrDebugOverlayCheckBox"
-                                                   Style="{StaticResource ModernCheckBox}"
-                                                   VerticalAlignment="Top"
-                                                   Checked="OcrDebugOverlay_Toggled"
-                                                   Unchecked="OcrDebugOverlay_Toggled"/>
-                                        <TextBlock Grid.Column="1" Text="&#xE890;" Style="{StaticResource OptionGlyph}"/>
-                                        <StackPanel Grid.Column="2">
+                                        <TextBlock Grid.Column="0"
+                                                   Text="&#xE890;"
+                                                   Style="{StaticResource OptionGlyph}"
+                                                   Margin="0,1,10,0"/>
+                                        <StackPanel Grid.Column="1">
                                             <TextBlock Text="{DynamicResource S.Settings.OcrDebug}"
                                                        Style="{StaticResource OptionTitle}"/>
                                             <TextBlock Text="{DynamicResource S.Settings.OcrDebugHint}"
@@ -1257,11 +1261,7 @@
                                         </StackPanel>
                                     </Grid>
 
-                                    <!-- Indented under the switch that turns them on, and greyed
-                                         with it: on their own they say nothing, and a tick that
-                                         changes nothing on screen is worse than one that is
-                                         plainly unavailable. -->
-                                    <Grid x:Name="OcrDebugBoxOptions" Margin="34,14,0,0">
+                                    <Grid Margin="25,14,0,0">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="*"/>
@@ -1296,8 +1296,8 @@
                                 </StackPanel>
                             </Border>
                         </StackPanel>
-                    </Border>
-                </Grid>
+                    </StackPanel>
+                </Border>
             </Grid>
         </ScrollViewer>
 

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -24,6 +24,45 @@
             <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="Margin"            Value="10,1,10,0"/>
         </Style>
+        <!-- A card heading that opens the card. Templated down to its content so it reads as the
+             heading it replaces and not as a button sitting where one used to be; what the template
+             adds is the part a heading cannot have — a hover, a pressed state that lands on the
+             press rather than on the release, and a focus ring for the keyboard. Padding is
+             cancelled by an equal negative margin so the hit area is larger than the words without
+             the words moving. -->
+        <Style x:Key="CardFoldToggle" TargetType="ToggleButton">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Cursor"     Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border x:Name="Hit"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="Transparent"
+                                BorderThickness="1"
+                                CornerRadius="6"
+                                Padding="7,5"
+                                Margin="-8,-6,-8,-6">
+                            <ContentPresenter/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Hit" Property="Background"
+                                        Value="{DynamicResource AppSurfaceBg}"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Hit" Property="Background"
+                                        Value="{DynamicResource AppSubtleBorder}"/>
+                            </Trigger>
+                            <Trigger Property="IsKeyboardFocused" Value="True">
+                                <Setter TargetName="Hit" Property="BorderBrush"
+                                        Value="{DynamicResource AppAccent}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
         <!-- The card's heading strip: glyph, title, and room under it before the first setting. -->
         <Style x:Key="CardHeaderRow" TargetType="StackPanel">
             <Setter Property="Orientation" Value="Horizontal"/>
@@ -1211,30 +1250,58 @@
                 <Border Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="2"
                         Style="{StaticResource CardBorder}">
                     <StackPanel>
-                        <Border x:Name="DebugToolsHeader"
-                                Background="Transparent"
-                                Cursor="Hand"
-                                MouseLeftButtonUp="DebugToolsHeader_Click">
+                        <!-- A ToggleButton and not a clickable Border: the fold is a two-state
+                             control, so it should carry that state itself, take focus, and answer
+                             the space bar. The template gives it what a Border cannot — a hover and
+                             a pressed appearance, the latter on the press rather than on the
+                             release, so the card answers the moment it is touched. -->
+                        <ToggleButton x:Name="DebugToolsToggle"
+                                      Style="{StaticResource CardFoldToggle}"
+                                      Checked="DebugToolsToggle_Toggled"
+                                      Unchecked="DebugToolsToggle_Toggled">
                             <StackPanel Style="{StaticResource CardHeaderRow}" Margin="0">
                                 <TextBlock Text="&#xEBE8;" Style="{StaticResource CardHeaderIcon}"/>
                                 <TextBlock Text="{DynamicResource S.Settings.DebugTools}"
                                            Style="{StaticResource CardTitle}"/>
                                 <!-- Beside the title rather than pushed to the far edge of a
-                                     full-width card, where it would read as belonging to nothing. -->
+                                     full-width card, where it would read as belonging to nothing.
+
+                                     It rotates rather than swapping to the other glyph, so opening
+                                     and closing run the same path in opposite directions and a
+                                     fold caught halfway has a chevron caught halfway. -->
                                 <TextBlock x:Name="DebugToolsChevron"
                                            Text="&#xE70D;"
                                            FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets"
                                            FontSize="12"
                                            Foreground="{DynamicResource AppTextSecondary}"
                                            VerticalAlignment="Center"
-                                           Margin="10,1,0,0"/>
+                                           Margin="10,1,0,0"
+                                           RenderTransformOrigin="0.5,0.5">
+                                    <TextBlock.RenderTransform>
+                                        <RotateTransform x:Name="DebugToolsChevronAngle" Angle="0"/>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </StackPanel>
-                        </Border>
+                        </ToggleButton>
 
+                        <!-- The fold clips; the panel inside it is what moves. Height is animated on
+                             this Border so the card's own height follows continuously and the cards
+                             below it are pushed rather than jumped. Collapsed outright when shut so
+                             the settings inside are out of the tab order as well as out of sight. -->
+                        <Border x:Name="DebugToolsFold"
+                                ClipToBounds="True"
+                                Height="0"
+                                Visibility="Collapsed">
                         <!-- The description is inside the fold with everything else: shut, this card
                              is its own title and nothing more, which is what a card nobody needs
                              should cost the page. -->
-                        <StackPanel x:Name="DebugToolsBody" Visibility="Collapsed">
+                        <StackPanel x:Name="DebugToolsBody" Opacity="0">
+                            <!-- Rises the last few pixels into place as it fades, so the content
+                                 arrives from behind the header it came out of rather than simply
+                                 appearing where it will end up. -->
+                            <StackPanel.RenderTransform>
+                                <TranslateTransform x:Name="DebugToolsBodyRise" Y="-8"/>
+                            </StackPanel.RenderTransform>
                             <TextBlock Text="{DynamicResource S.Settings.DebugToolsHint}"
                                        Style="{StaticResource OptionDescription}"
                                        Margin="27,8,0,0"/>
@@ -1296,6 +1363,7 @@
                                 </StackPanel>
                             </Border>
                         </StackPanel>
+                        </Border>
                     </StackPanel>
                 </Border>
             </Grid>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -488,6 +488,7 @@ public partial class SettingsPage : UserControl
         // Off Auto before animating, at the height it is showing right now.
         var target = expanded ? MeasuredDebugFoldHeight() : 0;
         DebugToolsFold.Height = DebugToolsFold.ActualHeight;
+        if (expanded) ScrollDebugToolsIntoView(target);
 
         var height = DebugFoldAnimation(target);
         height.Completed += (_, _) =>
@@ -517,6 +518,33 @@ public partial class SettingsPage : UserControl
         DebugToolsBody.BeginAnimation(OpacityProperty, null);
         DebugToolsBodyRise.BeginAnimation(TranslateTransform.YProperty, null);
         DebugToolsChevronAngle.BeginAnimation(RotateTransform.AngleProperty, null);
+    }
+
+    /// <summary>
+    /// Scrolls so the whole card is in view once it has finished opening, rather than leaving the
+    /// user to find the rest of what they just opened.
+    /// </summary>
+    /// <remarks>
+    /// <para>Aimed at where the card's bottom edge <em>will</em> be — its height now plus the fold
+    /// it is about to grow — because scrolling to where it is today would stop short by exactly the
+    /// part that is being revealed. The viewer clamps whatever it cannot reach yet and catches up
+    /// frame by frame as the fold opens, so the two movements finish together.</para>
+    ///
+    /// <para>Does nothing when the card already fits, which is the common case on a tall window.
+    /// Scrolling a page that did not need scrolling is worse than not scrolling one that did.</para>
+    /// </remarks>
+    private void ScrollDebugToolsIntoView(double foldHeight)
+    {
+        if (PresentationSource.FromVisual(DebugToolsCard) is null) return;
+
+        var content = (Visual)CardsScroll.Content;
+        var top = DebugToolsCard.TransformToAncestor(content).Transform(new System.Windows.Point(0, 0)).Y;
+        var bottom = top + DebugToolsCard.ActualHeight + foldHeight;
+
+        var offset = Math.Max(0, bottom - CardsScroll.ViewportHeight);
+        if (offset <= CardsScroll.VerticalOffset) return;
+
+        SmoothScroll.To(CardsScroll, offset, DebugFoldDuration, DebugFoldEasing);
     }
 
     /// <summary>How tall the fold's content wants to be at the width the card gives it.</summary>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -220,9 +220,15 @@ public partial class SettingsPage : UserControl
 
             VerboseLoggingCheckBox.IsChecked = s.VerboseLogging;
 
+            OcrDebugOverlayCheckBox.IsChecked = s.ShowOcrDebugOverlay;
+            OcrLineBoxesCheckBox.IsChecked = s.ShowOcrLineBoxes;
+            TextGroupBoxesCheckBox.IsChecked = s.ShowTextGroupBoxes;
+
             RefreshServiceTiles();
             UpdateScreenshotPathVisibility();
             UpdateVerboseLoggingAvailability();
+            CollapseDebugTools();
+            UpdateOcrDebugBoxAvailability();
         }
         finally
         {
@@ -407,6 +413,51 @@ public partial class SettingsPage : UserControl
         LogLevelService.Apply(verbose);
         Persist(s => s.VerboseLogging = verbose);
     }
+
+    /// <summary>
+    /// Shuts the 偵錯工具 card, which is how every visit to this page starts.
+    /// </summary>
+    /// <remarks>
+    /// Called from the load rather than left to the markup's initial state, because the page is
+    /// built once and shown again: without this, a card opened in one visit is still open in the
+    /// next. The fold is the one thing on this page that is not remembered — see AppSettings.
+    /// </remarks>
+    private void CollapseDebugTools() => SetDebugToolsExpanded(false);
+
+    private void DebugToolsHeader_Click(object sender, MouseButtonEventArgs e) =>
+        SetDebugToolsExpanded(DebugToolsBody.Visibility != Visibility.Visible);
+
+    private void SetDebugToolsExpanded(bool expanded)
+    {
+        DebugToolsBody.Visibility = expanded ? Visibility.Visible : Visibility.Collapsed;
+        DebugToolsChevron.Text = expanded ? "" : "";
+    }
+
+    private void OcrDebugOverlay_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+
+        bool show = OcrDebugOverlayCheckBox.IsChecked == true;
+        Persist(s => s.ShowOcrDebugOverlay = show);
+        UpdateOcrDebugBoxAvailability();
+    }
+
+    private void OcrDebugBoxes_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+
+        bool lines = OcrLineBoxesCheckBox.IsChecked == true;
+        bool groups = TextGroupBoxesCheckBox.IsChecked == true;
+        Persist(s =>
+        {
+            s.ShowOcrLineBoxes = lines;
+            s.ShowTextGroupBoxes = groups;
+        });
+    }
+
+    // Which boxes to draw only means something once there are boxes to draw.
+    private void UpdateOcrDebugBoxAvailability() =>
+        OcrDebugBoxOptions.IsEnabled = OcrDebugOverlayCheckBox.IsChecked == true;
 
     /// <summary>
     /// An environment variable outranks this setting, so when one is set the checkbox says so rather

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -220,15 +220,13 @@ public partial class SettingsPage : UserControl
 
             VerboseLoggingCheckBox.IsChecked = s.VerboseLogging;
 
-            OcrDebugOverlayCheckBox.IsChecked = s.ShowOcrDebugOverlay;
-            OcrLineBoxesCheckBox.IsChecked = s.ShowOcrLineBoxes;
-            TextGroupBoxesCheckBox.IsChecked = s.ShowTextGroupBoxes;
+            OcrLineBoxesCheckBox.IsChecked = s.OcrDebug.ShowLineBoxes;
+            TextGroupBoxesCheckBox.IsChecked = s.OcrDebug.ShowGroupBoxes;
 
             RefreshServiceTiles();
             UpdateScreenshotPathVisibility();
             UpdateVerboseLoggingAvailability();
             CollapseDebugTools();
-            UpdateOcrDebugBoxAvailability();
         }
         finally
         {
@@ -433,15 +431,6 @@ public partial class SettingsPage : UserControl
         DebugToolsChevron.Text = expanded ? "" : "";
     }
 
-    private void OcrDebugOverlay_Toggled(object sender, RoutedEventArgs e)
-    {
-        if (_loading) return;
-
-        bool show = OcrDebugOverlayCheckBox.IsChecked == true;
-        Persist(s => s.ShowOcrDebugOverlay = show);
-        UpdateOcrDebugBoxAvailability();
-    }
-
     private void OcrDebugBoxes_Toggled(object sender, RoutedEventArgs e)
     {
         if (_loading) return;
@@ -450,14 +439,10 @@ public partial class SettingsPage : UserControl
         bool groups = TextGroupBoxesCheckBox.IsChecked == true;
         Persist(s =>
         {
-            s.ShowOcrLineBoxes = lines;
-            s.ShowTextGroupBoxes = groups;
+            s.OcrDebug.ShowLineBoxes = lines;
+            s.OcrDebug.ShowGroupBoxes = groups;
         });
     }
-
-    // Which boxes to draw only means something once there are boxes to draw.
-    private void UpdateOcrDebugBoxAvailability() =>
-        OcrDebugBoxOptions.IsEnabled = OcrDebugOverlayCheckBox.IsChecked == true;
 
     /// <summary>
     /// An environment variable outranks this setting, so when one is set the checkbox says so rather

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -412,6 +412,22 @@ public partial class SettingsPage : UserControl
         Persist(s => s.VerboseLogging = verbose);
     }
 
+    /// <summary>How long the 偵錯工具 fold takes, and the shape of it.</summary>
+    /// <remarks>
+    /// Eased out and not elastic: nothing threw this open, so an overshoot would be motion the
+    /// gesture did not ask for. 0.3s is long enough to be followed and short enough that a second
+    /// press never has to wait for a first.
+    /// </remarks>
+    private static readonly Duration DebugFoldDuration = new(TimeSpan.FromMilliseconds(300));
+
+    private static readonly IEasingFunction DebugFoldEasing =
+        new CubicEase { EasingMode = EasingMode.EaseOut };
+
+    /// <summary>How far the fold's content sits above its resting place before it opens.</summary>
+    private const double DebugFoldRise = -8;
+
+    private bool _debugToolsExpanded;
+
     /// <summary>
     /// Shuts the 偵錯工具 card, which is how every visit to this page starts.
     /// </summary>
@@ -419,16 +435,96 @@ public partial class SettingsPage : UserControl
     /// Called from the load rather than left to the markup's initial state, because the page is
     /// built once and shown again: without this, a card opened in one visit is still open in the
     /// next. The fold is the one thing on this page that is not remembered — see AppSettings.
+    ///
+    /// Without animating, because this is not the card closing — it is the card being found shut,
+    /// and a page that plays its animations on arrival looks like it is still loading.
     /// </remarks>
-    private void CollapseDebugTools() => SetDebugToolsExpanded(false);
-
-    private void DebugToolsHeader_Click(object sender, MouseButtonEventArgs e) =>
-        SetDebugToolsExpanded(DebugToolsBody.Visibility != Visibility.Visible);
-
-    private void SetDebugToolsExpanded(bool expanded)
+    private void CollapseDebugTools()
     {
-        DebugToolsBody.Visibility = expanded ? Visibility.Visible : Visibility.Collapsed;
-        DebugToolsChevron.Text = expanded ? "" : "";
+        DebugToolsToggle.IsChecked = false;
+        SetDebugToolsExpanded(false, animate: false);
+    }
+
+    private void DebugToolsToggle_Toggled(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+
+        SetDebugToolsExpanded(DebugToolsToggle.IsChecked == true, animate: true);
+    }
+
+    /// <summary>
+    /// Opens or shuts the fold, carrying the card's height, the content and the chevron together.
+    /// </summary>
+    /// <remarks>
+    /// <para>Every animation is written with a target and no start, which is what makes the fold
+    /// reversible: WPF runs a To-only animation from whatever is on screen at that instant, so a
+    /// fold caught halfway open turns round from halfway rather than snapping to its full height
+    /// and closing from there. Pressing the header repeatedly does what pressing it looks like it
+    /// should do.</para>
+    ///
+    /// <para>The height is animated on the clipping Border rather than left to Auto, because Auto
+    /// cannot be animated — so it is pinned to its measured height for the duration and handed back
+    /// to Auto at the end, where the content is free to reflow again (a longer translation, a
+    /// wrapped line) without this having fixed a stale number to it.</para>
+    /// </remarks>
+    private void SetDebugToolsExpanded(bool expanded, bool animate)
+    {
+        _debugToolsExpanded = expanded;
+        if (expanded) DebugToolsFold.Visibility = Visibility.Visible;
+
+        // The Windows setting for animations inside a window. Off means shown the answer rather
+        // than the motion — the fold still works, it just arrives.
+        if (!animate || !SystemParameters.ClientAreaAnimation)
+        {
+            StopDebugFoldAnimations();
+            DebugToolsFold.Visibility = expanded ? Visibility.Visible : Visibility.Collapsed;
+            DebugToolsFold.Height = expanded ? double.NaN : 0;
+            DebugToolsBody.Opacity = expanded ? 1 : 0;
+            DebugToolsBodyRise.Y = expanded ? 0 : DebugFoldRise;
+            DebugToolsChevronAngle.Angle = expanded ? 180 : 0;
+            return;
+        }
+
+        // Off Auto before animating, at the height it is showing right now.
+        var target = expanded ? MeasuredDebugFoldHeight() : 0;
+        DebugToolsFold.Height = DebugToolsFold.ActualHeight;
+
+        var height = DebugFoldAnimation(target);
+        height.Completed += (_, _) =>
+        {
+            // A later press owns the fold now, and its own Completed will finish the job.
+            if (_debugToolsExpanded != expanded) return;
+
+            DebugToolsFold.BeginAnimation(HeightProperty, null);
+            DebugToolsFold.Height = expanded ? double.NaN : 0;
+            if (!expanded) DebugToolsFold.Visibility = Visibility.Collapsed;
+        };
+
+        DebugToolsFold.BeginAnimation(HeightProperty, height);
+        DebugToolsBody.BeginAnimation(OpacityProperty, DebugFoldAnimation(expanded ? 1 : 0));
+        DebugToolsBodyRise.BeginAnimation(
+            TranslateTransform.YProperty, DebugFoldAnimation(expanded ? 0 : DebugFoldRise));
+        DebugToolsChevronAngle.BeginAnimation(
+            RotateTransform.AngleProperty, DebugFoldAnimation(expanded ? 180 : 0));
+    }
+
+    private static DoubleAnimation DebugFoldAnimation(double to) =>
+        new(to, DebugFoldDuration) { EasingFunction = DebugFoldEasing };
+
+    private void StopDebugFoldAnimations()
+    {
+        DebugToolsFold.BeginAnimation(HeightProperty, null);
+        DebugToolsBody.BeginAnimation(OpacityProperty, null);
+        DebugToolsBodyRise.BeginAnimation(TranslateTransform.YProperty, null);
+        DebugToolsChevronAngle.BeginAnimation(RotateTransform.AngleProperty, null);
+    }
+
+    /// <summary>How tall the fold's content wants to be at the width the card gives it.</summary>
+    private double MeasuredDebugFoldHeight()
+    {
+        var width = DebugToolsFold.ActualWidth > 0 ? DebugToolsFold.ActualWidth : double.PositiveInfinity;
+        DebugToolsBody.Measure(new System.Windows.Size(width, double.PositiveInfinity));
+        return DebugToolsBody.DesiredSize.Height;
     }
 
     private void OcrDebugBoxes_Toggled(object sender, RoutedEventArgs e)

--- a/tests/OverTranslate.Tests/OcrDebugBoxesTests.cs
+++ b/tests/OverTranslate.Tests/OcrDebugBoxesTests.cs
@@ -52,8 +52,9 @@ public class OcrDebugBoxesTests
     }
 
     /// <summary>
-    /// The 偵錯工具 card opens shut. The load path shuts it on every visit as well — this pins the
-    /// markup half, which is what a reader tidying attributes would take for decoration.
+    /// The 偵錯工具 card opens shut, and its contents are out of the tab order while it is. The load
+    /// path shuts it on every visit as well; this pins the markup half, which is what a reader
+    /// tidying attributes would take for decoration.
     /// </summary>
     [Fact]
     public void TheDebugToolsCardIsCollapsedInMarkup()
@@ -62,10 +63,13 @@ public class OcrDebugBoxesTests
             StringsParityTests.ProjectDirectory(), "Views", "Settings", "SettingsPage.xaml");
         XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
 
-        var body = XDocument.Load(page)
+        var fold = XDocument.Load(page)
             .Descendants()
-            .Single(element => (string?)element.Attribute(x + "Name") == "DebugToolsBody");
+            .Single(element => (string?)element.Attribute(x + "Name") == "DebugToolsFold");
 
-        Assert.Equal("Collapsed", (string?)body.Attribute("Visibility"));
+        Assert.Equal("Collapsed", (string?)fold.Attribute("Visibility"));
+        Assert.Equal("0", (string?)fold.Attribute("Height"));
+        // Clipped, or the content would spill out of the card while the height is animating.
+        Assert.Equal("True", (string?)fold.Attribute("ClipToBounds"));
     }
 }

--- a/tests/OverTranslate.Tests/OcrDebugBoxesTests.cs
+++ b/tests/OverTranslate.Tests/OcrDebugBoxesTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Xml.Linq;
+using OverTranslate.Layout;
+using OverTranslate.Services;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class OcrDebugBoxesTests
+{
+    /// <summary>
+    /// Every line the recogniser returned gets a box, groups included — the debug view is about
+    /// what was read, so a group that swallowed three lines has to show all three.
+    /// </summary>
+    [Fact]
+    public void DrawsABoxForEveryRecognisedLine()
+    {
+        var blocks = new List<OcrTextBlock>
+        {
+            new("a wrapped sentence", new Rect(10, 10, 200, 60),
+                [new Rect(10, 10, 200, 28), new Rect(10, 42, 180, 28)]),
+            new("Exit", new Rect(10, 120, 70, 28)),
+        };
+
+        var lines = OcrDebugBoxes.LineBoxes(blocks);
+
+        Assert.Equal(3, lines.Count);
+        Assert.Contains(new Rect(10, 10, 200, 28), lines);
+        Assert.Contains(new Rect(10, 42, 180, 28), lines);
+        Assert.Contains(new Rect(10, 120, 70, 28), lines);
+    }
+
+    /// <summary>
+    /// A group box encloses its lines rather than coinciding with them, which is what makes the two
+    /// layers readable together — and the case that would otherwise be unreadable is the common
+    /// one: a group of a single line, where the two rectangles are the same rectangle.
+    /// </summary>
+    [Fact]
+    public void AGroupBoxSitsOutsideTheLinesItHolds()
+    {
+        var blocks = new List<OcrTextBlock> { new("Exit", new Rect(10, 120, 70, 28)) };
+
+        var group = Assert.Single(OcrDebugBoxes.GroupBoxes(blocks));
+        var line = Assert.Single(OcrDebugBoxes.LineBoxes(blocks));
+
+        Assert.True(group.Contains(line), $"{group} does not enclose {line}");
+        Assert.Equal(line.Left - OcrDebugBoxes.GroupOutset, group.Left);
+        Assert.Equal(line.Right + OcrDebugBoxes.GroupOutset, group.Right);
+    }
+
+    /// <summary>
+    /// The 偵錯工具 card opens shut. The load path shuts it on every visit as well — this pins the
+    /// markup half, which is what a reader tidying attributes would take for decoration.
+    /// </summary>
+    [Fact]
+    public void TheDebugToolsCardIsCollapsedInMarkup()
+    {
+        var page = Path.Combine(
+            StringsParityTests.ProjectDirectory(), "Views", "Settings", "SettingsPage.xaml");
+        XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+        var body = XDocument.Load(page)
+            .Descendants()
+            .Single(element => (string?)element.Attribute(x + "Name") == "DebugToolsBody");
+
+        Assert.Equal("Collapsed", (string?)body.Attribute("Visibility"));
+    }
+}

--- a/tests/OverTranslate.Tests/SettingsParsingTests.cs
+++ b/tests/OverTranslate.Tests/SettingsParsingTests.cs
@@ -349,6 +349,7 @@ public class SettingsParsingTests
         var captureGroup = json.IndexOf("\"Capture\":", StringComparison.Ordinal);
         var quickLookupGroup = json.IndexOf("\"QuickLookup\":", StringComparison.Ordinal);
         var realtimeGroup = json.IndexOf("\"Realtime\":", StringComparison.Ordinal);
+        var ocrDebugGroup = json.IndexOf("\"OcrDebug\":", StringComparison.Ordinal);
         var openAiGroup = json.IndexOf("\"OpenAi\":", StringComparison.Ordinal);
         var rootKeys = System.Text.Json.JsonDocument.Parse(json).RootElement
             .EnumerateObject()
@@ -357,11 +358,12 @@ public class SettingsParsingTests
 
         Assert.True(
             lastFlatKey >= 0 && captureGroup >= 0 && quickLookupGroup >= 0 && realtimeGroup >= 0
-            && openAiGroup >= 0);
+            && ocrDebugGroup >= 0 && openAiGroup >= 0);
         Assert.True(
             captureGroup > lastFlatKey,
             "grouped settings must be written after every flat one");
-        Assert.Equal(["Capture", "QuickLookup", "Realtime", "OpenAi"], rootKeys.TakeLast(4));
+        Assert.Equal(
+            ["Capture", "QuickLookup", "Realtime", "OcrDebug", "OpenAi"], rootKeys.TakeLast(5));
     }
 
     /// <summary>


### PR DESCRIPTION
## 內容

設定頁新增可折疊的偵錯工具區，開啟後截圖翻譯會在畫面上疊加 OCR 的辨識框與文字分組框。用途是把「這段字為什麼沒被翻譯／為什麼被併在一起」從猜測變成看得見。

## 幾個刻意的決定

- **偵錯框跟著原文顯示，不是跟著譯文。** 框是量在原文上的，畫在譯文上會對不準
- **顯示原文時也能複製到偵錯框。** 原文加上框，正是最值得傳給別人看的那個畫面
- **複製截圖會保留偵錯框。** 開著偵錯的人是在看這張截圖怎麼被讀的，複製就是他拿去給別人看的方式；沒有框的問題截圖不是任何問題的截圖
- **偵錯工具是獨立滿版列、沒有主開關。** 一個開關管一群開關，只會讓人不知道現在到底開了什麼

展開動畫可中斷，展開時捲動到完整顯示（`SmoothScroll`）。

## 驗證

- `OcrDebugBoxesTests`：框的座標換算與可見性
- `SettingsParsingTests`：新設定的讀寫與預設值
- 814 測試通過、2 略過、0 失敗