### PR TITLE
refactor: OCR 版面指標拆分，來源語言不再影響文字分組

### DIFF
--- a/src/OverTranslate/Services/Ocr/BoxShapeNoise.cs
+++ b/src/OverTranslate/Services/Ocr/BoxShapeNoise.cs
@@ -29,6 +29,14 @@ namespace OverTranslate.Services.Ocr;
 /// This matters more than the count suggests. Such a block is short, so it looks nothing like the
 /// subtitle already on screen, so it counts as a new sentence — and a region whose only reading is
 /// a lone □ replaces a correct translation with one.
+///
+/// The measurement is on <c>LayoutBounds</c>, the box the detector drew, because this runs after
+/// normalisation and <c>Bounds</c> by then means different things on different source languages: a
+/// CJK-normalised box is 0.82 as tall, so the same detection reads 1.22x higher and can cross the
+/// threshold on one language and not another. Measured over 2710 blocks of the image corpus, the
+/// rule took 17 of them under 英文, 32 under 日文 and 18 under 自動 while reading Bounds — and 14
+/// under all three while reading LayoutBounds. The eighteen 日文 lost that way were labels like
+/// 闇, 三, 決定 and 결정, which is the whole of what PR #161 was about.
 /// </remarks>
 internal static class BoxShapeNoise
 {
@@ -41,8 +49,8 @@ internal static class BoxShapeNoise
     public static bool IsTooWideForItsText(OcrTextBlock block)
     {
         var glyphs = ShortTextGlyphHeight.GlyphsIn(block.Text);
-        if (glyphs == 0 || block.Bounds.Height <= 0) return false;
+        if (glyphs == 0 || block.LayoutBounds.Height <= 0) return false;
 
-        return block.Bounds.Width / glyphs / block.Bounds.Height >= MaxWidthPerGlyph;
+        return block.LayoutBounds.Width / glyphs / block.LayoutBounds.Height >= MaxWidthPerGlyph;
     }
 }

--- a/src/OverTranslate/Services/Ocr/BoxShapeNoise.cs
+++ b/src/OverTranslate/Services/Ocr/BoxShapeNoise.cs
@@ -22,9 +22,21 @@ namespace OverTranslate.Services.Ocr;
 ///   2.0 and over                            160   □, □2, 🎶□2, [, [0]2|
 /// </code>
 ///
-/// The gap between the real words at 1.4 and the rubbish at 2.0 is what the threshold sits in. It
-/// could be pulled down to 1.5 and take the 15 blocks between them, which are also rubbish, but
-/// that is a twentieth of the benefit for most of the margin.
+/// The gap between the real words at 1.4 and the rubbish at 2.0 is what the threshold was placed
+/// in. It could be pulled down to 1.5 and take the 15 blocks between them, which are also rubbish,
+/// but that is a twentieth of the benefit for most of the margin.
+///
+/// That gap is a property of the sample it was measured on, not of the rule. Re-measured in
+/// September 2026 over the 2710 blocks of the image corpus, 36 of them fall between 1.4 and 2.0
+/// and real words and rubbish are interleaved there: "1 回02" at 1.96 and "{}2" at 1.94 beside
+/// 이 at 1.85, 闇 and 三 at 1.84, and 決定 at 1.74. So the threshold is not sitting in empty
+/// space on that corpus; it sits above everything legible in it. That makes 2.0 preservation-
+/// oriented on purpose — it under-catches, letting some rubbish through rather than risking a
+/// label — which is the same trade PR #161 made.
+///
+/// Nothing legible was found above the line: all 14 blocks it takes on that corpus are toolbar
+/// strips a recorder drew, a slab of an anime frame read as "A", or Korean pages read with a model
+/// that holds no Hangul, where the reading is wrong however it is filtered.
 ///
 /// This matters more than the count suggests. Such a block is short, so it looks nothing like the
 /// subtitle already on screen, so it counts as a new sentence — and a region whose only reading is
@@ -33,10 +45,10 @@ namespace OverTranslate.Services.Ocr;
 /// The measurement is on <c>LayoutBounds</c>, the box the detector drew, because this runs after
 /// normalisation and <c>Bounds</c> by then means different things on different source languages: a
 /// CJK-normalised box is 0.82 as tall, so the same detection reads 1.22x higher and can cross the
-/// threshold on one language and not another. Measured over 2710 blocks of the image corpus, the
-/// rule took 17 of them under 英文, 32 under 日文 and 18 under 自動 while reading Bounds — and 14
-/// under all three while reading LayoutBounds. The eighteen 日文 lost that way were labels like
-/// 闇, 三, 決定 and 결정, which is the whole of what PR #161 was about.
+/// threshold on one language and not another. On the same corpus the rule took 17 blocks under
+/// 英文, 32 under 日文 and 18 under 自動 while reading Bounds — and 14 under all three while
+/// reading LayoutBounds. The eighteen 日文 lost that way were labels like 闇, 三, 決定 and 결정,
+/// which is the whole of what PR #161 was about.
 /// </remarks>
 internal static class BoxShapeNoise
 {

--- a/src/OverTranslate/Services/Ocr/OcrLayoutScript.cs
+++ b/src/OverTranslate/Services/Ocr/OcrLayoutScript.cs
@@ -1,0 +1,86 @@
+namespace OverTranslate.Services.Ocr;
+
+/// <summary>
+/// Which writing system a block's own text is in, for the grouping geometry to reason about.
+/// </summary>
+/// <remarks>
+/// Decided per block from the text that was read, never from the source language the user picked:
+/// the same screenshot under 自動 and under 日文 must group identically, and the only way to get
+/// there is for nothing on the layout side to know what was picked. An explicit field rather than
+/// a null glyph height standing in for "this one is CJK", which is how the render metric ended up
+/// serving two callers that wanted opposite things.
+/// </remarks>
+public enum OcrLayoutScript
+{
+    /// <summary>No text to judge from — punctuation or symbols only.</summary>
+    Unknown,
+
+    /// <summary>No CJK, and something to read: letters or digits.</summary>
+    Latin,
+
+    /// <summary>Kana or Han, and no Latin letters.</summary>
+    Cjk,
+
+    /// <summary>Both, which a line of Japanese technical prose routinely is.</summary>
+    Mixed,
+}
+
+/// <summary>
+/// Reads <see cref="OcrLayoutScript"/> off a recognised line.
+/// </summary>
+/// <remarks>
+/// Any Han character counts, not two of them. Telling Chinese from Japanese needs the second one;
+/// knowing the line is set in full-width glyphs does not, and that is all the layout side asks.
+/// Two is also what left a single 攻 on the Latin geometry path — see #161.
+///
+/// Deliberately separate from <c>OnnxOcrEngine.UsesCjkLayoutForText</c>, which keeps its own rule
+/// because it chooses a *render* normalisation strategy, not the script of the text.
+/// </remarks>
+internal static class LayoutScriptDetection
+{
+    public static OcrLayoutScript For(string text)
+    {
+        var hasCjk = false;
+        var hasLatinLetter = false;
+        var hasReadableGlyph = false;
+
+        foreach (var c in text)
+        {
+            if (IsKana(c) || IsHanIdeograph(c))
+            {
+                hasCjk = true;
+                hasReadableGlyph = true;
+            }
+            else if (char.IsLetter(c))
+            {
+                hasLatinLetter = true;
+                hasReadableGlyph = true;
+            }
+            else if (char.IsDigit(c))
+            {
+                // Digits carry no script of their own, but a line of them is set in whatever the
+                // surrounding interface uses, and today every "Lv100" and "23:29" already takes the
+                // Latin path. Calling those Unknown would move them onto the coarse cross-script
+                // fallback for no measured reason.
+                hasReadableGlyph = true;
+            }
+        }
+
+        return (hasCjk, hasLatinLetter, hasReadableGlyph) switch
+        {
+            (true, true, _) => OcrLayoutScript.Mixed,
+            (true, false, _) => OcrLayoutScript.Cjk,
+            (false, _, true) => OcrLayoutScript.Latin,
+            _ => OcrLayoutScript.Unknown,
+        };
+    }
+
+    public static bool IsHanIdeograph(char c) =>
+        c is >= '一' and <= '鿿' || // CJK Unified Ideographs
+        c is >= '㐀' and <= '䶿' || // Extension A
+        c is >= '豈' and <= '﫿';   // Compatibility Ideographs
+
+    public static bool IsKana(char c) =>
+        c is >= 'ぁ' and <= 'ヿ' || // Hiragana + Katakana
+        c is >= 'ㇰ' and <= 'ㇿ';   // Katakana Phonetic Extensions
+}

--- a/src/OverTranslate/Services/Ocr/OcrLayoutScript.cs
+++ b/src/OverTranslate/Services/Ocr/OcrLayoutScript.cs
@@ -33,7 +33,7 @@ public enum OcrLayoutScript
 /// knowing the line is set in full-width glyphs does not, and that is all the layout side asks.
 /// Two is also what left a single 攻 on the Latin geometry path — see #161.
 ///
-/// Deliberately separate from <c>OnnxOcrEngine.UsesCjkLayoutForText</c>, which keeps its own rule
+/// Deliberately separate from <c>OnnxOcrEngine.UsesCjkRenderMetricsForText</c>, which keeps its own rule
 /// because it chooses a *render* normalisation strategy, not the script of the text.
 /// </remarks>
 internal static class LayoutScriptDetection

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Windows;
 
 namespace OverTranslate.Services.Ocr;
@@ -15,6 +16,8 @@ internal static class OcrTextBlockGrouper
     internal static List<OcrTextBlock> Group(
         IReadOnlyList<OcrTextBlock> blocks, List<NextLineDecision>? decisions)
     {
+        AssertLayoutGeometryFilled(blocks);
+
         if (blocks.Count <= 1)
             return blocks.ToList();
 
@@ -35,6 +38,30 @@ internal static class OcrTextBlockGrouper
         }
 
         return groups.Select(BuildGroup).ToList();
+    }
+
+    /// <summary>
+    /// Every block reaching the grouper must carry the detection box the layout tests measure on.
+    /// </summary>
+    /// <remarks>
+    /// Loud on purpose, and deliberately not a fallback to <c>Bounds</c>. A block that arrives with
+    /// nothing in LayoutBounds is a construction path that forgot to fill it, and quietly reading
+    /// Bounds instead would put the script-dependent geometry — the 0.820 this whole split exists
+    /// to remove — back into grouping without anything saying so. Compiled out of Release, so a
+    /// degenerate detection box cannot take the app down; the tests run Debug and will not miss it.
+    /// </remarks>
+    [Conditional("DEBUG")]
+    private static void AssertLayoutGeometryFilled(IReadOnlyList<OcrTextBlock> blocks)
+    {
+        foreach (var block in blocks)
+        {
+            if (block.LayoutBounds.Width > 0 && block.LayoutBounds.Height > 0)
+                continue;
+
+            throw new InvalidOperationException(
+                $"Block \"{block.Text}\" reached the grouper with no LayoutBounds " +
+                $"({block.LayoutBounds}). Fill it where the block is built.");
+        }
     }
 
     /// <summary>

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -78,9 +78,29 @@ internal static class OcrTextBlockGrouper
     }
 
     /// <summary>
-    /// One next-line verdict, with its geometry in line heights so numbers from captures of
+    /// One grouping verdict, with its geometry in line heights so numbers from captures of
     /// different sizes can be read side by side.
     /// </summary>
+    /// <remarks>
+    /// TWO KINDS SHARE THESE FIELDS AND DO NOT FILL THEM WITH THE SAME QUANTITIES. Anything
+    /// aggregating a run has to split on <c>Kind</c> first; pooling the two mixes a horizontal
+    /// measurement into a vertical distribution and reads as a pile of zeroes at one end.
+    ///
+    /// <code>
+    ///   field           Kind "next" (line below)        Kind "row" (same line, left to right)
+    ///   VerticalGap     vertical gap between lines      HORIZONTAL gap between neighbours
+    ///   LeftDelta       left-edge misalignment          vertical overlap rate, 0..1
+    ///   TextSizeRatio   glyph or box height ratio       unused, 0
+    ///   LineAdvance     baseline advance                unused, 0
+    ///   WidthRatio      width ratio                     width ratio
+    /// </code>
+    ///
+    /// Renaming the fields per kind means two records and two code paths through the grouper for
+    /// what is one diagnostic; naming them for the vertical case and documenting the reuse is the
+    /// cheaper honest option. <c>OcrHarness --group-explain</c> prints each kind with its own
+    /// labels, and must keep doing so.
+    /// </remarks>
+    /// <param name="Kind">"next" for a line-below verdict, "row" for a same-line one.</param>
     /// <param name="Rule">Which test decided, whether it joined or refused.</param>
     internal readonly record struct NextLineDecision(
         string Kind,

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -92,6 +92,7 @@ internal static class OcrTextBlockGrouper
         double LeftDelta,
         double TextSizeRatio,
         double WidthRatio,
+        double LineAdvance,
         bool Joined,
         string Rule);
 
@@ -268,6 +269,7 @@ internal static class OcrTextBlockGrouper
             VerticalOverlapRate(previous, current),
             0,
             previous.LayoutBounds.Width / Math.Max(1, current.LayoutBounds.Width),
+            0,
             joined,
             rule);
 
@@ -321,10 +323,30 @@ internal static class OcrTextBlockGrouper
             Math.Abs(previous.LayoutBounds.X - current.LayoutBounds.X) / Math.Max(1, avgHeight),
             TextSizeRatio(previous, current),
             previous.LayoutBounds.Width / Math.Max(1, current.LayoutBounds.Width),
+            LineAdvanceRatio(previous, current),
             joined,
             rule));
 
         return joined;
+    }
+
+    /// <summary>
+    /// The leading: how far the second line sits below the first, in detection-box heights. One
+    /// line advance is 1.0, so a paragraph reads a little under it and anything laid out on purpose
+    /// reads well over.
+    /// </summary>
+    /// <remarks>
+    /// Measured on <see cref="OcrTextBlock.LayoutBounds"/>, which is what makes a leading test
+    /// possible at all. Against the normalised box the same typographic leading comes back as two
+    /// different fractions — a Japanese Wikipedia paragraph read 0.37 between its lines where an
+    /// English one read 0.09 — so the two populations overlapped and no threshold separated them.
+    /// On the detector's own box they agree.
+    /// </remarks>
+    private static double LineAdvanceRatio(OcrTextBlock previous, OcrTextBlock current)
+    {
+        var box = (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0;
+
+        return box > 0 ? (current.LayoutBounds.Y - previous.LayoutBounds.Y) / box : -1;
     }
 
     private static (bool Joined, string Rule) JudgeNextLine(OcrTextBlock previous, OcrTextBlock current)
@@ -436,10 +458,18 @@ internal static class OcrTextBlockGrouper
         // menu entries looks like — a longer label above a shorter one, aligned, evenly spaced. It
         // read 「アビリティ」over「召喚石」and 「캐릭터강화」over「소지품」as wrapped sentences, glued
         // each pair into one string for the translator, and squeezed both into one bubble. See #75.
-        return IsLongEnoughToHaveWrapped(previous) &&
-               previous.LayoutBounds.Width >= current.LayoutBounds.Width * 1.35
+        if (!IsLongEnoughToHaveWrapped(previous) ||
+            previous.LayoutBounds.Width < current.LayoutBounds.Width * 1.35)
+            return (false, "no continuation evidence");
+
+        // A paragraph's last line is set at the paragraph's leading, so a pair spaced further apart
+        // than that is not a paragraph ending — it is a heading over the thing it labels, or the
+        // next entry in a list. This rule had no leading test at all, which is how a settings panel
+        // joined "Reveal all rooms before proceeding to next floor" to the unrelated checkbox under
+        // it purely because that one was shorter.
+        return LineAdvanceRatio(previous, current) <= WrappedFinalLineAdvance
             ? (true, "shorter final line")
-            : (false, "no continuation evidence");
+            : (false, "leading");
     }
 
     /// <summary>
@@ -457,6 +487,28 @@ internal static class OcrTextBlockGrouper
     /// half a sentence, which is the far worse failure — it is the whole of #74.</para>
     /// </remarks>
     private const double WrappedLineMinAspect = 8.0;
+
+    /// <summary>
+    /// The most leading a shorter following line can have and still be the end of the paragraph
+    /// above it.
+    /// </summary>
+    /// <remarks>
+    /// <para>Measured over the image corpus on LayoutBounds, after the row rule had stopped side by
+    /// side things being joined: every pair that is really one sentence wrapping sits at or under
+    /// 1.33 — a Korean panel's instruction at 1.26 and 1.33, an English page's "Resources for
+    /// Developers," / "by Developers" at 1.32 — while the pairs that must come apart start at 1.40:
+    /// three checkbox entries of the settings panel at 1.40 and 1.43, and a documentation site's
+    /// breadcrumb over its filter box at 1.55. Nothing falls between 1.33 and 1.40.</para>
+    ///
+    /// <para>1.38 is where the branch this was ported from put it, on a different corpus and a
+    /// reconstructed detection box; landing inside the empty band measured here as well is the
+    /// reason to keep the number rather than move it to the midpoint.</para>
+    ///
+    /// <para>Every script, not Latin only. The port gated this on Latin because it had to rebuild
+    /// the detector's box from the normalised one and that reconstruction was only approximate for
+    /// CJK. LayoutBounds is the box, so there is nothing to approximate and nothing to gate.</para>
+    /// </remarks>
+    private const double WrappedFinalLineAdvance = 1.38;
 
     private static bool IsLongEnoughToHaveWrapped(OcrTextBlock line) =>
         line.LayoutBounds.Height > 0 &&

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -34,7 +34,7 @@ internal static class OcrTextBlockGrouper
         if (blocks.Count <= 1)
             return blocks.ToList();
 
-        var sameLineMerged = MergeSameLineFragments(blocks);
+        var sameLineMerged = MergeSameLineFragments(blocks, decisions);
         var sorted = sameLineMerged
             .OrderBy(block => block.LayoutBounds.Y)
             .ThenBy(block => block.LayoutBounds.X)
@@ -83,6 +83,7 @@ internal static class OcrTextBlockGrouper
     /// </summary>
     /// <param name="Rule">Which test decided, whether it joined or refused.</param>
     internal readonly record struct NextLineDecision(
+        string Kind,
         string Previous,
         string Current,
         OcrLayoutScript PreviousScript,
@@ -94,99 +95,181 @@ internal static class OcrTextBlockGrouper
         bool Joined,
         string Rule);
 
-    private static List<OcrTextBlock> MergeSameLineFragments(IReadOnlyList<OcrTextBlock> blocks)
+    private static List<OcrTextBlock> MergeSameLineFragments(
+        IReadOnlyList<OcrTextBlock> blocks, List<NextLineDecision>? decisions)
     {
-        // Process left-to-right and append each fragment to whichever open row it continues, rather
-        // than a global Y-then-X sort + "compare only with the previous" merge. Latin word boxes on
-        // one line have tops that vary with ascenders/descenders (e.g. "Send" y=32 vs "to" y=37), so
-        // a Y-primary sort interleaves words from across the line and the sequential merge then
-        // leaves a single line scattered into separately translated words. Sorting by X keeps a
-        // line's fragments in reading order; the vertical-overlap test in CanJoinSameLine routes
-        // each fragment to the correct row when several lines are present.
+        var rows = BuildVisualRows(blocks);
+        var gaps = rows.SelectMany(AdjacentGaps).ToList();
+        var threshold = SameLineGapThreshold.Estimate(gaps);
+
+        return rows.SelectMany(row => SplitRowIntoLines(row, threshold.Value, decisions)).ToList();
+    }
+
+    /// <summary>
+    /// Gathers the boxes that sit on one line of the picture, left to right, whatever the spaces
+    /// between them turn out to mean.
+    /// </summary>
+    /// <remarks>
+    /// Membership only, with no gap test. Which spaces are wide enough to separate things cannot be
+    /// decided one pair at a time, because it depends on the spacing this particular capture uses,
+    /// and that cannot be measured until the rows are known. So the rows are built first and cut
+    /// afterwards.
+    ///
+    /// Sorted by X and not by Y. Latin word boxes on one line have tops that vary with ascenders
+    /// and descenders (a real line gave "Send" at y=32 beside "to" at y=37), so a Y-primary sort
+    /// interleaves words from across the capture and a row built in that order ends up holding
+    /// fragments of several. Reading order keeps a line's own boxes together, and the vertical
+    /// overlap test routes each box to the right row when several are open at once.
+    /// </remarks>
+    private static List<List<OcrTextBlock>> BuildVisualRows(IReadOnlyList<OcrTextBlock> blocks)
+    {
         var ordered = blocks
             .OrderBy(block => block.LayoutBounds.X)
             .ThenBy(block => block.LayoutBounds.Y)
             .ToList();
-        var merged = new List<OcrTextBlock>();
+        var rows = new List<List<OcrTextBlock>>();
 
         foreach (var block in ordered)
         {
-            var targetIndex = FindSameLineTarget(merged, block);
-            if (targetIndex >= 0)
-                merged[targetIndex] = MergeSameLine(merged[targetIndex], block);
-            else
-                merged.Add(block);
-        }
+            var bestRow = -1;
+            var bestOverlap = double.NegativeInfinity;
 
-        return merged;
-    }
-
-    // Among the open row-blocks, returns the one this fragment continues — the candidate to its left
-    // with the most vertical overlap (best row match), or -1 when none qualifies.
-    private static int FindSameLineTarget(List<OcrTextBlock> merged, OcrTextBlock block)
-    {
-        var bestIndex = -1;
-        var bestOverlap = double.NegativeInfinity;
-
-        for (var i = 0; i < merged.Count; i++)
-        {
-            var candidate = merged[i];
-            if (!CanJoinSameLine(candidate, block))
-                continue;
-
-            var overlap = Math.Min(candidate.LayoutBounds.Bottom, block.LayoutBounds.Bottom) -
-                          Math.Max(candidate.LayoutBounds.Top, block.LayoutBounds.Top);
-            if (overlap > bestOverlap)
+            for (var i = 0; i < rows.Count; i++)
             {
+                // Against the rightmost box of the row, which is the one this would follow.
+                var rightmost = rows[i][^1];
+                if (!SharesVisualRow(rightmost, block)) continue;
+
+                var overlap = VerticalOverlapRate(rightmost, block);
+                if (overlap <= bestOverlap) continue;
+
                 bestOverlap = overlap;
-                bestIndex = i;
+                bestRow = i;
             }
+
+            if (bestRow >= 0) rows[bestRow].Add(block);
+            else rows.Add([block]);
         }
 
-        return bestIndex;
+        return rows;
     }
 
-    private static bool CanJoinSameLine(OcrTextBlock previous, OcrTextBlock current)
+    /// <summary>Whether two boxes sit on the same line of the picture. Says nothing about joining.</summary>
+    private static bool SharesVisualRow(OcrTextBlock previous, OcrTextBlock current)
     {
-        var avgHeight = (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0;
-
         // Vertical overlap — NOT height ratio — is what tells an in-line word from a distinct
-        // neighbour. A short mid-line word ("to" h=25 on a h=31 line → heightRatio 0.81) sits on the
-        // same baseline, so its box is fully nested in the line (overlap ≈ 1.0). Two stacked buttons
-        // ("Download…report" h=32 next to a vertically offset "Create key" h=38 → heightRatio 0.84)
-        // overlap only ≈ 0.47. Their height ratios are inverted (0.81 < 0.84), so any single height
-        // threshold either drops "to" or merges the buttons. Keep height tolerant and let the strict
-        // overlap test below do the discriminating.
-        // 0.5 rather than 0.6, measured: a subtitle reading "Let's pay CiRCLE a visit on the way
+        // neighbour. A short mid-line word ("to" h=25 on a h=31 line, heightRatio 0.81) sits on the
+        // same baseline, so its box is fully nested in the line (overlap about 1.0). Two stacked
+        // buttons ("Download…report" h=32 next to a vertically offset "Create key" h=38,
+        // heightRatio 0.84) overlap only about 0.47. Their height ratios are inverted
+        // (0.81 < 0.84), so any single height threshold either drops "to" or merges the buttons.
+        // Keep height tolerant and let the strict overlap test do the discriminating.
+        //
+        // 0.5 rather than 0.6, measured: a subtitle reading "Let us pay CiRCLE a visit on the way
         // home." came back as an 888x88 box and a 141x51 one holding "home", a height ratio of
         // 0.58. They sit 2px apart with the shorter box entirely inside the taller one's rows, and
-        // the guard rejected them anyway — so "home" was translated on its own and appeared as a
+        // the guard rejected them anyway, so "home" was translated on its own and appeared as a
         // stray word to the right of a sentence missing its ending. The word's box is short because
         // the word has no descender, which is a property of the letters, not of whether they belong
-        // to the line. Discriminating between lines is the vertical-overlap test's job below, as the
-        // note above says; this only has to keep out boxes of wildly different size.
+        // to the line.
         var heightRatio = Math.Min(previous.LayoutBounds.Height, current.LayoutBounds.Height) /
                           Math.Max(previous.LayoutBounds.Height, current.LayoutBounds.Height);
-        if (heightRatio < 0.5)
-            return false;
 
-        var verticalOverlap = Math.Max(
+        return heightRatio >= MinimumRowHeightRatio &&
+               VerticalOverlapRate(previous, current) >= MinimumRowVerticalOverlap;
+    }
+
+    private static double VerticalOverlapRate(OcrTextBlock previous, OcrTextBlock current)
+    {
+        var overlap = Math.Max(
             0,
             Math.Min(previous.LayoutBounds.Bottom, current.LayoutBounds.Bottom) -
             Math.Max(previous.LayoutBounds.Top, current.LayoutBounds.Top));
-        var verticalOverlapRate = verticalOverlap /
-                                  Math.Max(1, Math.Min(previous.LayoutBounds.Height, current.LayoutBounds.Height));
-        if (verticalOverlapRate < 0.72)
-            return false;
+
+        return overlap /
+               Math.Max(1, Math.Min(previous.LayoutBounds.Height, current.LayoutBounds.Height));
+    }
+
+    /// <summary>The space before each box in a row, in line heights, neighbour to neighbour.</summary>
+    private static IEnumerable<double> AdjacentGaps(List<OcrTextBlock> row) =>
+        row.Zip(row.Skip(1), NormalizedGap);
+
+    private static double NormalizedGap(OcrTextBlock previous, OcrTextBlock current) =>
+        (current.LayoutBounds.X - previous.LayoutBounds.Right) /
+        Math.Max(1, (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0);
+
+    /// <summary>
+    /// Cuts one row wherever the space between neighbours is too wide to be a space between words,
+    /// and joins what is left.
+    /// </summary>
+    private static IEnumerable<OcrTextBlock> SplitRowIntoLines(
+        List<OcrTextBlock> row, double threshold, List<NextLineDecision>? decisions)
+    {
+        var lines = new List<OcrTextBlock>();
+        var line = row[0];
+
+        for (var i = 1; i < row.Count; i++)
+        {
+            var (joined, rule) = JudgeSameLine(row[i - 1], row[i], threshold);
+            decisions?.Add(SameLineDecision(row[i - 1], row[i], joined, rule));
+
+            if (joined)
+            {
+                line = MergeSameLine(line, row[i]);
+                continue;
+            }
+
+            lines.Add(line);
+            line = row[i];
+        }
+
+        lines.Add(line);
+        return lines;
+    }
+
+    private static (bool Joined, string Rule) JudgeSameLine(
+        OcrTextBlock previous, OcrTextBlock current, double threshold)
+    {
+        var avgHeight = (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0;
 
         // The gap can be negative: on large captures the detector's unclip expansion enlarges big
         // heading word-boxes until adjacent ones overlap horizontally (e.g. "Translate" right=533
-        // vs "your website" left=515 → gap -18), which the old `>= 0` guard rejected, scattering
+        // vs "your website" left=515, a gap of -18), which a non-negative guard rejected, scattering
         // one heading into word-by-word translations. Allow up to a line-height of overlap; the
-        // vertical-overlap and height-ratio checks above already keep stacked/unrelated lines out.
+        // checks in SharesVisualRow already keep stacked lines out.
         var horizontalGap = current.LayoutBounds.X - previous.LayoutBounds.Right;
-        return horizontalGap >= -avgHeight && horizontalGap <= Math.Max(avgHeight * 1.35, 18);
+        if (horizontalGap < -avgHeight)
+            return (false, "overlaps too far");
+
+        // The floor is for text too small for a ratio to mean much. It was 18px, which at the sizes
+        // it applied to was itself wide enough to cross a menu.
+        return horizontalGap <= Math.Max(avgHeight * threshold, MinimumRowGapPixels)
+            ? (true, "same row")
+            : (false, "horizontal gap");
     }
+
+    /// <inheritdoc cref="SharesVisualRow"/>
+    private const double MinimumRowHeightRatio = 0.5;
+
+    /// <inheritdoc cref="SharesVisualRow"/>
+    private const double MinimumRowVerticalOverlap = 0.72;
+
+    /// <inheritdoc cref="JudgeSameLine"/>
+    private const double MinimumRowGapPixels = 6;
+
+    private static NextLineDecision SameLineDecision(
+        OcrTextBlock previous, OcrTextBlock current, bool joined, string rule) =>
+        new("row",
+            previous.Text,
+            current.Text,
+            previous.LayoutScript,
+            current.LayoutScript,
+            NormalizedGap(previous, current),
+            VerticalOverlapRate(previous, current),
+            0,
+            previous.LayoutBounds.Width / Math.Max(1, current.LayoutBounds.Width),
+            joined,
+            rule);
 
     private static OcrTextBlock MergeSameLine(OcrTextBlock previous, OcrTextBlock current)
     {
@@ -229,6 +312,7 @@ internal static class OcrTextBlockGrouper
 
         var avgHeight = (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0;
         decisions.Add(new NextLineDecision(
+            "next",
             previous.Text,
             current.Text,
             previous.LayoutScript,
@@ -249,7 +333,7 @@ internal static class OcrTextBlockGrouper
         if (TextSizeRatio(previous, current) < 0.88)
             return (false, "text size");
 
-        // The gap can be negative, for exactly the reason it can horizontally in CanJoinSameLine:
+        // The gap can be negative, for exactly the reason it can horizontally in JudgeSameLine:
         // the detector's unclip expansion grows every box a little past its glyphs, so two lines of
         // one wrapped sentence routinely come back overlapping by a few pixels. A `< 0` guard threw
         // those apart, and each half was then translated on its own — which is not a cosmetic
@@ -296,7 +380,7 @@ internal static class OcrTextBlockGrouper
     /// sentence, re-read as the picture moved, gave anything from 0.68 to 1.00 across eight passes:
     /// text that merged or did not depending on the frame.</para>
     ///
-    /// <para>This is the argument <see cref="CanJoinSameLine"/> already makes about its own height
+    /// <para>This is the argument <see cref="SharesVisualRow"/> already makes about its own height
     /// test — box height is a property of the letters, not of whether they belong together — and the
     /// answer there was to keep the test tolerant. Here there is a better one available: the engine
     /// already measures the ink for Latin lines, because both overlays need it to size their font.

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -129,14 +129,16 @@ internal static class OcrTextBlockGrouper
         var right = Math.Max(previous.Bounds.Right, current.Bounds.Right);
         var bottom = Math.Max(previous.Bounds.Bottom, current.Bounds.Bottom);
         var text = JoinInlineText(previous.Text, current.Text);
+        var layoutScript = LayoutScriptDetection.For(text);
 
         return new OcrTextBlock(
             text,
             new Rect(left, top, right - left, bottom - top),
             RenderGlyphHeight: CombineGlyphHeight(previous.RenderGlyphHeight, current.RenderGlyphHeight),
             Confidence: CombineConfidence([previous, current]),
-            LayoutScript: LayoutScriptDetection.For(text),
-            LayoutBounds: Rect.Union(previous.LayoutBounds, current.LayoutBounds));
+            LayoutScript: layoutScript,
+            LayoutBounds: Rect.Union(previous.LayoutBounds, current.LayoutBounds),
+            LayoutGlyphHeight: CombineLayoutGlyphHeight(layoutScript, [previous, current]));
     }
 
     private static string JoinInlineText(string left, string right)
@@ -313,6 +315,8 @@ internal static class OcrTextBlockGrouper
             .ToList();
         double? groupGlyphHeight = glyphHeights.Count > 0 ? glyphHeights[glyphHeights.Count / 2] : null;
 
+        var layoutScript = LayoutScriptDetection.For(text);
+
         return new OcrTextBlock(
             text,
             new Rect(x, y, right - x, bottom - y),
@@ -322,8 +326,9 @@ internal static class OcrTextBlockGrouper
             // Re-read rather than folded together: the field's contract is "the script of this
             // block's own text", and a group whose lines are Latin and CJK is exactly the Mixed
             // that the joined text reports.
-            LayoutScriptDetection.For(text),
-            blocks.Select(block => block.LayoutBounds).Aggregate(Rect.Union));
+            layoutScript,
+            blocks.Select(block => block.LayoutBounds).Aggregate(Rect.Union),
+            CombineLayoutGlyphHeight(layoutScript, blocks));
     }
 
     /// <summary>
@@ -349,6 +354,24 @@ internal static class OcrTextBlockGrouper
         }
 
         return weight > 0 ? weighted / weight : null;
+    }
+
+    /// <summary>
+    /// One layout glyph height for several lines: the median of theirs, and nothing at all once
+    /// the joined text is no longer of a single script.
+    /// </summary>
+    private static double? CombineLayoutGlyphHeight(OcrLayoutScript script, IReadOnlyList<OcrTextBlock> blocks)
+    {
+        if (script is not (OcrLayoutScript.Latin or OcrLayoutScript.Cjk))
+            return null;
+
+        var heights = blocks
+            .Where(block => block.LayoutGlyphHeight is > 0)
+            .Select(block => block.LayoutGlyphHeight!.Value)
+            .OrderBy(height => height)
+            .ToList();
+
+        return heights.Count > 0 ? heights[heights.Count / 2] : null;
     }
 
     private static double? CombineGlyphHeight(double? a, double? b) =>

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -4,7 +4,16 @@ namespace OverTranslate.Services.Ocr;
 
 internal static class OcrTextBlockGrouper
 {
-    public static List<OcrTextBlock> Group(IReadOnlyList<OcrTextBlock> blocks)
+    public static List<OcrTextBlock> Group(IReadOnlyList<OcrTextBlock> blocks) => Group(blocks, null);
+
+    /// <param name="decisions">
+    /// Collects one entry per line pair the next-line test was asked about, with the geometry it
+    /// judged on and which rule decided. Null in the app; OcrHarness passes a list, because these
+    /// thresholds cannot be tuned from the grouped output alone — it shows what was joined, never
+    /// how close the rest came to being.
+    /// </param>
+    internal static List<OcrTextBlock> Group(
+        IReadOnlyList<OcrTextBlock> blocks, List<NextLineDecision>? decisions)
     {
         if (blocks.Count <= 1)
             return blocks.ToList();
@@ -19,7 +28,7 @@ internal static class OcrTextBlockGrouper
         foreach (var block in sorted)
         {
             var previousGroup = groups.LastOrDefault();
-            if (previousGroup is not null && CanJoinNextLine(previousGroup[^1], block))
+            if (previousGroup is not null && CanJoinNextLine(previousGroup[^1], block, decisions))
                 previousGroup.Add(block);
             else
                 groups.Add([block]);
@@ -27,6 +36,23 @@ internal static class OcrTextBlockGrouper
 
         return groups.Select(BuildGroup).ToList();
     }
+
+    /// <summary>
+    /// One next-line verdict, with its geometry in line heights so numbers from captures of
+    /// different sizes can be read side by side.
+    /// </summary>
+    /// <param name="Rule">Which test decided, whether it joined or refused.</param>
+    internal readonly record struct NextLineDecision(
+        string Previous,
+        string Current,
+        OcrLayoutScript PreviousScript,
+        OcrLayoutScript CurrentScript,
+        double VerticalGap,
+        double LeftDelta,
+        double TextSizeRatio,
+        double WidthRatio,
+        bool Joined,
+        string Rule);
 
     private static List<OcrTextBlock> MergeSameLineFragments(IReadOnlyList<OcrTextBlock> blocks)
     {
@@ -154,11 +180,34 @@ internal static class OcrTextBlockGrouper
         return needsSpace ? $"{left} {right}" : $"{left}{right}";
     }
 
-    private static bool CanJoinNextLine(OcrTextBlock previous, OcrTextBlock current)
+    private static bool CanJoinNextLine(
+        OcrTextBlock previous, OcrTextBlock current, List<NextLineDecision>? decisions)
+    {
+        var (joined, rule) = JudgeNextLine(previous, current);
+        if (decisions is null)
+            return joined;
+
+        var avgHeight = (previous.Bounds.Height + current.Bounds.Height) / 2.0;
+        decisions.Add(new NextLineDecision(
+            previous.Text,
+            current.Text,
+            previous.LayoutScript,
+            current.LayoutScript,
+            (current.Bounds.Y - previous.Bounds.Bottom) / Math.Max(1, avgHeight),
+            Math.Abs(previous.Bounds.X - current.Bounds.X) / Math.Max(1, avgHeight),
+            TextSizeRatio(previous, current),
+            previous.Bounds.Width / Math.Max(1, current.Bounds.Width),
+            joined,
+            rule));
+
+        return joined;
+    }
+
+    private static (bool Joined, string Rule) JudgeNextLine(OcrTextBlock previous, OcrTextBlock current)
     {
         var avgHeight = (previous.Bounds.Height + current.Bounds.Height) / 2.0;
         if (TextSizeRatio(previous, current) < 0.88)
-            return false;
+            return (false, "text size");
 
         // The gap can be negative, for exactly the reason it can horizontally in CanJoinSameLine:
         // the detector's unclip expansion grows every box a little past its glyphs, so two lines of
@@ -176,11 +225,11 @@ internal static class OcrTextBlockGrouper
         // merge takes most of them first, and this is the backstop for the rest.
         var verticalGap = current.Bounds.Y - (previous.Bounds.Y + previous.Bounds.Height);
         if (verticalGap < -avgHeight * 0.5 || verticalGap > Math.Max(avgHeight * 0.8, 10))
-            return false;
+            return (false, "vertical gap");
 
         var leftDelta = Math.Abs(previous.Bounds.X - current.Bounds.X);
         if (leftDelta > Math.Max(avgHeight * 1.2, 18))
-            return false;
+            return (false, "alignment");
 
         var overlap = Math.Max(
             0,
@@ -189,7 +238,10 @@ internal static class OcrTextBlockGrouper
         var overlapRate = overlap / Math.Max(1, Math.Min(previous.Bounds.Width, current.Bounds.Width));
         var isAlignedContinuation =
             overlapRate >= 0.35 || leftDelta <= Math.Max(avgHeight * 0.7, 12);
-        return isAlignedContinuation && HasSentenceContinuationEvidence(previous, current);
+        if (!isAlignedContinuation)
+            return (false, "not aligned enough to continue");
+
+        return SentenceContinuationEvidence(previous, current);
     }
 
     /// <summary>
@@ -227,20 +279,21 @@ internal static class OcrTextBlockGrouper
                Math.Max(previous.Bounds.Height, current.Bounds.Height);
     }
 
-    private static bool HasSentenceContinuationEvidence(OcrTextBlock previous, OcrTextBlock current)
+    private static (bool Joined, string Rule) SentenceContinuationEvidence(
+        OcrTextBlock previous, OcrTextBlock current)
     {
         var previousText = previous.Text.Trim();
         var currentText = current.Text.Trim();
         if (previousText.Length == 0 || currentText.Length == 0)
-            return false;
+            return (false, "empty text");
 
         if (HasUnclosedDelimiter(previousText) ||
             EndsWithContinuationPunctuation(previousText) ||
             StartsWithContinuationPunctuation(currentText))
-            return true;
+            return (true, "punctuation");
 
         if (EndsWithSentenceTerminator(previousText))
-            return false;
+            return (false, "sentence terminator");
 
         // A much shorter following line is a common natural wrap shape.
         // Similar-width lines without linguistic evidence are kept separate
@@ -251,7 +304,9 @@ internal static class OcrTextBlockGrouper
         // read 「アビリティ」over「召喚石」and 「캐릭터강화」over「소지품」as wrapped sentences, glued
         // each pair into one string for the translator, and squeezed both into one bubble. See #75.
         return IsLongEnoughToHaveWrapped(previous) &&
-               previous.Bounds.Width >= current.Bounds.Width * 1.35;
+               previous.Bounds.Width >= current.Bounds.Width * 1.35
+            ? (true, "shorter final line")
+            : (false, "no continuation evidence");
     }
 
     /// <summary>

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -3,6 +3,19 @@ using System.Windows;
 
 namespace OverTranslate.Services.Ocr;
 
+/// <summary>
+/// Joins the lines the engine read into the blocks that get translated together.
+/// </summary>
+/// <remarks>
+/// Every measurement a decision here is made on comes from <c>LayoutBounds</c>, the box the
+/// detector drew, and never from <c>Bounds</c>. Bounds has been normalised per script by the time
+/// it arrives — a CJK line is pulled in onto its glyphs and a Latin one is left whole — so reading
+/// it made every threshold mean something different depending on which language the user had
+/// selected. The horizontal figures are the same in both (normalisation only touches Y and height);
+/// the vertical ones are not, and neither is anything derived from a line height.
+///
+/// What the group carries out is still Bounds: that is the area the overlay has to cover.
+/// </remarks>
 internal static class OcrTextBlockGrouper
 {
     public static List<OcrTextBlock> Group(IReadOnlyList<OcrTextBlock> blocks) => Group(blocks, null);
@@ -23,8 +36,8 @@ internal static class OcrTextBlockGrouper
 
         var sameLineMerged = MergeSameLineFragments(blocks);
         var sorted = sameLineMerged
-            .OrderBy(block => block.Bounds.Y)
-            .ThenBy(block => block.Bounds.X)
+            .OrderBy(block => block.LayoutBounds.Y)
+            .ThenBy(block => block.LayoutBounds.X)
             .ToList();
 
         var groups = new List<List<OcrTextBlock>>();
@@ -91,8 +104,8 @@ internal static class OcrTextBlockGrouper
         // line's fragments in reading order; the vertical-overlap test in CanJoinSameLine routes
         // each fragment to the correct row when several lines are present.
         var ordered = blocks
-            .OrderBy(block => block.Bounds.X)
-            .ThenBy(block => block.Bounds.Y)
+            .OrderBy(block => block.LayoutBounds.X)
+            .ThenBy(block => block.LayoutBounds.Y)
             .ToList();
         var merged = new List<OcrTextBlock>();
 
@@ -121,8 +134,8 @@ internal static class OcrTextBlockGrouper
             if (!CanJoinSameLine(candidate, block))
                 continue;
 
-            var overlap = Math.Min(candidate.Bounds.Bottom, block.Bounds.Bottom) -
-                          Math.Max(candidate.Bounds.Top, block.Bounds.Top);
+            var overlap = Math.Min(candidate.LayoutBounds.Bottom, block.LayoutBounds.Bottom) -
+                          Math.Max(candidate.LayoutBounds.Top, block.LayoutBounds.Top);
             if (overlap > bestOverlap)
             {
                 bestOverlap = overlap;
@@ -135,7 +148,7 @@ internal static class OcrTextBlockGrouper
 
     private static bool CanJoinSameLine(OcrTextBlock previous, OcrTextBlock current)
     {
-        var avgHeight = (previous.Bounds.Height + current.Bounds.Height) / 2.0;
+        var avgHeight = (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0;
 
         // Vertical overlap — NOT height ratio — is what tells an in-line word from a distinct
         // neighbour. A short mid-line word ("to" h=25 on a h=31 line → heightRatio 0.81) sits on the
@@ -152,17 +165,17 @@ internal static class OcrTextBlockGrouper
         // the word has no descender, which is a property of the letters, not of whether they belong
         // to the line. Discriminating between lines is the vertical-overlap test's job below, as the
         // note above says; this only has to keep out boxes of wildly different size.
-        var heightRatio = Math.Min(previous.Bounds.Height, current.Bounds.Height) /
-                          Math.Max(previous.Bounds.Height, current.Bounds.Height);
+        var heightRatio = Math.Min(previous.LayoutBounds.Height, current.LayoutBounds.Height) /
+                          Math.Max(previous.LayoutBounds.Height, current.LayoutBounds.Height);
         if (heightRatio < 0.5)
             return false;
 
         var verticalOverlap = Math.Max(
             0,
-            Math.Min(previous.Bounds.Bottom, current.Bounds.Bottom) -
-            Math.Max(previous.Bounds.Top, current.Bounds.Top));
+            Math.Min(previous.LayoutBounds.Bottom, current.LayoutBounds.Bottom) -
+            Math.Max(previous.LayoutBounds.Top, current.LayoutBounds.Top));
         var verticalOverlapRate = verticalOverlap /
-                                  Math.Max(1, Math.Min(previous.Bounds.Height, current.Bounds.Height));
+                                  Math.Max(1, Math.Min(previous.LayoutBounds.Height, current.LayoutBounds.Height));
         if (verticalOverlapRate < 0.72)
             return false;
 
@@ -171,7 +184,7 @@ internal static class OcrTextBlockGrouper
         // vs "your website" left=515 → gap -18), which the old `>= 0` guard rejected, scattering
         // one heading into word-by-word translations. Allow up to a line-height of overlap; the
         // vertical-overlap and height-ratio checks above already keep stacked/unrelated lines out.
-        var horizontalGap = current.Bounds.X - previous.Bounds.Right;
+        var horizontalGap = current.LayoutBounds.X - previous.LayoutBounds.Right;
         return horizontalGap >= -avgHeight && horizontalGap <= Math.Max(avgHeight * 1.35, 18);
     }
 
@@ -214,16 +227,16 @@ internal static class OcrTextBlockGrouper
         if (decisions is null)
             return joined;
 
-        var avgHeight = (previous.Bounds.Height + current.Bounds.Height) / 2.0;
+        var avgHeight = (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0;
         decisions.Add(new NextLineDecision(
             previous.Text,
             current.Text,
             previous.LayoutScript,
             current.LayoutScript,
-            (current.Bounds.Y - previous.Bounds.Bottom) / Math.Max(1, avgHeight),
-            Math.Abs(previous.Bounds.X - current.Bounds.X) / Math.Max(1, avgHeight),
+            (current.LayoutBounds.Y - previous.LayoutBounds.Bottom) / Math.Max(1, avgHeight),
+            Math.Abs(previous.LayoutBounds.X - current.LayoutBounds.X) / Math.Max(1, avgHeight),
             TextSizeRatio(previous, current),
-            previous.Bounds.Width / Math.Max(1, current.Bounds.Width),
+            previous.LayoutBounds.Width / Math.Max(1, current.LayoutBounds.Width),
             joined,
             rule));
 
@@ -232,7 +245,7 @@ internal static class OcrTextBlockGrouper
 
     private static (bool Joined, string Rule) JudgeNextLine(OcrTextBlock previous, OcrTextBlock current)
     {
-        var avgHeight = (previous.Bounds.Height + current.Bounds.Height) / 2.0;
+        var avgHeight = (previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0;
         if (TextSizeRatio(previous, current) < 0.88)
             return (false, "text size");
 
@@ -250,19 +263,19 @@ internal static class OcrTextBlockGrouper
         // -0.9 to -1.0. Nothing at all falls between, so the threshold sits in empty space rather
         // than on either edge. Those row-mates are what this really has to keep out; the same-line
         // merge takes most of them first, and this is the backstop for the rest.
-        var verticalGap = current.Bounds.Y - (previous.Bounds.Y + previous.Bounds.Height);
+        var verticalGap = current.LayoutBounds.Y - (previous.LayoutBounds.Y + previous.LayoutBounds.Height);
         if (verticalGap < -avgHeight * 0.5 || verticalGap > Math.Max(avgHeight * 0.8, 10))
             return (false, "vertical gap");
 
-        var leftDelta = Math.Abs(previous.Bounds.X - current.Bounds.X);
+        var leftDelta = Math.Abs(previous.LayoutBounds.X - current.LayoutBounds.X);
         if (leftDelta > Math.Max(avgHeight * 1.2, 18))
             return (false, "alignment");
 
         var overlap = Math.Max(
             0,
-            Math.Min(previous.Bounds.Right, current.Bounds.Right) -
-            Math.Max(previous.Bounds.Left, current.Bounds.Left));
-        var overlapRate = overlap / Math.Max(1, Math.Min(previous.Bounds.Width, current.Bounds.Width));
+            Math.Min(previous.LayoutBounds.Right, current.LayoutBounds.Right) -
+            Math.Max(previous.LayoutBounds.Left, current.LayoutBounds.Left));
+        var overlapRate = overlap / Math.Max(1, Math.Min(previous.LayoutBounds.Width, current.LayoutBounds.Width));
         var isAlignedContinuation =
             overlapRate >= 0.35 || leftDelta <= Math.Max(avgHeight * 0.7, 12);
         if (!isAlignedContinuation)
@@ -340,7 +353,7 @@ internal static class OcrTextBlockGrouper
         // read 「アビリティ」over「召喚石」and 「캐릭터강화」over「소지품」as wrapped sentences, glued
         // each pair into one string for the translator, and squeezed both into one bubble. See #75.
         return IsLongEnoughToHaveWrapped(previous) &&
-               previous.Bounds.Width >= current.Bounds.Width * 1.35
+               previous.LayoutBounds.Width >= current.LayoutBounds.Width * 1.35
             ? (true, "shorter final line")
             : (false, "no continuation evidence");
     }
@@ -362,8 +375,8 @@ internal static class OcrTextBlockGrouper
     private const double WrappedLineMinAspect = 8.0;
 
     private static bool IsLongEnoughToHaveWrapped(OcrTextBlock line) =>
-        line.Bounds.Height > 0 &&
-        line.Bounds.Width / line.Bounds.Height >= WrappedLineMinAspect;
+        line.LayoutBounds.Height > 0 &&
+        line.LayoutBounds.Width / line.LayoutBounds.Height >= WrappedLineMinAspect;
 
     private static bool HasUnclosedDelimiter(string text) =>
         Count(text, '「') > Count(text, '」') ||

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -135,7 +135,8 @@ internal static class OcrTextBlockGrouper
             new Rect(left, top, right - left, bottom - top),
             RenderGlyphHeight: CombineGlyphHeight(previous.RenderGlyphHeight, current.RenderGlyphHeight),
             Confidence: CombineConfidence([previous, current]),
-            LayoutScript: LayoutScriptDetection.For(text));
+            LayoutScript: LayoutScriptDetection.For(text),
+            LayoutBounds: Rect.Union(previous.LayoutBounds, current.LayoutBounds));
     }
 
     private static string JoinInlineText(string left, string right)
@@ -321,7 +322,8 @@ internal static class OcrTextBlockGrouper
             // Re-read rather than folded together: the field's contract is "the script of this
             // block's own text", and a group whose lines are Latin and CJK is exactly the Mixed
             // that the joined text reports.
-            LayoutScriptDetection.For(text));
+            LayoutScriptDetection.For(text),
+            blocks.Select(block => block.LayoutBounds).Aggregate(Rect.Union));
     }
 
     /// <summary>

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -133,7 +133,7 @@ internal static class OcrTextBlockGrouper
         return new OcrTextBlock(
             text,
             new Rect(left, top, right - left, bottom - top),
-            SourceGlyphHeight: CombineGlyphHeight(previous.SourceGlyphHeight, current.SourceGlyphHeight),
+            RenderGlyphHeight: CombineGlyphHeight(previous.RenderGlyphHeight, current.RenderGlyphHeight),
             Confidence: CombineConfidence([previous, current]));
     }
 
@@ -215,8 +215,8 @@ internal static class OcrTextBlockGrouper
     /// </remarks>
     private static double TextSizeRatio(OcrTextBlock previous, OcrTextBlock current)
     {
-        if (previous.SourceGlyphHeight is { } previousGlyph and > 0 &&
-            current.SourceGlyphHeight is { } currentGlyph and > 0)
+        if (previous.RenderGlyphHeight is { } previousGlyph and > 0 &&
+            current.RenderGlyphHeight is { } currentGlyph and > 0)
             return Math.Min(previousGlyph, currentGlyph) / Math.Max(previousGlyph, currentGlyph);
 
         return Math.Min(previous.Bounds.Height, current.Bounds.Height) /
@@ -305,8 +305,8 @@ internal static class OcrTextBlockGrouper
         // Aggregate the per-line glyph heights (Latin only; null for CJK) so the group's overlay
         // font is sized from the real glyph height, while Bounds remains the full coverage area.
         var glyphHeights = blocks
-            .Where(block => block.SourceGlyphHeight.HasValue)
-            .Select(block => block.SourceGlyphHeight!.Value)
+            .Where(block => block.RenderGlyphHeight.HasValue)
+            .Select(block => block.RenderGlyphHeight!.Value)
             .OrderBy(height => height)
             .ToList();
         double? groupGlyphHeight = glyphHeights.Count > 0 ? glyphHeights[glyphHeights.Count / 2] : null;

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -293,17 +293,26 @@ internal static class OcrTextBlockGrouper
     /// above and one more wrapped English line — and separates none that were already joined. The
     /// threshold does not move; it was never the problem. See issue #79.</para>
     ///
-    /// <para>CJK reports no glyph height because its box already sits on the glyphs, so those keep
-    /// comparing boxes and are unaffected.</para>
+    /// <para>Glyph heights are compared only within one script. A Latin box carries ascender and
+    /// descender room a CJK one does not, so the two numbers do not mean the same thing, and no
+    /// constant converts between them — that was measured, and the ratio turned out to be a
+    /// property of the particular words rather than of the scripts.</para>
+    ///
+    /// <para>Everything else falls back to the raw detection boxes, which is coarse but at least
+    /// impartial: one detector, one procedure, whatever the text is. It is what the old code did
+    /// too, except that it compared the *normalised* boxes — and those are 0.820 of each other
+    /// across scripts before a single letter is read, so every Latin line beside a CJK one was
+    /// refused by a size test it could not have passed. That is issue #164's 「OPTIONS／ゲーム設定」.</para>
     /// </remarks>
-    private static double TextSizeRatio(OcrTextBlock previous, OcrTextBlock current)
+    internal static double TextSizeRatio(OcrTextBlock previous, OcrTextBlock current)
     {
-        if (previous.RenderGlyphHeight is { } previousGlyph and > 0 &&
-            current.RenderGlyphHeight is { } currentGlyph and > 0)
+        if (previous.LayoutScript == current.LayoutScript &&
+            previous.LayoutGlyphHeight is { } previousGlyph and > 0 &&
+            current.LayoutGlyphHeight is { } currentGlyph and > 0)
             return Math.Min(previousGlyph, currentGlyph) / Math.Max(previousGlyph, currentGlyph);
 
-        return Math.Min(previous.Bounds.Height, current.Bounds.Height) /
-               Math.Max(previous.Bounds.Height, current.Bounds.Height);
+        return Math.Min(previous.LayoutBounds.Height, current.LayoutBounds.Height) /
+               Math.Max(previous.LayoutBounds.Height, current.LayoutBounds.Height);
     }
 
     private static (bool Joined, string Rule) SentenceContinuationEvidence(

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -134,7 +134,8 @@ internal static class OcrTextBlockGrouper
             text,
             new Rect(left, top, right - left, bottom - top),
             RenderGlyphHeight: CombineGlyphHeight(previous.RenderGlyphHeight, current.RenderGlyphHeight),
-            Confidence: CombineConfidence([previous, current]));
+            Confidence: CombineConfidence([previous, current]),
+            LayoutScript: LayoutScriptDetection.For(text));
     }
 
     private static string JoinInlineText(string left, string right)
@@ -316,7 +317,11 @@ internal static class OcrTextBlockGrouper
             new Rect(x, y, right - x, bottom - y),
             blocks.Select(block => block.Bounds).ToList(),
             groupGlyphHeight,
-            CombineConfidence(blocks));
+            CombineConfidence(blocks),
+            // Re-read rather than folded together: the field's contract is "the script of this
+            // block's own text", and a group whose lines are Latin and CJK is exactly the Mixed
+            // that the joined text reports.
+            LayoutScriptDetection.For(text));
     }
 
     /// <summary>

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -1112,7 +1112,6 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         foreach (var block in blocks)
         {
             var isCjk = UsesCjkLayoutForText(block.Text);
-
             normalized.Add(NormalizeBlock(block, isCjk, AutomaticGlyphHeightFromPitch));
         }
 

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -1149,13 +1149,58 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     internal static List<OcrTextBlock> NormalizeBlocks(List<OcrTextBlock> blocks, bool isCjk)
         => blocks.Select(block => NormalizeBlock(block, isCjk)).ToList();
 
+    /// <summary>
+    /// Glyph body height estimated from a detection box: 0.82 of it, clamped against the average
+    /// glyph pitch on wide lines where unclip leaves the box vertically loose.
+    /// </summary>
+    /// <remarks>
+    /// ONNX/unclip can return vertically loose boxes on wide single lines. The average glyph pitch
+    /// is a better proxy for the real line height than an over-tall detection rectangle.
+    /// </remarks>
+    private static double EstimateGlyphHeight(System.Windows.Rect box, int glyphCount, double glyphHeightFromPitch)
+    {
+        const double verticalScale = 0.82;
+
+        var glyphHeight = box.Height * verticalScale;
+
+        if (glyphCount >= ShortTextGlyphHeight.PitchCorrectedFromGlyphs &&
+            box.Width > box.Height * 2)
+        {
+            var estimatedGlyphPitch = box.Width / glyphCount;
+            glyphHeight = Math.Min(glyphHeight, estimatedGlyphPitch * glyphHeightFromPitch);
+        }
+
+        return Math.Max(1, glyphHeight);
+    }
+
+    /// <summary>
+    /// The same estimate keyed on the block's own script rather than on the language the user
+    /// picked, so it reads the same under 自動 as under 日文.
+    /// </summary>
+    /// <remarks>
+    /// Mixed and Unknown get nothing: there is no single glyph body to estimate, and grouping
+    /// falls back to the raw detection box for them. Latin carries the short-line correction the
+    /// overlay's own height carries, because too few glyphs for the pitch clamp leaves 0.82 of the
+    /// box standing, which is 1.7x the truth. CJK does not, matching how its box is normalised.
+    /// </remarks>
+    internal static double? LayoutGlyphHeightFor(OcrLayoutScript script, System.Windows.Rect box, string text)
+    {
+        if (script is not (OcrLayoutScript.Latin or OcrLayoutScript.Cjk))
+            return null;
+
+        var glyphCount = text.Count(c => !char.IsWhiteSpace(c));
+        var glyphHeight = EstimateGlyphHeight(box, glyphCount, script == OcrLayoutScript.Cjk ? 1.18 : 1.3);
+
+        return script == OcrLayoutScript.Cjk
+            ? glyphHeight
+            : ShortTextGlyphHeight.For(glyphHeight, box.Height, glyphCount);
+    }
+
     private static OcrTextBlock NormalizeBlock(
         OcrTextBlock block,
         bool isCjk,
         double? glyphHeightFromPitchOverride = null)
     {
-        const double verticalScale = 0.82;
-
         // Convert the average source-glyph pitch (width / glyphCount) into the line height that
         // drives the overlay font size, clamping the unclipped (loose) detection box so text is
         // not rendered far too large. The multiplier is keyed on the *rendered* script, which is
@@ -1168,28 +1213,17 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // Per block, from its own text, and the box exactly as the detector drew it. Both callers
         // reach here, and this runs before the CJK branch below rewrites Bounds, so it is the one
         // place the layout side gets told what it is looking at.
+        var layoutScript = LayoutScriptDetection.For(block.Text);
         block = block with
         {
-            LayoutScript = LayoutScriptDetection.For(block.Text),
+            LayoutScript = layoutScript,
             LayoutBounds = block.Bounds,
+            LayoutGlyphHeight = LayoutGlyphHeightFor(layoutScript, block.Bounds, block.Text),
         };
 
         var bounds = block.Bounds;
-        var glyphHeight = bounds.Height * verticalScale;
         var glyphCount = block.Text.Count(c => !char.IsWhiteSpace(c));
-
-        // ONNX/unclip can return vertically loose boxes on wide single lines.
-        // The average glyph pitch is a better proxy for the real line height than
-        // an over-tall detection rectangle.
-        if (glyphCount >= ShortTextGlyphHeight.PitchCorrectedFromGlyphs &&
-            bounds.Width > bounds.Height * 2)
-        {
-            var estimatedGlyphPitch = bounds.Width / glyphCount;
-            var maxExpectedHeight = estimatedGlyphPitch * glyphHeightFromPitch;
-            glyphHeight = Math.Min(glyphHeight, maxExpectedHeight);
-        }
-
-        glyphHeight = Math.Max(1, glyphHeight);
+        var glyphHeight = EstimateGlyphHeight(bounds, glyphCount, glyphHeightFromPitch);
 
         if (isCjk)
         {

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -216,7 +216,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         Bitmap bitmap, string sourceLanguage, int? maxDetectSize = null)
     {
         var normalizedLanguage = OcrLanguageRouter.Normalize(sourceLanguage);
-        var isCjk = OcrLanguageRouter.UsesCjkOnnx(normalizedLanguage);
+        var useCjkRenderMetrics = OcrLanguageRouter.UsesCjkOnnx(normalizedLanguage);
         var usesAutomaticLayout = OcrLanguageRouter.UsesAutomaticLayout(normalizedLanguage);
 
         // Select the runtime and register an in-use reference atomically under _sync, so the
@@ -238,7 +238,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             using var skBitmap = ConvertToSkBitmap(bitmap);
             using var detectorInput = AlignForDetector(skBitmap, options.Padding);
             var result = runtime.Engine.Detect(detectorInput, options);
-            var blocks = ApplyBlockFilters(result.TextBlocks, normalizedLanguage, isCjk, usesAutomaticLayout);
+            var blocks = ApplyBlockFilters(result.TextBlocks, normalizedLanguage, useCjkRenderMetrics, usesAutomaticLayout);
 
             // Counts and lengths only — enough to tell "found nothing" from "found the wrong thing"
             // without the recognised text itself, which LogBlocks keeps at Debug.
@@ -909,7 +909,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     // One method rather than a chain repeated at each entry point: the order matters (see the
     // comments inside), and a second copy of it is the kind of thing that drifts a filter at a time.
     private static List<OcrTextBlock> ApplyBlockFilters(
-        TextBlock[] textBlocks, string normalizedLanguage, bool isCjk, bool usesAutomaticLayout)
+        TextBlock[] textBlocks, string normalizedLanguage, bool useCjkRenderMetrics, bool usesAutomaticLayout)
     {
         var converted = ConvertBlocks(textBlocks);
 
@@ -927,7 +927,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // out, so a stray box is never joined to the line beside it.
         var normalized = usesAutomaticLayout
             ? NormalizeAutomaticBlocks(converted)
-            : NormalizeBlocks(converted, isCjk);
+            : NormalizeBlocks(converted, useCjkRenderMetrics);
 
         return RemoveMisshapenBlocks(normalized, normalizedLanguage);
     }
@@ -1097,12 +1097,17 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     }
 
     /// <summary>
-    /// Chooses the layout path from one recognized block when the source language is automatic.
-    /// Kana is unambiguously Japanese. Two Han characters are enough to identify real CJK text,
-    /// while a lone Han character stays on the Latin path so the existing icon-noise filter can
-    /// remove the common one-character misreads found in English interfaces.
+    /// Which of the two render normalisations one recognised block gets when the source language
+    /// is automatic. Kana is unambiguously Japanese, and two Han characters identify real CJK text.
     /// </summary>
-    internal static bool UsesCjkLayoutForText(string text) =>
+    /// <remarks>
+    /// Not the block's script — that is <see cref="LayoutScriptDetection.For"/>, which counts a
+    /// single Han character and which grouping reads. This is a choice between two ways of sizing
+    /// the overlay's font, and the two answers deliberately differ: the layout side wants to know
+    /// what is written, the render side wants a font scale that does not jump between frames when
+    /// a borderline reading changes. Nothing here reaches grouping.
+    /// </remarks>
+    internal static bool UsesCjkRenderMetricsForText(string text) =>
         text.Any(LayoutScriptDetection.IsKana) || text.Count(LayoutScriptDetection.IsHanIdeograph) >= 2;
 
     internal static List<OcrTextBlock> NormalizeAutomaticBlocks(List<OcrTextBlock> blocks)
@@ -1111,15 +1116,15 @@ internal sealed class OnnxOcrEngine : IOcrEngine
 
         foreach (var block in blocks)
         {
-            var isCjk = UsesCjkLayoutForText(block.Text);
-            normalized.Add(NormalizeBlock(block, isCjk, AutomaticGlyphHeightFromPitch));
+            var useCjkRenderMetrics = UsesCjkRenderMetricsForText(block.Text);
+            normalized.Add(NormalizeBlock(block, useCjkRenderMetrics, AutomaticGlyphHeightFromPitch));
         }
 
         return normalized;
     }
 
-    internal static List<OcrTextBlock> NormalizeBlocks(List<OcrTextBlock> blocks, bool isCjk)
-        => blocks.Select(block => NormalizeBlock(block, isCjk)).ToList();
+    internal static List<OcrTextBlock> NormalizeBlocks(List<OcrTextBlock> blocks, bool useCjkRenderMetrics)
+        => blocks.Select(block => NormalizeBlock(block, useCjkRenderMetrics)).ToList();
 
     /// <summary>
     /// Glyph body height estimated from a detection box: 0.82 of it, clamped against the average
@@ -1168,9 +1173,16 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             : ShortTextGlyphHeight.For(glyphHeight, box.Height, glyphCount);
     }
 
+    /// <param name="useCjkRenderMetrics">
+    /// Which overlay-font normalisation to apply. It follows the source language the user picked
+    /// (or, under 自動, one block's own text), and it is render-only: it decides the pitch
+    /// multiplier and whether Bounds is pulled in onto the glyphs. Everything grouping reads is
+    /// filled in below from the block's own text and the detector's own box, so this cannot reach
+    /// it — which is the whole of why the metrics were split.
+    /// </param>
     private static OcrTextBlock NormalizeBlock(
         OcrTextBlock block,
-        bool isCjk,
+        bool useCjkRenderMetrics,
         double? glyphHeightFromPitchOverride = null)
     {
         // Convert the average source-glyph pitch (width / glyphCount) into the line height that
@@ -1180,11 +1192,12 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // not a Latin one. Measured EN-vs-KO box heights on the same screenshot showed the old
         // Latin value (2.0) rendered English ~1.7x larger than the Korean (CJK) path; 1.3 brings
         // it in line, leaving English just slightly larger than CJK.
-        var glyphHeightFromPitch = glyphHeightFromPitchOverride ?? (isCjk ? 1.18 : 1.3);
+        var glyphHeightFromPitch = glyphHeightFromPitchOverride ?? (useCjkRenderMetrics ? 1.18 : 1.3);
 
-        // Per block, from its own text, and the box exactly as the detector drew it. Both callers
-        // reach here, and this runs before the CJK branch below rewrites Bounds, so it is the one
-        // place the layout side gets told what it is looking at.
+        // Per block, from its own text, and the box exactly as the detector drew it — neither of
+        // them touched by useCjkRenderMetrics above. Both callers reach here, and this runs before
+        // the CJK branch below rewrites Bounds, so it is the one place the layout side is told what
+        // it is looking at.
         var layoutScript = LayoutScriptDetection.For(block.Text);
         block = block with
         {
@@ -1197,7 +1210,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         var glyphCount = block.Text.Count(c => !char.IsWhiteSpace(c));
         var glyphHeight = EstimateGlyphHeight(bounds, glyphCount, glyphHeightFromPitch);
 
-        if (isCjk)
+        if (useCjkRenderMetrics)
         {
             // CJK glyphs ≈ the detection box height, so shrinking + recentering the box
             // drives both the overlay font and its background coverage correctly.

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -908,7 +908,15 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     // Everything between the library handing back its raw blocks and the caller getting usable ones.
     // One method rather than a chain repeated at each entry point: the order matters (see the
     // comments inside), and a second copy of it is the kind of thing that drifts a filter at a time.
-    private static List<OcrTextBlock> ApplyBlockFilters(
+    /// <remarks>
+    /// Internal rather than private so the source-language contract can be tested on the real chain
+    /// instead of one rebuilt in the test. Two rules in here have already drifted into being
+    /// language-dependent by accident — the lone-ideograph cleanup openly, and BoxShapeNoise by
+    /// reading a Bounds that normalisation had rewritten — and neither was caught by the tests that
+    /// covered those rules one at a time. A test that calls this method inherits whatever is added
+    /// to the chain later; one that lists the stages does not.
+    /// </remarks>
+    internal static List<OcrTextBlock> ApplyBlockFilters(
         TextBlock[] textBlocks, string normalizedLanguage, bool useCjkRenderMetrics, bool usesAutomaticLayout)
     {
         var converted = ConvertBlocks(textBlocks);

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -277,8 +277,8 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             // labels, ratings), which a Latin-only model dropped or garbled; this reads Latin AND
             // those CJK glyphs in one pass. The text is still Latin, so source-language routing
             // (UsesCjkOnnx) keeps EN on the Latin layout path. Lone-ideograph icon misreads that
-            // come with reading both scripts at once are no longer stripped — see
-            // <see cref="StripLoneIdeographs"/>.
+            // come with reading both scripts at once are stripped only where nothing CJK is left
+            // behind — see <see cref="StripLoneIdeographs"/>.
             //
             // Korean stays on its own model above because v6 carries no Hangul at all — measured
             // on its dictionary, 0 of 18,708 characters — so the one model cannot cover KO.
@@ -917,11 +917,14 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // it, and it costs the whole line its translation rather than just one character.
         converted = FoldBlockDiacritics(converted);
 
-        // The lone-ideograph icon filter used to run here, on Latin pages only. It is off — see
-        // StripLoneIdeographs, which is kept for whatever replaces it — because a cleanup that
-        // deletes text on some source languages and not others is the one thing that cannot be
-        // reconciled with reading the same picture the same way whatever the user picked.
-        //
+        // Every language, and that is the change that let this run at all. It used to be a Latin-
+        // pages-only rule, which made the recognised text depend on the source language picked;
+        // narrowed to "only when nothing CJK is left" it is safe to apply to all four alike, so
+        // 田Projects reads as Projects under 自動 and under 日文 and under 中文 identically. Before
+        // normalisation, so the script and glyph height a block is measured with come from the
+        // text that survives. See StripLoneIdeographs for what it will not touch.
+        converted = StripIconIdeographs(converted);
+
         // After normalisation, because that is where a CJK box is pulled in onto its glyphs and
         // the shape being judged becomes the real one. Before grouping, which happens further
         // out, so a stray box is never joined to the line beside it.
@@ -971,9 +974,9 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// Drops boxes that cannot be holding the text read out of them — see <see cref="BoxShapeNoise"/>.
     /// </summary>
     /// <remarks>
-    /// Applies to every language, which the lone-ideograph rule that used to sit beside it did not.
-    /// A Japanese or Korean capture had no noise filter at all before this, and the lone □ that a
-    /// detector returns for a strip of interface is not a script-specific problem.
+    /// Applies to every language, as the lone-ideograph rule beside it now does too. A Japanese or
+    /// Korean capture had no noise filter at all before this, and the lone □ that a detector
+    /// returns for a strip of interface is not a script-specific problem.
     /// </remarks>
     internal static List<OcrTextBlock> RemoveMisshapenBlocks(List<OcrTextBlock> blocks, string language)
     {
@@ -996,6 +999,41 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         }
 
         return kept ?? blocks;
+    }
+
+    /// <summary>
+    /// Rewrites the text of blocks that begin or end with an icon's ideograph — see
+    /// <see cref="StripLoneIdeographs"/>. Never drops a block.
+    /// </summary>
+    /// <remarks>
+    /// The rule it used to have could empty a block, and the caller then removed it. It cannot any
+    /// more: a cut needs a Latin letter beside the ideograph to happen at all, so at least that
+    /// letter survives. Nothing here decides whether a block exists, which is one less way for the
+    /// same picture to come back with different blocks.
+    /// </remarks>
+    internal static List<OcrTextBlock> StripIconIdeographs(List<OcrTextBlock> blocks)
+    {
+        List<OcrTextBlock>? cleaned = null;
+
+        for (var index = 0; index < blocks.Count; index++)
+        {
+            var text = StripLoneIdeographs(blocks[index].Text);
+            if (text == blocks[index].Text)
+            {
+                cleaned?.Add(blocks[index]);
+                continue;
+            }
+
+            cleaned ??= [.. blocks.Take(index)];
+            cleaned.Add(blocks[index] with { Text = text });
+
+            if (Log.IsDebugEnabled)
+                Log.Debug(
+                    "ONNX OCR stripped an icon ideograph \"{Before}\" -> \"{After}\"",
+                    blocks[index].Text, text);
+        }
+
+        return cleaned ?? blocks;
     }
 
     private static List<OcrTextBlock> FoldBlockDiacritics(List<OcrTextBlock> blocks)
@@ -1070,30 +1108,54 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         or >= 'Ḁ' and <= 'ỿ';     // Latin Extended Additional
 
     // Strips a single isolated Han ideograph glued to the start or end of a Latin word, which is
-    // what an icon misread on a Latin page looks like. The letter-adjacency guard preserves date
-    // glyphs like the 年/月/日 in "2026年5月8日" (those sit next to digits), and multi-ideograph runs
-    // (真實中文 such as 翻譯這個網頁 / 免費) are never single, so are kept.
+    // what an icon misread looks like. The letter-adjacency guard preserves date glyphs like the
+    // 年/月/日 in "2026年5月8日" (those sit next to digits), and multi-ideograph runs (真實中文 such
+    // as 翻譯這個網頁 / 免費) are never single, so are kept.
     //
     // A block that is nothing BUT one ideograph is deliberately not touched. It used to be dropped
     // outright, on the reasoning that a lone ideograph on an English page is an icon — and that is
     // sometimes true, but 攻 防 技 火 水 光 闇 標準 are how a Chinese or Japanese interface labels
     // things, and a screenshot is not required to be in one language just because the user named
-    // one. The old rule deleted them under 英文 and under 自動 alike, silently and with nothing in
-    // the log. Keeping a piece of OCR rubbish costs the reader one wrong word; deleting a real
-    // label costs them the one thing they pointed the tool at.
+    // one. Keeping a piece of OCR rubbish costs the reader one wrong word; deleting a real label
+    // costs them the one thing they pointed the tool at.
+    //
+    // The remainder gate is what makes this safe enough to run on every source language, which is
+    // the shape it has to have: a cleanup that rewrites text on some source languages and not
+    // others cannot be reconciled with reading the same picture the same way whatever the user
+    // picked. Strip only when what is left carries no CJK at all — 本Wikiについて keeps its 本
+    // because the rest of it is Japanese, and a line that reads as CJK or Mixed after the cut is
+    // one this rule has no business judging.
+    //
+    // Two known gaps, neither closed by the narrowing:
+    //
+    //   文A日本語 — the remainder A日本語 is Mixed, so the 文 an icon was read as stays. That is the
+    //   price of the gate and it is the right way round: a kept rubbish character is visible to the
+    //   reader, a deleted real one is not.
+    //
+    //   閣Lv100 50 — the remainder is pure Latin so this DOES strip, and on the picture that came
+    //   from it is a real 闇 misread as 閣, not an icon. Narrowing does not solve wrong deletion;
+    //   only a heuristic that looks at the box geometry or the recognition confidence can tell an
+    //   icon's ideograph from a text one, and that is still deferred. Do not read this rule as
+    //   having fixed that.
     internal static string StripLoneIdeographs(string text)
     {
         text = text.Trim();
         if (text.Length == 0)
             return text;
 
-        if (text.Length >= 2 && LayoutScriptDetection.IsHanIdeograph(text[0]) && !LayoutScriptDetection.IsHanIdeograph(text[1]) && char.IsAsciiLetter(text[1]))
-            text = text[1..].TrimStart();
+        var stripped = text;
 
-        if (text.Length >= 2 && LayoutScriptDetection.IsHanIdeograph(text[^1]) && !LayoutScriptDetection.IsHanIdeograph(text[^2]) && char.IsAsciiLetter(text[^2]))
-            text = text[..^1].TrimEnd();
+        if (stripped.Length >= 2 && LayoutScriptDetection.IsHanIdeograph(stripped[0]) && !LayoutScriptDetection.IsHanIdeograph(stripped[1]) && char.IsAsciiLetter(stripped[1]))
+            stripped = stripped[1..].TrimStart();
 
-        return text;
+        if (stripped.Length >= 2 && LayoutScriptDetection.IsHanIdeograph(stripped[^1]) && !LayoutScriptDetection.IsHanIdeograph(stripped[^2]) && char.IsAsciiLetter(stripped[^2]))
+            stripped = stripped[..^1].TrimEnd();
+
+        // Same reading of "CJK" the grouping side uses, so the two cannot drift apart on what
+        // counts as real text. When in doubt, keep: this returns the original, not the cut.
+        return LayoutScriptDetection.For(stripped) is OcrLayoutScript.Cjk or OcrLayoutScript.Mixed
+            ? text
+            : stripped;
     }
 
     /// <summary>

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -974,7 +974,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// about Latin pages. A Japanese or Korean capture had no noise filter at all before this, and
     /// the lone □ that a detector returns for a strip of interface is not a script-specific problem.
     /// </remarks>
-    private static List<OcrTextBlock> RemoveMisshapenBlocks(List<OcrTextBlock> blocks, string language)
+    internal static List<OcrTextBlock> RemoveMisshapenBlocks(List<OcrTextBlock> blocks, string language)
     {
         List<OcrTextBlock>? kept = null;
 

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -276,8 +276,9 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             // Latin-script ones. English UI captures very often contain embedded Chinese (chrome,
             // labels, ratings), which a Latin-only model dropped or garbled; this reads Latin AND
             // those CJK glyphs in one pass. The text is still Latin, so source-language routing
-            // (UsesCjkOnnx) keeps EN on the Latin layout path. Lone-ideograph icon misreads are
-            // stripped by RemoveIconIdeographNoise.
+            // (UsesCjkOnnx) keeps EN on the Latin layout path. Lone-ideograph icon misreads that
+            // come with reading both scripts at once are no longer stripped — see
+            // <see cref="StripLoneIdeographs"/>.
             //
             // Korean stays on its own model above because v6 carries no Hangul at all — measured
             // on its dictionary, 0 of 18,708 characters — so the one model cannot cover KO.
@@ -916,11 +917,11 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // it, and it costs the whole line its translation rather than just one character.
         converted = FoldBlockDiacritics(converted);
 
-        // On a non-CJK (Latin) page the shared general model occasionally misreads icons
-        // as a lone Han ideograph; strip that noise without touching real embedded Chinese.
-        if (!isCjk && !usesAutomaticLayout)
-            converted = RemoveIconIdeographNoise(converted);
-
+        // The lone-ideograph icon filter used to run here, on Latin pages only. It is off — see
+        // StripLoneIdeographs, which is kept for whatever replaces it — because a cleanup that
+        // deletes text on some source languages and not others is the one thing that cannot be
+        // reconciled with reading the same picture the same way whatever the user picked.
+        //
         // After normalisation, because that is where a CJK box is pulled in onto its glyphs and
         // the shape being judged becomes the real one. Before grouping, which happens further
         // out, so a stray box is never joined to the line beside it.
@@ -970,9 +971,9 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// Drops boxes that cannot be holding the text read out of them — see <see cref="BoxShapeNoise"/>.
     /// </summary>
     /// <remarks>
-    /// Applies to every language, unlike <see cref="RemoveIconIdeographNoise"/>, which is a rule
-    /// about Latin pages. A Japanese or Korean capture had no noise filter at all before this, and
-    /// the lone □ that a detector returns for a strip of interface is not a script-specific problem.
+    /// Applies to every language, which the lone-ideograph rule that used to sit beside it did not.
+    /// A Japanese or Korean capture had no noise filter at all before this, and the lone □ that a
+    /// detector returns for a strip of interface is not a script-specific problem.
     /// </remarks>
     internal static List<OcrTextBlock> RemoveMisshapenBlocks(List<OcrTextBlock> blocks, string language)
     {
@@ -995,23 +996,6 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         }
 
         return kept ?? blocks;
-    }
-
-    // Removes lone-Han-ideograph icon misreads from a Latin page's blocks. English never contains
-    // a Han ideograph and real embedded Chinese labels are runs of >= 2 ideographs, so this leaves
-    // genuine text untouched while dropping graphic/icon noise the general model reads as e.g. 白.
-    private static List<OcrTextBlock> RemoveIconIdeographNoise(List<OcrTextBlock> blocks)
-    {
-        var cleaned = new List<OcrTextBlock>(blocks.Count);
-        foreach (var block in blocks)
-        {
-            var text = StripLoneIdeographs(block.Text);
-            if (text.Length == 0)
-                continue; // nothing but the stripped ideograph and whitespace was there
-            cleaned.Add(text == block.Text ? block : block with { Text = text });
-        }
-
-        return cleaned;
     }
 
     private static List<OcrTextBlock> FoldBlockDiacritics(List<OcrTextBlock> blocks)
@@ -1128,19 +1112,8 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         foreach (var block in blocks)
         {
             var isCjk = UsesCjkLayoutForText(block.Text);
-            var candidate = block;
 
-            if (!isCjk)
-            {
-                var cleanedText = StripLoneIdeographs(block.Text);
-                if (cleanedText.Length == 0)
-                    continue;
-
-                if (cleanedText != block.Text)
-                    candidate = block with { Text = cleanedText };
-            }
-
-            normalized.Add(NormalizeBlock(candidate, isCjk, AutomaticGlyphHeightFromPitch));
+            normalized.Add(NormalizeBlock(block, isCjk, AutomaticGlyphHeightFromPitch));
         }
 
         return normalized;

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -1103,23 +1103,14 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         if (text.Length == 0)
             return text;
 
-        if (text.Length >= 2 && IsHanIdeograph(text[0]) && !IsHanIdeograph(text[1]) && char.IsAsciiLetter(text[1]))
+        if (text.Length >= 2 && LayoutScriptDetection.IsHanIdeograph(text[0]) && !LayoutScriptDetection.IsHanIdeograph(text[1]) && char.IsAsciiLetter(text[1]))
             text = text[1..].TrimStart();
 
-        if (text.Length >= 2 && IsHanIdeograph(text[^1]) && !IsHanIdeograph(text[^2]) && char.IsAsciiLetter(text[^2]))
+        if (text.Length >= 2 && LayoutScriptDetection.IsHanIdeograph(text[^1]) && !LayoutScriptDetection.IsHanIdeograph(text[^2]) && char.IsAsciiLetter(text[^2]))
             text = text[..^1].TrimEnd();
 
         return text;
     }
-
-    private static bool IsHanIdeograph(char c) =>
-        c is >= '一' and <= '鿿' || // CJK Unified Ideographs
-        c is >= '㐀' and <= '䶿' || // Extension A
-        c is >= '豈' and <= '﫿';   // Compatibility Ideographs
-
-    private static bool IsKana(char c) =>
-        c is >= 'ぁ' and <= 'ヿ' || // Hiragana + Katakana
-        c is >= 'ㇰ' and <= 'ㇿ';   // Katakana Phonetic Extensions
 
     /// <summary>
     /// Chooses the layout path from one recognized block when the source language is automatic.
@@ -1128,7 +1119,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// remove the common one-character misreads found in English interfaces.
     /// </summary>
     internal static bool UsesCjkLayoutForText(string text) =>
-        text.Any(IsKana) || text.Count(IsHanIdeograph) >= 2;
+        text.Any(LayoutScriptDetection.IsKana) || text.Count(LayoutScriptDetection.IsHanIdeograph) >= 2;
 
     internal static List<OcrTextBlock> NormalizeAutomaticBlocks(List<OcrTextBlock> blocks)
     {
@@ -1155,7 +1146,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         return normalized;
     }
 
-    private static List<OcrTextBlock> NormalizeBlocks(List<OcrTextBlock> blocks, bool isCjk)
+    internal static List<OcrTextBlock> NormalizeBlocks(List<OcrTextBlock> blocks, bool isCjk)
         => blocks.Select(block => NormalizeBlock(block, isCjk)).ToList();
 
     private static OcrTextBlock NormalizeBlock(
@@ -1173,6 +1164,10 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // Latin value (2.0) rendered English ~1.7x larger than the Korean (CJK) path; 1.3 brings
         // it in line, leaving English just slightly larger than CJK.
         var glyphHeightFromPitch = glyphHeightFromPitchOverride ?? (isCjk ? 1.18 : 1.3);
+
+        // Per block, from its own text. Both callers reach here, so this is the single place the
+        // layout side is told what script it is looking at.
+        block = block with { LayoutScript = LayoutScriptDetection.For(block.Text) };
 
         var bounds = block.Bounds;
         var glyphHeight = bounds.Height * verticalScale;

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -1003,13 +1003,25 @@ internal sealed class OnnxOcrEngine : IOcrEngine
 
     /// <summary>
     /// Rewrites the text of blocks that begin or end with an icon's ideograph — see
-    /// <see cref="StripLoneIdeographs"/>. Never drops a block.
+    /// <see cref="StripLoneIdeographs"/>. Returns as many blocks as it was given.
     /// </summary>
     /// <remarks>
-    /// The rule it used to have could empty a block, and the caller then removed it. It cannot any
-    /// more: a cut needs a Latin letter beside the ideograph to happen at all, so at least that
-    /// letter survives. Nothing here decides whether a block exists, which is one less way for the
-    /// same picture to come back with different blocks.
+    /// The rule it used to have could empty a block, and the caller then removed it. That cannot
+    /// happen here: a cut needs a Latin letter beside the ideograph to happen at all, so at least
+    /// that letter survives and every block handed in is handed back.
+    ///
+    /// IT CAN STILL COST A BLOCK ITS LIFE FURTHER DOWN, which is the part worth knowing. This runs
+    /// before normalisation and <see cref="RemoveMisshapenBlocks"/> runs after it, and that filter
+    /// judges a box against how many characters are in it — so taking one character off can push a
+    /// box over <see cref="BoxShapeNoise"/>'s ratio and have it dropped there. Measured on the
+    /// screenshot corpus, exactly one capture of 256 loses a block this way: a Korean panel's "早E"
+    /// becomes "E", too little text for a box that wide, and goes. That reading is icon noise and
+    /// the other skill slots on the same screen read "E V+", so the outcome is right — but it is
+    /// the shape filter deleting it, not this, and a redesign of the icon heuristic has to account
+    /// for the coupling rather than assume text cleanup is free.
+    ///
+    /// None of it reintroduces a source-language dependency: neither this rule nor the shape filter
+    /// asks what the user picked, so the same picture still loses the same block on all four.
     /// </remarks>
     internal static List<OcrTextBlock> StripIconIdeographs(List<OcrTextBlock> blocks)
     {

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -1165,9 +1165,14 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // it in line, leaving English just slightly larger than CJK.
         var glyphHeightFromPitch = glyphHeightFromPitchOverride ?? (isCjk ? 1.18 : 1.3);
 
-        // Per block, from its own text. Both callers reach here, so this is the single place the
-        // layout side is told what script it is looking at.
-        block = block with { LayoutScript = LayoutScriptDetection.For(block.Text) };
+        // Per block, from its own text, and the box exactly as the detector drew it. Both callers
+        // reach here, and this runs before the CJK branch below rewrites Bounds, so it is the one
+        // place the layout side gets told what it is looking at.
+        block = block with
+        {
+            LayoutScript = LayoutScriptDetection.For(block.Text),
+            LayoutBounds = block.Bounds,
+        };
 
         var bounds = block.Bounds;
         var glyphHeight = bounds.Height * verticalScale;

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -1208,7 +1208,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         // enormously. See ShortTextGlyphHeight for the measurements.
         return block with
         {
-            SourceGlyphHeight = ShortTextGlyphHeight.For(glyphHeight, bounds.Height, glyphCount)
+            RenderGlyphHeight = ShortTextGlyphHeight.For(glyphHeight, bounds.Height, glyphCount)
         };
     }
 

--- a/src/OverTranslate/Services/Ocr/SameLineGapThreshold.cs
+++ b/src/OverTranslate/Services/Ocr/SameLineGapThreshold.cs
@@ -1,0 +1,141 @@
+namespace OverTranslate.Services.Ocr;
+
+/// <summary>
+/// Where the line falls between a space that separates words and a space that separates things,
+/// for one capture, measured in line heights.
+/// </summary>
+/// <remarks>
+/// <para>The distance is not a property of the application — it is a property of the picture. A
+/// documentation site sets its navigation 0.6 of a line apart and its prose 0.3; a dense panel may
+/// run 0.15 and 0.35. One fixed number cannot be right for both, and being wrong in the merging
+/// direction is expensive: eleven menu entries glued into one string change what the translator is
+/// asked, while a sentence left in two halves is only what the previous version already did.</para>
+///
+/// <para>So the gaps a capture actually contains are measured, split in two, and the line drawn
+/// between the halves. When they do not fall into two convincing halves — too few of them, one side
+/// nearly empty, the two sides touching, or an answer outside the range any real spacing occupies —
+/// this returns <see cref="Fallback"/> and says why. That number is the measured one from the
+/// screenshot corpus and remains correct whenever the picture cannot say better.</para>
+/// </remarks>
+internal readonly record struct SameLineGapThreshold(double Value, bool Adaptive, string Reason)
+{
+    /// <summary>
+    /// The threshold used whenever a capture cannot supply a more convincing one.
+    /// </summary>
+    /// <remarks>
+    /// Measured across the screenshot corpus: word gaps inside one real line run from -0.18 to 0.38
+    /// (the nine in "Send this session to the background and free the terminal", and every same-row
+    /// pair the tests were built from), while a documentation site's eleven navigation entries run
+    /// 0.54 to 0.70 and two cards side by side 1.11. Nothing at all lies between 0.38 and 0.54, so
+    /// this sits in the middle of that empty band rather than against either edge.
+    /// </remarks>
+    public const double Fallback = 0.45;
+
+    /// <summary>Gaps outside this are not spacing decisions and are left out of the measurement.</summary>
+    /// <remarks>
+    /// Below the floor the boxes overlap further than the detector's expansion explains; above the
+    /// ceiling is the distance across a layout rather than between neighbours, and a handful of
+    /// those would drag the loose half so far out that the midpoint between the two halves lands
+    /// nowhere near any real spacing.
+    /// </remarks>
+    private const double SampleFloor = -1.0;
+
+    /// <inheritdoc cref="SampleFloor"/>
+    private const double SampleCeiling = 2.0;
+
+    /// <summary>How many gaps a capture must show before its own spacing is believed.</summary>
+    private const int MinimumSamples = 6;
+
+    /// <summary>How many gaps each half needs before it counts as a population rather than a stray.</summary>
+    private const int MinimumHalfSize = 2;
+
+    /// <summary>
+    /// How far apart the two halves must sit, in line heights, to be two kinds of space rather than
+    /// one kind unevenly measured.
+    /// </summary>
+    /// <remarks>
+    /// The measured band between word spacing and item spacing is 0.16 wide (0.38 to 0.54). Asking
+    /// for that much again means a capture whose gaps merely spread out — prose alone, or a menu
+    /// alone — cannot produce a split, because the widest run of one kind of space seen so far does
+    /// not contain a hole this big.
+    /// </remarks>
+    private const double MinimumSeparation = 0.15;
+
+    /// <summary>The range a believable answer falls in.</summary>
+    /// <remarks>
+    /// Bounded on both sides rather than clamped into: an estimate outside this is not a slightly
+    /// wrong threshold to be pulled back, it is evidence that the two halves were not the two kinds
+    /// of space this is looking for, and the fallback is the better answer.
+    /// </remarks>
+    private const double MinimumThreshold = 0.25;
+
+    /// <inheritdoc cref="MinimumThreshold"/>
+    private const double MaximumThreshold = 0.55;
+
+    public static SameLineGapThreshold Estimate(IReadOnlyList<double> gaps)
+    {
+        var samples = gaps
+            .Where(gap => gap is >= SampleFloor and <= SampleCeiling)
+            .OrderBy(gap => gap)
+            .ToList();
+
+        if (samples.Count < MinimumSamples)
+            return FallbackWith("too few gaps");
+
+        var split = BestSplit(samples);
+        if (split < 0)
+            return FallbackWith("no two-sided split");
+
+        var tightest = samples[split - 1];
+        var loosest = samples[split];
+        if (loosest - tightest < MinimumSeparation)
+            return FallbackWith("halves not separated");
+
+        var threshold = (tightest + loosest) / 2;
+        return threshold is < MinimumThreshold or > MaximumThreshold
+            ? FallbackWith("outside the believable range")
+            : new SameLineGapThreshold(threshold, true, "measured on this capture");
+    }
+
+    private static SameLineGapThreshold FallbackWith(string reason) => new(Fallback, false, reason);
+
+    /// <summary>
+    /// Where a sorted list of gaps divides into two groups, or -1 when it cannot be divided.
+    /// </summary>
+    /// <remarks>
+    /// Every place the sorted list could be cut is tried and the one leaving the least spread
+    /// within the two halves wins. In one dimension that is exhaustive rather than iterative, which
+    /// makes it both optimal and the same answer every time — where k-means would hand back
+    /// whatever its starting points led to, and a test would be pinning that instead of the data.
+    /// The list is short enough (the gaps of one screenshot) that trying them all costs nothing.
+    /// </remarks>
+    private static int BestSplit(List<double> sorted)
+    {
+        var best = -1;
+        var bestSpread = double.PositiveInfinity;
+
+        for (var split = MinimumHalfSize; split <= sorted.Count - MinimumHalfSize; split++)
+        {
+            var spread = Spread(sorted, 0, split) + Spread(sorted, split, sorted.Count);
+            if (spread >= bestSpread) continue;
+
+            bestSpread = spread;
+            best = split;
+        }
+
+        return best;
+    }
+
+    /// <summary>Summed squared distance from the mean, over one half.</summary>
+    private static double Spread(List<double> sorted, int from, int to)
+    {
+        double sum = 0;
+        for (var i = from; i < to; i++) sum += sorted[i];
+
+        var mean = sum / (to - from);
+        double spread = 0;
+        for (var i = from; i < to; i++) spread += (sorted[i] - mean) * (sorted[i] - mean);
+
+        return spread;
+    }
+}

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -12,7 +12,7 @@ public record OcrTextBlock(
     // Bounds. For Latin source the detection box is much taller than the rendered CJK font,
     // so Bounds stays full (for background coverage) while this drives only the font size.
     // Null for CJK, where Bounds already matches the glyph height.
-    double? SourceGlyphHeight = null,
+    double? RenderGlyphHeight = null,
     // Mean per-character recognition confidence, 0–1. Reading the same unchanged text twice
     // gives two slightly different answers, and this is what says which to believe; null when
     // the engine reported no scores.
@@ -169,7 +169,7 @@ public class OcrService : IDisposable
             SourceLineBounds = null,
             // After mapping back, a column is tall and narrow. The rotated row height is the
             // original glyph width and is the useful reference for a square vertical cell.
-            SourceGlyphHeight = block.Bounds.Height,
+            RenderGlyphHeight = block.Bounds.Height,
         }).ToList();
 
         return MergeVerticalColumns(columns);

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -109,7 +109,7 @@ public class OcrService : IDisposable
     // of the failure this ordering exists to prevent, so "no noise admitted" is an absence of the
     // test case, not a pass. Left alone deliberately. What would reopen it is a corpus with scenery
     // sitting on a subtitle's own row.
-    private static List<OcrTextBlock> RejectUnconvincingBlocks(List<OcrTextBlock> blocks)
+    internal static List<OcrTextBlock> RejectUnconvincingBlocks(List<OcrTextBlock> blocks)
     {
         List<OcrTextBlock>? kept = null;
 

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -19,7 +19,12 @@ public record OcrTextBlock(
     double? Confidence = null,
     // Writing system of this block's own text, for the grouping geometry to reason about. Never
     // derived from the source language the user picked — that is the whole point of it existing.
-    OcrLayoutScript LayoutScript = OcrLayoutScript.Unknown)
+    OcrLayoutScript LayoutScript = OcrLayoutScript.Unknown,
+    // The detector's own box, before any script-specific normalisation. Bounds is not comparable
+    // across scripts — a CJK one is pulled in onto its glyphs and a Latin one is not, a ratio of
+    // 0.820 that refused every mixed-script pair on size alone. This is what grouping measures
+    // with: one detector, one procedure, whatever the text turns out to be.
+    System.Windows.Rect LayoutBounds = default)
 {
     public IReadOnlyList<System.Windows.Rect> Lines => SourceLineBounds ?? [Bounds];
 }

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -179,9 +179,13 @@ public class OcrService : IDisposable
         var columns = blocks.Select(block => block with
         {
             Bounds = MapVerticalBoundsBack(block.Bounds, bitmap.Width),
+            // The layout box turns with the picture. Without it the second pass below would be
+            // reading a rectangle still in the rotated frame beside one that is not.
+            LayoutBounds = MapVerticalBoundsBack(block.LayoutBounds, bitmap.Width),
             SourceLineBounds = null,
             // After mapping back, a column is tall and narrow. The rotated row height is the
-            // original glyph width and is the useful reference for a square vertical cell.
+            // original glyph width and is the useful reference for a square vertical cell. Only the
+            // render metric: what the columns are grouped on is LayoutBounds, above.
             RenderGlyphHeight = block.Bounds.Height,
         }).ToList();
 
@@ -202,7 +206,7 @@ public class OcrService : IDisposable
     {
         var remaining = columns
             .Where(IsVerticalColumnCandidate)
-            .OrderByDescending(column => column.Bounds.X)
+            .OrderByDescending(column => column.LayoutBounds.X)
             .ToList();
         var merged = new List<OcrTextBlock>();
 
@@ -238,22 +242,26 @@ public class OcrService : IDisposable
         const double maxWidthToHeightRatio = 1.4;
         int characters = column.Text.Count(character => !char.IsWhiteSpace(character));
         return characters <= 1 ||
-               column.Bounds.Width <= column.Bounds.Height * maxWidthToHeightRatio;
+               column.LayoutBounds.Width <= column.LayoutBounds.Height * maxWidthToHeightRatio;
     }
 
     private static bool IsSameVerticalTextGroup(OcrTextBlock a, OcrTextBlock b)
     {
-        double columnWidth = Math.Max(a.Bounds.Width, b.Bounds.Width);
-        if (Math.Abs(a.Bounds.Y - b.Bounds.Y) > columnWidth * 0.6)
+        double columnWidth = Math.Max(a.LayoutBounds.Width, b.LayoutBounds.Width);
+        if (Math.Abs(a.LayoutBounds.Y - b.LayoutBounds.Y) > columnWidth * 0.6)
             return false;
 
-        double gap = Math.Max(a.Bounds.Left, b.Bounds.Left) - Math.Min(a.Bounds.Right, b.Bounds.Right);
+        double gap = Math.Max(a.LayoutBounds.Left, b.LayoutBounds.Left) -
+                     Math.Min(a.LayoutBounds.Right, b.LayoutBounds.Right);
         return gap <= columnWidth * 0.6;
     }
 
     private static OcrTextBlock CombineVerticalColumns(List<OcrTextBlock> group)
     {
-        var ordered = group.OrderByDescending(column => column.Bounds.X).ToList();
+        // Reading order is a layout question, so it is decided on the detector's boxes. Everything
+        // built below — the coverage rectangle, the cell size, the character cells — is what the
+        // overlay draws, and stays on Bounds.
+        var ordered = group.OrderByDescending(column => column.LayoutBounds.X).ToList();
         var bounds = ordered.Select(column => column.Bounds).Aggregate(Rect.Union);
         var widths = ordered.Select(column => column.Bounds.Width).OrderBy(width => width).ToList();
         var glyphSize = widths[widths.Count / 2];
@@ -267,12 +275,38 @@ public class OcrService : IDisposable
             : scored.Sum(column => column.Confidence!.Value * Math.Max(1, column.Text.Length)) /
               scored.Sum(column => Math.Max(1, column.Text.Length));
 
+        var text = string.Concat(ordered.Select(column => column.Text));
+        var layoutScript = LayoutScriptDetection.For(text);
+
         return new OcrTextBlock(
-            string.Concat(ordered.Select(column => column.Text)),
+            text,
             bounds,
             lines,
             glyphSize,
-            confidence);
+            confidence,
+            // From the text as read. A vertical frame is not required to be Japanese — a western
+            // title down the spine of a book is still Latin.
+            layoutScript,
+            ordered.Select(column => column.LayoutBounds).Aggregate(Rect.Union),
+            CombineVerticalGlyphSize(layoutScript, ordered));
+    }
+
+    /// <summary>
+    /// One layout glyph size for a merged column group: the median of the columns', and nothing
+    /// once the joined text is no longer of a single script.
+    /// </summary>
+    private static double? CombineVerticalGlyphSize(OcrLayoutScript script, List<OcrTextBlock> columns)
+    {
+        if (script is not (OcrLayoutScript.Latin or OcrLayoutScript.Cjk))
+            return null;
+
+        var sizes = columns
+            .Where(column => column.LayoutGlyphHeight is > 0)
+            .Select(column => column.LayoutGlyphHeight!.Value)
+            .OrderBy(size => size)
+            .ToList();
+
+        return sizes.Count > 0 ? sizes[sizes.Count / 2] : null;
     }
 
     private static List<Rect> SplitIntoVerticalCharacterCells(Rect column, double glyphSize)

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -24,7 +24,12 @@ public record OcrTextBlock(
     // across scripts — a CJK one is pulled in onto its glyphs and a Latin one is not, a ratio of
     // 0.820 that refused every mixed-script pair on size alone. This is what grouping measures
     // with: one detector, one procedure, whatever the text turns out to be.
-    System.Windows.Rect LayoutBounds = default)
+    System.Windows.Rect LayoutBounds = default,
+    // Estimated glyph body height for LayoutScript, from LayoutBounds. Comparable within one
+    // script only: a Latin box carries ascender and descender room a CJK one does not, and no
+    // constant converts between them — that was measured, and it is a property of the text
+    // rather than of the scripts. Null for Mixed and Unknown, which have no single answer.
+    double? LayoutGlyphHeight = null)
 {
     public IReadOnlyList<System.Windows.Rect> Lines => SourceLineBounds ?? [Bounds];
 }

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -16,7 +16,10 @@ public record OcrTextBlock(
     // Mean per-character recognition confidence, 0–1. Reading the same unchanged text twice
     // gives two slightly different answers, and this is what says which to believe; null when
     // the engine reported no scores.
-    double? Confidence = null)
+    double? Confidence = null,
+    // Writing system of this block's own text, for the grouping geometry to reason about. Never
+    // derived from the source language the user picked — that is the whole point of it existing.
+    OcrLayoutScript LayoutScript = OcrLayoutScript.Unknown)
 {
     public IReadOnlyList<System.Windows.Rect> Lines => SourceLineBounds ?? [Bounds];
 }

--- a/src/OverTranslate/Services/Providers/DeepLProvider.cs
+++ b/src/OverTranslate/Services/Providers/DeepLProvider.cs
@@ -55,7 +55,7 @@ public class DeepLProvider : ITranslationProvider
             // (can happen when inputs are empty/whitespace-only or filtered server-side).
             if (i >= arrayLen)
             {
-                results.Add(new TranslatedBlock(blocks[i].Text, "", blocks[i].Bounds, blocks[i].Lines, blocks[i].SourceGlyphHeight));
+                results.Add(new TranslatedBlock(blocks[i].Text, "", blocks[i].Bounds, blocks[i].Lines, blocks[i].RenderGlyphHeight));
                 continue;
             }
             var t = translations[i];
@@ -66,7 +66,7 @@ public class DeepLProvider : ITranslationProvider
                     langVotes[lang] = langVotes.GetValueOrDefault(lang) + 1;
             }
             var translated = t.GetProperty("text").GetString() ?? "";
-            results.Add(new TranslatedBlock(blocks[i].Text, translated, blocks[i].Bounds, blocks[i].Lines, blocks[i].SourceGlyphHeight));
+            results.Add(new TranslatedBlock(blocks[i].Text, translated, blocks[i].Bounds, blocks[i].Lines, blocks[i].RenderGlyphHeight));
         }
 
         string detectedLang = langVotes.Count > 0

--- a/src/OverTranslate/Services/Providers/GTranslateProvider.cs
+++ b/src/OverTranslate/Services/Providers/GTranslateProvider.cs
@@ -90,7 +90,7 @@ public class GTranslateProvider : ITranslationProvider
             var (translation, detLang) = results[i];
             if (!string.IsNullOrEmpty(detLang))
                 langVotes[detLang] = langVotes.GetValueOrDefault(detLang) + 1;
-            translated.Add(new TranslatedBlock(blocks[i].Text, translation, blocks[i].Bounds, blocks[i].Lines, blocks[i].SourceGlyphHeight));
+            translated.Add(new TranslatedBlock(blocks[i].Text, translation, blocks[i].Bounds, blocks[i].Lines, blocks[i].RenderGlyphHeight));
         }
 
         string detectedLang = langVotes.Count > 0 ? langVotes.MaxBy(kv => kv.Value).Key : "";

--- a/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
+++ b/src/OverTranslate/Services/Providers/OpenAiCompatibleProvider.cs
@@ -142,7 +142,7 @@ public sealed class OpenAiCompatibleProvider : ITranslationProvider
                 translations[i],
                 block.Bounds,
                 block.Lines,
-                block.SourceGlyphHeight));
+                block.RenderGlyphHeight));
         }
 
         var detected = LanguageData.IsAutomaticSource(sourceLang) ? "" : sourceLang.ToUpperInvariant();

--- a/src/OverTranslate/Services/Providers/ResilientProvider.cs
+++ b/src/OverTranslate/Services/Providers/ResilientProvider.cs
@@ -83,7 +83,7 @@ public class ResilientProvider : ITranslationProvider
             if (!string.IsNullOrEmpty(detLang))
                 langVotes[detLang] = langVotes.GetValueOrDefault(detLang) + 1;
             engineVotes[engine] = engineVotes.GetValueOrDefault(engine) + 1;
-            translated.Add(new TranslatedBlock(blocks[i].Text, translation, blocks[i].Bounds, blocks[i].Lines, blocks[i].SourceGlyphHeight));
+            translated.Add(new TranslatedBlock(blocks[i].Text, translation, blocks[i].Bounds, blocks[i].Lines, blocks[i].RenderGlyphHeight));
         }
 
         string primary   = _engines[0].Name;

--- a/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeNaturalBackground.cs
@@ -50,7 +50,7 @@ internal static class RealtimeNaturalBackground
         .. blocks
             .Where(block => !string.IsNullOrWhiteSpace(block.TranslatedText))
             .SelectMany(block => (block.SourceLineBounds is { Count: > 0 } lines ? lines : [block.Bounds])
-                .Select(line => GlyphBounds(line, block.SourceGlyphHeight)))
+                .Select(line => GlyphBounds(line, block.RenderGlyphHeight)))
     ];
 
     /// <summary>The part of a line rectangle its glyphs actually occupy.</summary>

--- a/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
@@ -812,7 +812,7 @@ public sealed class RealtimeTranslationSession
                         : block.Text,
                 block.Bounds,
                 block.SourceLineBounds,
-                block.SourceGlyphHeight))
+                block.RenderGlyphHeight))
             .ToList();
     }
 

--- a/src/OverTranslate/Services/TranslationService.cs
+++ b/src/OverTranslate/Services/TranslationService.cs
@@ -10,7 +10,7 @@ public record TranslatedBlock(
     string TranslatedText,
     System.Windows.Rect Bounds,
     IReadOnlyList<System.Windows.Rect>? SourceLineBounds = null,
-    double? SourceGlyphHeight = null,
+    double? RenderGlyphHeight = null,
     System.Windows.Media.Color BackgroundColor = default,
     System.Windows.Media.Color TextColor = default);
 

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
@@ -845,7 +845,7 @@ public partial class OverlayWindow : Window
     {
         // Latin blocks carry the reduced glyph height separately so the font is not sized from
         // the (much taller) full coverage box. This takes priority over the line-bounds median.
-        if (block.SourceGlyphHeight is { } glyphHeight && glyphHeight > 0)
+        if (block.RenderGlyphHeight is { } glyphHeight && glyphHeight > 0)
             return glyphHeight / _dpiY;
 
         if (block.SourceLineBounds is not { Count: > 0 })

--- a/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
@@ -690,7 +690,7 @@ public partial class RealtimeBlockWindow : Window
         // Latin sources carry the real glyph height separately: their detection box is much taller
         // than the text in it, and sizing the font from the box would render the translation far
         // larger than what it replaces.
-        if (line.SourceGlyphHeight is { } glyphHeight && glyphHeight > 0)
+        if (line.RenderGlyphHeight is { } glyphHeight && glyphHeight > 0)
             return glyphHeight / _dpiY;
 
         if (line.SourceLineBounds is not { Count: > 0 } lineBounds)

--- a/tests/OverTranslate.Tests/BoxShapeNoiseTests.cs
+++ b/tests/OverTranslate.Tests/BoxShapeNoiseTests.cs
@@ -11,8 +11,10 @@ namespace OverTranslate.Tests;
 /// </summary>
 public class BoxShapeNoiseTests
 {
+    // As the engine hands it over: the rule reads LayoutBounds, the box the detector drew, so a
+    // fixture that only sets Bounds is not a block this rule has ever been asked about.
     private static OcrTextBlock Block(string text, double width, double height) =>
-        new(text, new Rect(100, 100, width, height));
+        new OcrTextBlock(text, new Rect(100, 100, width, height)).AsDetected();
 
     [Theory]
     // One character in a box six times wider than tall, which is what a detector returns for a

--- a/tests/OverTranslate.Tests/DetectedBlocks.cs
+++ b/tests/OverTranslate.Tests/DetectedBlocks.cs
@@ -1,0 +1,31 @@
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// Blocks as the engine hands them over, for tests that build them by hand instead of reading an
+/// image.
+/// </summary>
+/// <remarks>
+/// Nothing has run the normalisation that fills LayoutBounds / LayoutScript / LayoutGlyphHeight on
+/// a hand-built block, and the grouper refuses one that arrives without them. Filling them here
+/// with the production functions — rather than teaching the grouper to fall back to Bounds — keeps
+/// the fixtures honest about what the grouper actually receives.
+/// </remarks>
+internal static class DetectedBlocks
+{
+    public static OcrTextBlock AsDetected(this OcrTextBlock block)
+    {
+        var script = LayoutScriptDetection.For(block.Text);
+        return block with
+        {
+            LayoutScript = script,
+            LayoutBounds = block.Bounds,
+            LayoutGlyphHeight = OnnxOcrEngine.LayoutGlyphHeightFor(script, block.Bounds, block.Text),
+        };
+    }
+
+    public static List<OcrTextBlock> AsDetected(this IEnumerable<OcrTextBlock> blocks) =>
+        blocks.Select(block => block.AsDetected()).ToList();
+}

--- a/tests/OverTranslate.Tests/DetectedBlocks.cs
+++ b/tests/OverTranslate.Tests/DetectedBlocks.cs
@@ -17,6 +17,11 @@ internal static class DetectedBlocks
 {
     public static OcrTextBlock AsDetected(this OcrTextBlock block)
     {
+        // A fixture that set its own layout box meant it: those are the cases where the two
+        // rectangles have to disagree for the test to be worth anything.
+        if (block.LayoutBounds.Width > 0 && block.LayoutBounds.Height > 0)
+            return block;
+
         var script = LayoutScriptDetection.For(block.Text);
         return block with
         {

--- a/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
+++ b/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
@@ -81,14 +81,16 @@ public class LayoutScriptDetectionTests
     }
 
     /// <summary>
-    /// Nothing rewrites a block's text on the way to layout any more, so the classification is of
-    /// what was actually read.
+    /// Normalisation classifies the text it is given and never rewrites it, so whatever reaches it
+    /// reaches every source language identically.
     /// </summary>
     /// <remarks>
     /// The lone-ideograph cleanup used to run on the Latin and automatic paths and not on the CJK
     /// one, which took the leading Han off each of these under 英文 and 自動 and left it under 日文.
-    /// For 甲Glossaries that changed the answer outright — Mixed became Latin — and for the other two
-    /// it changed the text a reader would be shown. See 本Wikiについて, which is a heading, not noise.
+    /// For 甲Glossaries that changed the answer outright — Mixed became Latin. It now runs once,
+    /// earlier, for all four alike, and it will not touch 文A日本語 or 本Wikiについて at all — the
+    /// latter is a heading, not noise. 甲Glossaries is stripped before it gets here; what this
+    /// guards is that normalisation itself is not a second place where text can change.
     /// </remarks>
     [Theory]
     [InlineData("甲Glossaries")]
@@ -113,17 +115,26 @@ public class LayoutScriptDetectionTests
     }
 
     /// <summary>
-    /// The rule itself stays, unreferenced by the product, as the starting point for whatever
-    /// replaces it: 904 blocks measured, four hits, all four real icon noise.
+    /// The lone-ideograph cleanup runs once, ahead of normalisation, and asks no question that
+    /// could be answered differently per source language.
     /// </summary>
+    /// <remarks>
+    /// It used to run twice — inside the automatic normaliser and again beside it for explicit
+    /// Latin — which is how the same picture came back with different text under 自動 and under
+    /// 日文. Normalising is not where text is decided any more, and these three calls prove it: all
+    /// three leave the string exactly as handed to them.
+    /// </remarks>
     [Fact]
-    public void TheLoneIdeographRule_StillExists_ButNoLongerRunsOnAnyPath()
+    public void TheLoneIdeographRule_RunsBeforeNormalisation_NotInsideIt()
     {
-        Assert.Equal("Glossaries", OnnxOcrEngine.StripLoneIdeographs("甲Glossaries"));
-
         var bounds = new System.Windows.Rect(0, 0, 240, 30);
-        Assert.Equal(
-            "甲Glossaries",
-            OnnxOcrEngine.NormalizeAutomaticBlocks([new("甲Glossaries", bounds)])[0].Text);
+        List<OcrTextBlock> Blocks() => [new("甲Glossaries", bounds)];
+
+        Assert.Equal("甲Glossaries", OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false)[0].Text);
+        Assert.Equal("甲Glossaries", OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true)[0].Text);
+        Assert.Equal("甲Glossaries", OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks())[0].Text);
+
+        // And the stage that does decide it takes no language, so it cannot answer differently.
+        Assert.Equal("Glossaries", OnnxOcrEngine.StripIconIdeographs(Blocks())[0].Text);
     }
 }

--- a/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
+++ b/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
@@ -45,10 +45,7 @@ public class LayoutScriptDetectionTests
         [
             new("OPTIONS", bounds),
             new("ゲーム設定", bounds),
-            // 文A日本語 rather than 甲Glossaries: the icon-noise rule still runs on the
-            // automatic path today and strips the leading Han off both, which only changes the
-            // answer for the one that has no other CJK left. Step 7 turns that rule off and
-            // 甲Glossaries belongs back here then.
+            new("甲Glossaries", bounds),
             new("文A日本語", bounds),
             new("攻", bounds),
         ];
@@ -62,6 +59,7 @@ public class LayoutScriptDetectionTests
         [
             OcrLayoutScript.Latin,
             OcrLayoutScript.Cjk,
+            OcrLayoutScript.Mixed,
             OcrLayoutScript.Mixed,
             OcrLayoutScript.Cjk,
         ];
@@ -80,5 +78,52 @@ public class LayoutScriptDetectionTests
         Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false)[0].LayoutScript);
         Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true)[0].LayoutScript);
         Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks())[0].LayoutScript);
+    }
+
+    /// <summary>
+    /// Nothing rewrites a block's text on the way to layout any more, so the classification is of
+    /// what was actually read.
+    /// </summary>
+    /// <remarks>
+    /// The lone-ideograph cleanup used to run on the Latin and automatic paths and not on the CJK
+    /// one, which took the leading Han off each of these under 英文 and 自動 and left it under 日文.
+    /// For 甲Glossaries that changed the answer outright — Mixed became Latin — and for the other two
+    /// it changed the text a reader would be shown. See 本Wikiについて, which is a heading, not noise.
+    /// </remarks>
+    [Theory]
+    [InlineData("甲Glossaries")]
+    [InlineData("文A日本語")]
+    [InlineData("本Wikiについて")]
+    public void MixedScriptText_IsKeptVerbatim_OnEverySourceLanguage(string text)
+    {
+        var bounds = new System.Windows.Rect(0, 0, 240, 30);
+        List<OcrTextBlock> Blocks() => [new(text, bounds)];
+
+        foreach (var normalized in new[]
+        {
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false),
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true),
+            OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks()),
+        })
+        {
+            var block = Assert.Single(normalized);
+            Assert.Equal(text, block.Text);
+            Assert.Equal(OcrLayoutScript.Mixed, block.LayoutScript);
+        }
+    }
+
+    /// <summary>
+    /// The rule itself stays, unreferenced by the product, as the starting point for whatever
+    /// replaces it: 904 blocks measured, four hits, all four real icon noise.
+    /// </summary>
+    [Fact]
+    public void TheLoneIdeographRule_StillExists_ButNoLongerRunsOnAnyPath()
+    {
+        Assert.Equal("Glossaries", OnnxOcrEngine.StripLoneIdeographs("甲Glossaries"));
+
+        var bounds = new System.Windows.Rect(0, 0, 240, 30);
+        Assert.Equal(
+            "甲Glossaries",
+            OnnxOcrEngine.NormalizeAutomaticBlocks([new("甲Glossaries", bounds)])[0].Text);
     }
 }

--- a/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
+++ b/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
@@ -1,0 +1,84 @@
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The layout side's view of a block's script, which must come from the text and nothing else.
+/// </summary>
+public class LayoutScriptDetectionTests
+{
+    [Theory]
+    [InlineData("Shots deal more damage", OcrLayoutScript.Latin)]
+    [InlineData("Lv100", OcrLayoutScript.Latin)]
+    [InlineData("2026/07/24 23:29", OcrLayoutScript.Latin)]
+    [InlineData("彈匣內每發子彈", OcrLayoutScript.Cjk)]
+    [InlineData("カタカナ", OcrLayoutScript.Cjk)]
+    // One Han character is a full-width glyph like any other. Two was only ever needed to tell
+    // Chinese from Japanese, which the layout side never asks. See #161.
+    [InlineData("攻", OcrLayoutScript.Cjk)]
+    [InlineData("→", OcrLayoutScript.Unknown)]
+    [InlineData("", OcrLayoutScript.Unknown)]
+    public void Script_IsReadOffTheTextItself(string text, OcrLayoutScript expected)
+    {
+        Assert.Equal(expected, LayoutScriptDetection.For(text));
+    }
+
+    [Theory]
+    // Not an edge case: a line of Japanese technical prose carrying Western terms, a game panel
+    // labelling a stat, and a wiki heading are all ordinary content.
+    [InlineData("甲Glossaries")]
+    [InlineData("文A日本語")]
+    [InlineData("本Wikiについて")]
+    [InlineData("2005 年から CSS, HTML, JavaScript のドキュメントを作成しています。")]
+    public void MixedScriptBlock_IsClassifiedAsMixed(string text)
+    {
+        Assert.Equal(OcrLayoutScript.Mixed, LayoutScriptDetection.For(text));
+    }
+
+    [Fact]
+    public void LayoutScript_IsChosenPerBlock_RegardlessOfSourceLanguage()
+    {
+        var bounds = new System.Windows.Rect(0, 0, 240, 30);
+        List<OcrTextBlock> Blocks() =>
+        [
+            new("OPTIONS", bounds),
+            new("ゲーム設定", bounds),
+            // 文A日本語 rather than 甲Glossaries: the icon-noise rule still runs on the
+            // automatic path today and strips the leading Han off both, which only changes the
+            // answer for the one that has no other CJK left. Step 7 turns that rule off and
+            // 甲Glossaries belongs back here then.
+            new("文A日本語", bounds),
+            new("攻", bounds),
+        ];
+
+        // The three normalisation paths the source language routes to today.
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
+
+        OcrLayoutScript[] expected =
+        [
+            OcrLayoutScript.Latin,
+            OcrLayoutScript.Cjk,
+            OcrLayoutScript.Mixed,
+            OcrLayoutScript.Cjk,
+        ];
+
+        Assert.Equal(expected, latin.Select(block => block.LayoutScript));
+        Assert.Equal(expected, cjk.Select(block => block.LayoutScript));
+        Assert.Equal(expected, automatic.Select(block => block.LayoutScript));
+    }
+
+    [Fact]
+    public void MixedScriptClassification_IsIndependentOfSourceLanguage()
+    {
+        var bounds = new System.Windows.Rect(0, 0, 240, 30);
+        List<OcrTextBlock> Blocks() => [new("本Wikiについて", bounds)];
+
+        Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false)[0].LayoutScript);
+        Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true)[0].LayoutScript);
+        Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks())[0].LayoutScript);
+    }
+}

--- a/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
+++ b/tests/OverTranslate.Tests/LayoutScriptDetectionTests.cs
@@ -51,8 +51,8 @@ public class LayoutScriptDetectionTests
         ];
 
         // The three normalisation paths the source language routes to today.
-        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
-        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true);
         var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
 
         OcrLayoutScript[] expected =
@@ -75,8 +75,8 @@ public class LayoutScriptDetectionTests
         var bounds = new System.Windows.Rect(0, 0, 240, 30);
         List<OcrTextBlock> Blocks() => [new("本Wikiについて", bounds)];
 
-        Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false)[0].LayoutScript);
-        Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true)[0].LayoutScript);
+        Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false)[0].LayoutScript);
+        Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true)[0].LayoutScript);
         Assert.Equal(OcrLayoutScript.Mixed, OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks())[0].LayoutScript);
     }
 
@@ -101,8 +101,8 @@ public class LayoutScriptDetectionTests
 
         foreach (var normalized in new[]
         {
-            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false),
-            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true),
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false),
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true),
             OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks()),
         })
         {

--- a/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
+++ b/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
@@ -88,4 +88,58 @@ public class OcrLayoutGeometryTests
 
         Assert.Null(normalized[0].LayoutGlyphHeight);
     }
+
+    /// <summary>
+    /// The shape filter must reach the same verdict whatever the user picked, which is only true
+    /// while it measures the detection box rather than the normalised one.
+    /// </summary>
+    /// <remarks>
+    /// The fixture is the case this was found on: a 74x40 detection holding one full-width glyph.
+    /// Normalised for CJK the box becomes 74x32.8, and 74 / 1 / 32.8 = 2.26 crosses the 2.0 bar
+    /// while the detection's own 1.85 does not. Under 日文 the label was deleted and under 英文 it
+    /// survived — the same picture, the same reading, a different menu setting. Eighteen blocks of
+    /// the corpus went that way, among them 闇, 三, 決定 and 결정.
+    /// </remarks>
+    [Fact]
+    public void ShapeFilter_ReachesTheSameVerdict_WhateverTheSourceLanguage()
+    {
+        var detected = new System.Windows.Rect(10, 10, 74, 40);
+        List<OcrTextBlock> Blocks() => [new("闇", detected)];
+
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
+
+        // The fixture is only worth anything if the two rectangles disagree across the threshold.
+        Assert.NotEqual(cjk[0].Bounds, cjk[0].LayoutBounds);
+        Assert.True(cjk[0].Bounds.Width / cjk[0].Bounds.Height >= BoxShapeNoise.MaxWidthPerGlyph);
+        Assert.True(cjk[0].LayoutBounds.Width / cjk[0].LayoutBounds.Height < BoxShapeNoise.MaxWidthPerGlyph);
+
+        foreach (var normalized in new[] { latin, cjk, automatic })
+        {
+            Assert.False(BoxShapeNoise.IsTooWideForItsText(normalized[0]));
+            Assert.Single(OnnxOcrEngine.RemoveMisshapenBlocks(normalized, "JA"));
+        }
+    }
+
+    /// <summary>
+    /// And the same in the other direction: a box that really is too wide goes, on every language.
+    /// </summary>
+    [Fact]
+    public void ShapeFilter_StillDropsAWidelyMisshapenBox_WhateverTheSourceLanguage()
+    {
+        var detected = new System.Windows.Rect(10, 10, 300, 40);
+        List<OcrTextBlock> Blocks() => [new("□", detected)];
+
+        foreach (var normalized in new[]
+        {
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false),
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true),
+            OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks()),
+        })
+        {
+            Assert.True(BoxShapeNoise.IsTooWideForItsText(normalized[0]));
+            Assert.Empty(OnnxOcrEngine.RemoveMisshapenBlocks(normalized, "JA"));
+        }
+    }
 }

--- a/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
+++ b/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
@@ -1,0 +1,47 @@
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The geometry grouping measures with, which must not depend on the source language the user
+/// picked. Bounds may still be normalised per script — that is the overlay's business.
+/// </summary>
+public class OcrLayoutGeometryTests
+{
+    [Fact]
+    public void LayoutBounds_IsIdenticalAcrossSourceLanguages_ForSameRawDetection()
+    {
+        var detected = new System.Windows.Rect(40, 120, 240, 30);
+        List<OcrTextBlock> Blocks() =>
+        [
+            new("Shots deal more damage", detected),
+            new("彈匣內每發子彈的傷害", detected),
+        ];
+
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
+
+        foreach (var normalized in new[] { latin, cjk, automatic })
+        {
+            Assert.Equal(detected, normalized[0].LayoutBounds);
+            Assert.Equal(detected, normalized[1].LayoutBounds);
+        }
+
+        // The 0.820 that this exists to get away from: Bounds still differs by script, and still
+        // differs between the paths the source language routes to. Grouping must stop reading it.
+        Assert.NotEqual(latin[1].Bounds.Height, cjk[1].Bounds.Height);
+    }
+
+    [Fact]
+    public void LayoutBounds_IsTheDetectionBox_NotTheNormalisedOne()
+    {
+        var detected = new System.Windows.Rect(0, 0, 120, 30);
+        var normalized = OnnxOcrEngine.NormalizeBlocks([new("設定設定", detected)], isCjk: true);
+
+        Assert.Equal(detected, normalized[0].LayoutBounds);
+        Assert.True(normalized[0].Bounds.Height < detected.Height);
+    }
+}

--- a/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
+++ b/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
@@ -20,8 +20,8 @@ public class OcrLayoutGeometryTests
             new("彈匣內每發子彈的傷害", detected),
         ];
 
-        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
-        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true);
         var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
 
         foreach (var normalized in new[] { latin, cjk, automatic })
@@ -39,7 +39,7 @@ public class OcrLayoutGeometryTests
     public void LayoutBounds_IsTheDetectionBox_NotTheNormalisedOne()
     {
         var detected = new System.Windows.Rect(0, 0, 120, 30);
-        var normalized = OnnxOcrEngine.NormalizeBlocks([new("設定設定", detected)], isCjk: true);
+        var normalized = OnnxOcrEngine.NormalizeBlocks([new("設定設定", detected)], useCjkRenderMetrics: true);
 
         Assert.Equal(detected, normalized[0].LayoutBounds);
         Assert.True(normalized[0].Bounds.Height < detected.Height);
@@ -55,8 +55,8 @@ public class OcrLayoutGeometryTests
             new("彈匣內每發子彈的傷害", detected),
         ];
 
-        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
-        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true);
         var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
 
         Assert.Equal(latin.Select(b => b.LayoutGlyphHeight), cjk.Select(b => b.LayoutGlyphHeight));
@@ -70,7 +70,7 @@ public class OcrLayoutGeometryTests
     public void CjkLayoutGlyphHeight_IsAnEstimate_NotTheDetectionBox()
     {
         var detected = new System.Windows.Rect(0, 0, 120, 30);
-        var normalized = OnnxOcrEngine.NormalizeBlocks([new("設定設定", detected)], isCjk: true);
+        var normalized = OnnxOcrEngine.NormalizeBlocks([new("設定設定", detected)], useCjkRenderMetrics: true);
 
         var height = Assert.IsType<double>(normalized[0].LayoutGlyphHeight);
         Assert.True(height < normalized[0].LayoutBounds.Height);
@@ -84,7 +84,7 @@ public class OcrLayoutGeometryTests
     public void MixedAndUnknownBlocks_CarryNoLayoutGlyphHeight(string text)
     {
         var detected = new System.Windows.Rect(0, 0, 240, 30);
-        var normalized = OnnxOcrEngine.NormalizeBlocks([new(text, detected)], isCjk: false);
+        var normalized = OnnxOcrEngine.NormalizeBlocks([new(text, detected)], useCjkRenderMetrics: false);
 
         Assert.Null(normalized[0].LayoutGlyphHeight);
     }
@@ -106,8 +106,8 @@ public class OcrLayoutGeometryTests
         var detected = new System.Windows.Rect(10, 10, 74, 40);
         List<OcrTextBlock> Blocks() => [new("闇", detected)];
 
-        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
-        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true);
         var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
 
         // The fixture is only worth anything if the two rectangles disagree across the threshold.
@@ -133,8 +133,8 @@ public class OcrLayoutGeometryTests
 
         foreach (var normalized in new[]
         {
-            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false),
-            OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true),
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: false),
+            OnnxOcrEngine.NormalizeBlocks(Blocks(), useCjkRenderMetrics: true),
             OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks()),
         })
         {

--- a/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
+++ b/tests/OverTranslate.Tests/OcrLayoutGeometryTests.cs
@@ -44,4 +44,48 @@ public class OcrLayoutGeometryTests
         Assert.Equal(detected, normalized[0].LayoutBounds);
         Assert.True(normalized[0].Bounds.Height < detected.Height);
     }
+
+    [Fact]
+    public void LayoutGlyphHeight_IsIdenticalAcrossSourceLanguages_ForSameRawDetection()
+    {
+        var detected = new System.Windows.Rect(40, 120, 240, 30);
+        List<OcrTextBlock> Blocks() =>
+        [
+            new("Shots deal more damage", detected),
+            new("彈匣內每發子彈的傷害", detected),
+        ];
+
+        var latin = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: false);
+        var cjk = OnnxOcrEngine.NormalizeBlocks(Blocks(), isCjk: true);
+        var automatic = OnnxOcrEngine.NormalizeAutomaticBlocks(Blocks());
+
+        Assert.Equal(latin.Select(b => b.LayoutGlyphHeight), cjk.Select(b => b.LayoutGlyphHeight));
+        Assert.Equal(latin.Select(b => b.LayoutGlyphHeight), automatic.Select(b => b.LayoutGlyphHeight));
+
+        // The render metric is what still differs: it is keyed on the language route, on purpose.
+        Assert.NotEqual(latin[0].RenderGlyphHeight, automatic[0].RenderGlyphHeight);
+    }
+
+    [Fact]
+    public void CjkLayoutGlyphHeight_IsAnEstimate_NotTheDetectionBox()
+    {
+        var detected = new System.Windows.Rect(0, 0, 120, 30);
+        var normalized = OnnxOcrEngine.NormalizeBlocks([new("設定設定", detected)], isCjk: true);
+
+        var height = Assert.IsType<double>(normalized[0].LayoutGlyphHeight);
+        Assert.True(height < normalized[0].LayoutBounds.Height);
+        // Same 0.82 shrink and pitch clamp the overlay's own CJK box carries.
+        Assert.Equal(normalized[0].Bounds.Height, height, precision: 9);
+    }
+
+    [Theory]
+    [InlineData("甲Glossaries")]
+    [InlineData("→")]
+    public void MixedAndUnknownBlocks_CarryNoLayoutGlyphHeight(string text)
+    {
+        var detected = new System.Windows.Rect(0, 0, 240, 30);
+        var normalized = OnnxOcrEngine.NormalizeBlocks([new(text, detected)], isCjk: false);
+
+        Assert.Null(normalized[0].LayoutGlyphHeight);
+    }
 }

--- a/tests/OverTranslate.Tests/OcrServiceTests.cs
+++ b/tests/OverTranslate.Tests/OcrServiceTests.cs
@@ -122,18 +122,74 @@ public class OcrServiceTests
     [InlineData("技", "技")]
     [InlineData("火", "火")]
     [InlineData("水", "水")]
-    // A lone ideograph glued to the start/end of a Latin word is icon noise -> stripped.
+    // A lone ideograph glued to the start/end of a Latin word is icon noise -> stripped, but only
+    // where what is left carries no CJK at all. All of these came off a real capture.
     [InlineData("甲Glossaries", "Glossaries")]
     [InlineData("业spoken terms", "spoken terms")]
+    [InlineData("文A English (US)", "A English (US)")]  // MDN's language switcher icon
+    [InlineData("田Projects", "Projects")]              // GitHub's ⊞ project icon
+    [InlineData("日Wiki", "Wiki")]                      // GitHub's 📖 wiki icon
+    [InlineData("区Insights Settings", "Insights Settings")]
+    [InlineData("三VOICE", "VOICE")]
+    [InlineData("百LOG", "LOG")]
+    [InlineData("CH是", "CH")]                          // at the end of the line as well
+    [InlineData("ev丘", "ev")]
     // Real text must be preserved untouched:
     [InlineData("2026年5月8日", "2026年5月8日")]   // date glyphs sit next to digits, not letters
     [InlineData("翻譯這個網頁", "翻譯這個網頁")]     // multi-ideograph run = real Chinese
     [InlineData("免費", "免費")]
     [InlineData("Google Translate", "Google Translate")]
     [InlineData("4.3 (82,985)·免費·參考資源", "4.3 (82,985)·免費·參考資源")]
+    // The remainder gate: cutting these would leave Japanese behind, so nothing is cut.
+    [InlineData("本Wikiについて", "本Wikiについて")]
+    [InlineData("文A日本語", "文A日本語")]
     public void StripLoneIdeographs_RemovesIconNoiseButKeepsRealText(string input, string expected)
     {
         Assert.Equal(expected, OnnxOcrEngine.StripLoneIdeographs(input));
+    }
+
+    /// <summary>
+    /// The narrowing did not fix wrong deletion, and this records the case that proves it.
+    /// </summary>
+    /// <remarks>
+    /// On the picture this came from, 閣 is a misread 闇 — the element name on a game panel, real
+    /// text — and the remainder is pure Latin, so the rule cuts it. Nothing about the shape of the
+    /// string separates it from 甲Glossaries two cases up, which is genuine icon noise. Telling
+    /// them apart needs the box geometry or the recognition confidence, and that is still deferred.
+    /// Change this test only alongside a rule that can actually make the distinction.
+    /// </remarks>
+    [Fact]
+    public void StripLoneIdeographs_StillCutsARealLabelItCannotDistinguish()
+    {
+        Assert.Equal("Lv100 50", OnnxOcrEngine.StripLoneIdeographs("閣Lv100 50"));
+    }
+
+    /// <summary>
+    /// The rule rewrites text and never decides whether a block exists.
+    /// </summary>
+    /// <remarks>
+    /// The version before it was narrowed could empty a block, and its caller then dropped it, so
+    /// which blocks came back depended on the source language. It cannot now: a cut needs a Latin
+    /// letter beside the ideograph, so that letter always survives.
+    /// </remarks>
+    [Fact]
+    public void StripIconIdeographs_RewritesTextWithoutDroppingBlocks()
+    {
+        var bounds = new System.Windows.Rect(0, 0, 120, 20);
+        List<OcrTextBlock> blocks =
+        [
+            new("田Projects", bounds),
+            new("本Wikiについて", bounds),
+            new("攻", bounds),
+            new("Settings", bounds),
+        ];
+
+        var cleaned = OnnxOcrEngine.StripIconIdeographs(blocks);
+
+        Assert.Equal(
+            ["Projects", "本Wikiについて", "攻", "Settings"],
+            cleaned.Select(block => block.Text));
+        Assert.Equal(blocks.Count, cleaned.Count);
     }
 
     [Theory]

--- a/tests/OverTranslate.Tests/OcrServiceTests.cs
+++ b/tests/OverTranslate.Tests/OcrServiceTests.cs
@@ -60,7 +60,7 @@ public class OcrServiceTests
     [InlineData("English 中文", true)]
     public void AutomaticLayout_IsChosenPerRecognizedBlock(string text, bool expectedCjk)
     {
-        Assert.Equal(expectedCjk, OnnxOcrEngine.UsesCjkLayoutForText(text));
+        Assert.Equal(expectedCjk, OnnxOcrEngine.UsesCjkRenderMetricsForText(text));
     }
 
     [Fact]
@@ -84,12 +84,14 @@ public class OcrServiceTests
         Assert.Null(normalized[1].RenderGlyphHeight);
         Assert.True(normalized[1].Bounds.Height < bounds.Height);
 
-        // Kept, where it used to be deleted. It is still measured on the Latin path — one Han
-        // character does not satisfy UsesCjkLayoutForText — which is wrong for a full-width glyph
-        // and is pinned here so the geometry work that fixes it has to come past this test rather
-        // than change it by accident. Wrong geometry is a smaller fault than a missing label.
+        // Kept, where it used to be deleted. The render side still measures it on the Latin path —
+        // one Han character does not satisfy UsesCjkRenderMetricsForText — and that is now a
+        // deliberate difference rather than the open defect this comment used to describe: the
+        // layout side reads a lone Han as Cjk (see LayoutScript below), while the overlay's font
+        // scale stays on the rule that keeps it from jumping between frames.
         Assert.Equal("白", normalized[2].Text);
         Assert.NotNull(normalized[2].RenderGlyphHeight);
+        Assert.Equal(OcrLayoutScript.Cjk, normalized[2].LayoutScript);
     }
 
     [Fact]
@@ -219,7 +221,7 @@ public class OcrServiceTests
         var blocks = await engine.RecognizeAsync(bitmap, "AUTO");
 
         Assert.NotEmpty(blocks);
-        Assert.Contains(blocks, block => OnnxOcrEngine.UsesCjkLayoutForText(block.Text));
+        Assert.Contains(blocks, block => OnnxOcrEngine.UsesCjkRenderMetricsForText(block.Text));
     }
 
     [Fact]
@@ -239,7 +241,7 @@ public class OcrServiceTests
         var text = TextOf(blocks);
 
         Assert.Contains("日本語", text);
-        Assert.Contains(blocks, block => OnnxOcrEngine.UsesCjkLayoutForText(block.Text));
+        Assert.Contains(blocks, block => OnnxOcrEngine.UsesCjkRenderMetricsForText(block.Text));
     }
 
     [Fact]

--- a/tests/OverTranslate.Tests/OcrServiceTests.cs
+++ b/tests/OverTranslate.Tests/OcrServiceTests.cs
@@ -165,12 +165,17 @@ public class OcrServiceTests
     }
 
     /// <summary>
-    /// The rule rewrites text and never decides whether a block exists.
+    /// The rule rewrites text and hands back every block it was given.
     /// </summary>
     /// <remarks>
     /// The version before it was narrowed could empty a block, and its caller then dropped it, so
     /// which blocks came back depended on the source language. It cannot now: a cut needs a Latin
     /// letter beside the ideograph, so that letter always survives.
+    ///
+    /// This is about this stage only, and does not say a stripped block always reaches the caller.
+    /// RemoveMisshapenBlocks runs later and sizes a box against its character count, so a block
+    /// this shortens can still be dropped there — one capture in the screenshot corpus does exactly
+    /// that. See StripIconIdeographs for the measurement.
     /// </remarks>
     [Fact]
     public void StripIconIdeographs_RewritesTextWithoutDroppingBlocks()

--- a/tests/OverTranslate.Tests/OcrServiceTests.cs
+++ b/tests/OverTranslate.Tests/OcrServiceTests.cs
@@ -78,10 +78,10 @@ public class OcrServiceTests
 
         Assert.Equal(3, normalized.Count);
         Assert.Equal("Settings", normalized[0].Text);
-        Assert.NotNull(normalized[0].SourceGlyphHeight);
+        Assert.NotNull(normalized[0].RenderGlyphHeight);
         Assert.Equal(bounds.Height, normalized[0].Bounds.Height);
         Assert.Equal("設定", normalized[1].Text);
-        Assert.Null(normalized[1].SourceGlyphHeight);
+        Assert.Null(normalized[1].RenderGlyphHeight);
         Assert.True(normalized[1].Bounds.Height < bounds.Height);
 
         // Kept, where it used to be deleted. It is still measured on the Latin path — one Han
@@ -89,7 +89,7 @@ public class OcrServiceTests
         // and is pinned here so the geometry work that fixes it has to come past this test rather
         // than change it by accident. Wrong geometry is a smaller fault than a missing label.
         Assert.Equal("白", normalized[2].Text);
-        Assert.NotNull(normalized[2].SourceGlyphHeight);
+        Assert.NotNull(normalized[2].RenderGlyphHeight);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class OcrServiceTests
             new("設定設定設定設定", bounds),
         ]);
 
-        var latinGlyphHeight = normalized[0].SourceGlyphHeight;
+        var latinGlyphHeight = normalized[0].RenderGlyphHeight;
         var cjkGlyphHeight = normalized[1].Bounds.Height;
 
         Assert.NotNull(latinGlyphHeight);

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -434,7 +434,7 @@ public class OcrTextBlockGrouperTests
         Assert.Equal(1.0, OcrTextBlockGrouper.TextSizeRatio(latin, cjk), precision: 9);
 
         // What it used to be: normalisation makes the same box 0.82 as tall on the CJK side.
-        var normalizedCjk = OnnxOcrEngine.NormalizeBlocks([new("ゲーム設定", new Rect(10, 10, 240, 30))], isCjk: true)[0];
+        var normalizedCjk = OnnxOcrEngine.NormalizeBlocks([new("ゲーム設定", new Rect(10, 10, 240, 30))], useCjkRenderMetrics: true)[0];
         Assert.True(normalizedCjk.Bounds.Height / latin.Bounds.Height < 0.88);
     }
 

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -376,13 +376,21 @@ public class OcrTextBlockGrouperTests
     /// And what that must not cost: a real wrapped sentence, whose first line is long because it
     /// ran out of room. Real bounds from the same corpus as the menu above.
     /// </summary>
+    /// <remarks>
+    /// The boxes are the detector's, which is not what this fixture used to hold: it carried the
+    /// normalised ones, 30 and 29 tall against the same 51px step, and those put the pair 1.73 line
+    /// advances apart. The capture itself reads 1.33 — the normalisation had taken a quarter off
+    /// the height and left the step, so the leading came back looking half again as loose as it is.
+    /// Re-measured on the capture: gap 0.39 of a line, advance 1.33, heights 0.89 apart, first line
+    /// 2.27 times the width of the second.
+    /// </remarks>
     [Fact]
     public void StillGroupsASentenceLongEnoughToHaveWrapped()
     {
         var blocks = new List<OcrTextBlock>
         {
-            new("그랑 사이퍼의 갑판에 있는 연습용 더미를 조사하면", new Rect(354, 427, 564, 30)),
-            new("플레이할 수 있습니다", new Rect(355, 478, 248, 29)),
+            new("그랑 사이퍼의 갑판에 있는 연습용 더미를 조사하면", new Rect(355, 429, 563, 32.9)),
+            new("플레이할 수 있습니다", new Rect(355, 475.4, 248, 37)),
         };
 
         var grouped = GroupDetected(blocks);
@@ -552,4 +560,62 @@ public class OcrTextBlockGrouperTests
             ["Alpha beta", "Gamma delta", "Epsilon zeta", "Eta theta"],
             grouped.Select(block => block.Text));
     }
+
+    /// <summary>
+    /// A checkbox entry is not the last line of the entry above it, however much shorter it is.
+    /// </summary>
+    /// <remarks>
+    /// Measured from region-panel-en, the corpus set that exists to catch exactly this: three of
+    /// its entries were being joined on the width rule alone, at 1.40 and 1.43 line advances, while
+    /// every pair in the corpus that really is one sentence wrapping stops at 1.33.
+    /// </remarks>
+    [Fact]
+    public void AShorterLineSetTooFarBelow_IsNotTheEndOfTheParagraph()
+    {
+        var blocks = new List<OcrTextBlock>
+        {
+            new("Reveal all rooms before proceeding to next floor", new Rect(100, 100, 520, 30)),
+            new("Allow automatic pomander use", new Rect(100, 143, 320, 30)),
+        };
+
+        // 43 / 30 = 1.43 line advances, past what a paragraph's own leading reaches.
+        var grouped = GroupDetected(blocks);
+
+        Assert.Equal(2, grouped.Count);
+    }
+
+    /// <summary>
+    /// The leading is measured on the detector's box, and this pair is where that changes the
+    /// answer.
+    /// </summary>
+    /// <remarks>
+    /// A CJK pair stepped 44px apart in boxes the engine normalised from 34 down to 27.9. On the
+    /// detection height that is 1.29 line advances and the second line ends the paragraph; on the
+    /// normalised height it is 1.58 and it does not. Which one the rule reads decides the answer,
+    /// and only one of them is the same on every source language.
+    /// </remarks>
+    [Fact]
+    public void WrappedFinalLineLeading_IsMeasuredOnLayoutBounds_NotTheNormalisedBox()
+    {
+        OcrTextBlock Normalised(string text, double y, double width) =>
+            new OcrTextBlock(text, new Rect(100, y + 3.05, width, 27.9))
+            {
+                LayoutBounds = new Rect(100, y, width, 34),
+                LayoutScript = OcrLayoutScript.Cjk,
+            };
+
+        var previous = Normalised("彾匣內每發子彈的傷害會增加而且", 100, 460);
+        var current = Normalised("更容易觸發", 144, 160);
+
+        Assert.Equal(44 / 34.0, LineAdvanceOf(previous, current), precision: 6);
+        Assert.True(44 / 34.0 < 1.38);
+        Assert.True(44 / 27.9 > 1.38);
+
+        var merged = Assert.Single(OcrTextBlockGrouper.Group([previous, current]));
+        Assert.Equal(2, merged.Lines.Count);
+    }
+
+    private static double LineAdvanceOf(OcrTextBlock previous, OcrTextBlock current) =>
+        (current.LayoutBounds.Y - previous.LayoutBounds.Y) /
+        ((previous.LayoutBounds.Height + current.LayoutBounds.Height) / 2.0);
 }

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -16,7 +16,7 @@ public class OcrTextBlockGrouperTests
             new("食尚玩家", new Rect(10, 40, 110, 24)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Single(grouped);
         Assert.Equal(2, grouped[0].Lines.Count);
@@ -32,7 +32,7 @@ public class OcrTextBlockGrouperTests
             new("RIGHT", new Rect(220, 38, 110, 20)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -46,7 +46,7 @@ public class OcrTextBlockGrouperTests
             new("summary", new Rect(10, 48, 180, 16)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -60,7 +60,7 @@ public class OcrTextBlockGrouperTests
             new("body text", new Rect(10, 44, 220, 24)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -75,7 +75,7 @@ public class OcrTextBlockGrouperTests
             new("攻略", new Rect(106, 10, 42, 24)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Single(grouped);
         Assert.Equal("寧夏夜市攻略", grouped[0].Text);
@@ -101,7 +101,7 @@ public class OcrTextBlockGrouperTests
             new("to", new Rect(539, 37, 72, 54)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Single(grouped);
         Assert.Equal("Send this session to the background and free the terminal", grouped[0].Text);
@@ -120,7 +120,7 @@ public class OcrTextBlockGrouperTests
             new("your website", new Rect(515, 71, 565, 102)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Single(grouped);
         Assert.Equal("Translate your website", grouped[0].Text);
@@ -139,7 +139,7 @@ public class OcrTextBlockGrouperTests
             new("the", new Rect(250, 8, 46, 31)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Single(grouped);
         Assert.Equal("session to the", grouped[0].Text);
@@ -157,7 +157,7 @@ public class OcrTextBlockGrouperTests
             new("Create key", new Rect(1632, 298, 112, 38)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -171,7 +171,7 @@ public class OcrTextBlockGrouperTests
             new("右側", new Rect(140, 10, 42, 24)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -185,7 +185,7 @@ public class OcrTextBlockGrouperTests
             new("GO ON」のセットリストプレイリストを公開！", new Rect(10, 40, 290, 24)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Single(grouped);
     }
@@ -199,7 +199,7 @@ public class OcrTextBlockGrouperTests
             new("食尚玩家最新整理", new Rect(10, 40, 210, 24)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -213,7 +213,7 @@ public class OcrTextBlockGrouperTests
             new("第二句重新開始", new Rect(10, 40, 110, 24)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -231,7 +231,7 @@ public class OcrTextBlockGrouperTests
             new("home.", new Rect(970, 106, 141, 51)),
         };
 
-        var merged = Assert.Single(OcrTextBlockGrouper.Group(blocks));
+        var merged = Assert.Single(GroupDetected(blocks));
         Assert.Equal("Let's pay CiRCLE a visit on the way home.", merged.Text);
     }
 
@@ -246,7 +246,7 @@ public class OcrTextBlockGrouperTests
             new("Create key", new Rect(215, 27, 160, 38)),
         };
 
-        Assert.Equal(2, OcrTextBlockGrouper.Group(blocks).Count);
+        Assert.Equal(2, GroupDetected(blocks).Count);
     }
 
     [Fact]
@@ -261,7 +261,7 @@ public class OcrTextBlockGrouperTests
             new("!!", new Rect(266, 10, 20, 24), Confidence: 0.6),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         var merged = Assert.Single(grouped);
         Assert.NotNull(merged.Confidence);
@@ -277,7 +277,7 @@ public class OcrTextBlockGrouperTests
             new("第二段文字", new Rect(112, 10, 100, 24)),
         };
 
-        var merged = Assert.Single(OcrTextBlockGrouper.Group(blocks));
+        var merged = Assert.Single(GroupDetected(blocks));
         Assert.Null(merged.Confidence);
     }
 
@@ -296,7 +296,7 @@ public class OcrTextBlockGrouperTests
             new("magazine", new Rect(698, 311, 109, 31)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         var merged = Assert.Single(grouped);
         Assert.Equal(
@@ -319,7 +319,7 @@ public class OcrTextBlockGrouperTests
             new("magazine", new Rect(112, 108, 105, 26), RenderGlyphHeight: 15),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         var merged = Assert.Single(grouped);
         Assert.Equal(
@@ -340,7 +340,7 @@ public class OcrTextBlockGrouperTests
             new("Narmaya", new Rect(41, 79, 90, 29), RenderGlyphHeight: 11.6),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -360,7 +360,7 @@ public class OcrTextBlockGrouperTests
             new("所持品", new Rect(165, 539, 94, 38)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
@@ -378,7 +378,7 @@ public class OcrTextBlockGrouperTests
             new("플레이할 수 있습니다", new Rect(355, 478, 248, 29)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         var merged = Assert.Single(grouped);
         Assert.Equal(2, merged.Lines.Count);
@@ -399,8 +399,11 @@ public class OcrTextBlockGrouperTests
             new("HOLD TO SALVAGE", new Rect(20, 361, 160, 25)),
         };
 
-        var grouped = OcrTextBlockGrouper.Group(blocks);
+        var grouped = GroupDetected(blocks);
 
         Assert.Equal(2, grouped.Count);
     }
+
+    private static List<OcrTextBlock> GroupDetected(IReadOnlyList<OcrTextBlock> blocks) =>
+        OcrTextBlockGrouper.Group(blocks.AsDetected());
 }

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -315,8 +315,8 @@ public class OcrTextBlockGrouperTests
         var blocks = new List<OcrTextBlock>
         {
             new("Shots deal more damage for each bullet remaining in the",
-                new Rect(111, 78, 566, 30), SourceGlyphHeight: 16),
-            new("magazine", new Rect(112, 108, 105, 26), SourceGlyphHeight: 15),
+                new Rect(111, 78, 566, 30), RenderGlyphHeight: 16),
+            new("magazine", new Rect(112, 108, 105, 26), RenderGlyphHeight: 15),
         };
 
         var grouped = OcrTextBlockGrouper.Group(blocks);
@@ -336,8 +336,8 @@ public class OcrTextBlockGrouperTests
     {
         var blocks = new List<OcrTextBlock>
         {
-            new("2026/07/24 23:29 AUTO SAVE", new Rect(40, 40, 300, 35), SourceGlyphHeight: 20),
-            new("Narmaya", new Rect(41, 79, 90, 29), SourceGlyphHeight: 11.6),
+            new("2026/07/24 23:29 AUTO SAVE", new Rect(40, 40, 300, 35), RenderGlyphHeight: 20),
+            new("Narmaya", new Rect(41, 79, 90, 29), RenderGlyphHeight: 11.6),
         };
 
         var grouped = OcrTextBlockGrouper.Group(blocks);

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -331,13 +331,20 @@ public class OcrTextBlockGrouperTests
     /// holding text of visibly different sizes. A save-slot stamp over a character name did this —
     /// boxes 0.83 apart, letters 0.58. Reading the glyphs is what tells them apart.
     /// </summary>
+    /// <remarks>
+    /// The widths are what make the glyph heights come out at the measured 20 and 11.7: the engine
+    /// does not measure ink, it estimates it from the average glyph pitch, so a box has to be as
+    /// wide as the text in it was. They were 300 and 90 while this fixture set the glyph heights by
+    /// hand, and those boxes yield 16.96 and 11.70 — a ratio of 0.98, which is to say the pair the
+    /// test is built on would have merged in the app whatever this assertion said.
+    /// </remarks>
     [Fact]
     public void KeepsLinesOfDifferentTextSizesApartEvenWhenTheirBoxesMatch()
     {
         var blocks = new List<OcrTextBlock>
         {
-            new("2026/07/24 23:29 AUTO SAVE", new Rect(40, 40, 300, 35), RenderGlyphHeight: 20),
-            new("Narmaya", new Rect(41, 79, 90, 29), RenderGlyphHeight: 11.6),
+            new("2026/07/24 23:29 AUTO SAVE", new Rect(40, 40, 354, 35), RenderGlyphHeight: 20),
+            new("Narmaya", new Rect(41, 79, 63, 29), RenderGlyphHeight: 11.7),
         };
 
         var grouped = GroupDetected(blocks);
@@ -406,4 +413,83 @@ public class OcrTextBlockGrouperTests
 
     private static List<OcrTextBlock> GroupDetected(IReadOnlyList<OcrTextBlock> blocks) =>
         OcrTextBlockGrouper.Group(blocks.AsDetected());
+
+    /// <summary>
+    /// Symptom B: two lines whose detection boxes are exactly the same size, one Latin and one CJK.
+    /// </summary>
+    /// <remarks>
+    /// The size test used to compare normalised boxes, and a CJK one is pulled in to 0.82 of its
+    /// detection box while a Latin one is left whole — so this pair read 0.820 against a 0.88 gate
+    /// and was refused before anything about the text, the spacing or the alignment was consulted.
+    /// No mixed-script pair could ever pass it.
+    /// </remarks>
+    [Fact]
+    public void CrossScriptPair_WithEqualDetectionBoxes_IsNotRefusedBySizeTest()
+    {
+        var latin = new OcrTextBlock("OPTIONS", new Rect(10, 10, 240, 30)).AsDetected();
+        var cjk = new OcrTextBlock("ゲーム設定", new Rect(10, 10, 240, 30)).AsDetected();
+
+        Assert.Equal(OcrLayoutScript.Latin, latin.LayoutScript);
+        Assert.Equal(OcrLayoutScript.Cjk, cjk.LayoutScript);
+        Assert.Equal(1.0, OcrTextBlockGrouper.TextSizeRatio(latin, cjk), precision: 9);
+
+        // What it used to be: normalisation makes the same box 0.82 as tall on the CJK side.
+        var normalizedCjk = OnnxOcrEngine.NormalizeBlocks([new("ゲーム設定", new Rect(10, 10, 240, 30))], isCjk: true)[0];
+        Assert.True(normalizedCjk.Bounds.Height / latin.Bounds.Height < 0.88);
+    }
+
+    /// <summary>
+    /// A block that is itself both scripts has no single glyph body to measure, so it compares on
+    /// the detection box like any other cross-script pairing.
+    /// </summary>
+    [Fact]
+    public void MixedScriptBlock_UsesLayoutBoundsForSizeComparison()
+    {
+        var mixed = new OcrTextBlock("甲Glossaries", new Rect(10, 10, 240, 30)).AsDetected();
+        var latin = new OcrTextBlock("Glossaries", new Rect(10, 50, 200, 30)).AsDetected();
+
+        Assert.Equal(OcrLayoutScript.Mixed, mixed.LayoutScript);
+        Assert.Null(mixed.LayoutGlyphHeight);
+        Assert.Equal(1.0, OcrTextBlockGrouper.TextSizeRatio(mixed, latin), precision: 9);
+    }
+
+    /// <summary>
+    /// The Latin-dominant case the same rule covers: a line of Japanese prose carrying Western
+    /// terms must not be sized as though every glyph in it were full-width.
+    /// </summary>
+    [Fact]
+    public void MixedScriptBlock_DoesNotUseCjkGlyphMetricForLatinDominantText()
+    {
+        var box = new Rect(10, 10, 600, 30);
+        var mixed = new OcrTextBlock(
+            "2005 年から CSS, HTML, JavaScript のドキュメントを作成しています。", box).AsDetected();
+        var cjk = new OcrTextBlock("技術文書を書いています", box).AsDetected();
+
+        Assert.Null(mixed.LayoutGlyphHeight);
+        Assert.NotNull(cjk.LayoutGlyphHeight);
+        Assert.NotEqual(cjk.LayoutGlyphHeight, mixed.LayoutGlyphHeight);
+
+        // Same box, so the comparison is 1.0 — not the CJK glyph estimate measured off one of them.
+        Assert.Equal(1.0, OcrTextBlockGrouper.TextSizeRatio(mixed, cjk), precision: 9);
+    }
+
+    /// <summary>
+    /// 「OPTIONS／ゲーム設定」and 「Back／戻る」: each label is joined to its own translation
+    /// candidate line, and the two pairs stay apart from each other.
+    /// </summary>
+    [Fact]
+    public void Mixed_EnglishJapanese_DoesNotCrossMergeParagraphs()
+    {
+        var blocks = new List<OcrTextBlock>
+        {
+            new("OPTIONS", new Rect(10, 10, 240, 30)),
+            new("ゲーム設定", new Rect(10, 190, 240, 30)),
+            new("Back", new Rect(10, 370, 140, 30)),
+            new("戻る", new Rect(10, 550, 140, 30)),
+        };
+
+        var grouped = GroupDetected(blocks);
+
+        Assert.Equal(4, grouped.Count);
+    }
 }

--- a/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
+++ b/tests/OverTranslate.Tests/OcrTextBlockGrouperTests.cs
@@ -492,4 +492,64 @@ public class OcrTextBlockGrouperTests
 
         Assert.Equal(4, grouped.Count);
     }
+
+    /// <summary>
+    /// The row rule measures on the detector's box, and this pair is where that changes the answer.
+    /// </summary>
+    /// <remarks>
+    /// Two CJK words 16px apart, in boxes the engine has normalised from 40px down to 32.8. Against
+    /// the detection height the space is 0.40 of a line and they are one line of text; against the
+    /// normalised height it is 0.49 and they are two things side by side. Reading Bounds here would
+    /// put the same picture on either side of the threshold depending on the source language the
+    /// user picked, which is what the whole split of the metrics exists to stop.
+    /// </remarks>
+    [Fact]
+    public void SameLineGap_IsMeasuredOnLayoutBounds_NotTheNormalisedBox()
+    {
+        OcrTextBlock Normalised(string text, double x) =>
+            new OcrTextBlock(text, new Rect(x, 13.6, 40, 32.8))
+            {
+                LayoutBounds = new Rect(x, 10, 40, 40),
+                LayoutScript = OcrLayoutScript.Cjk,
+            };
+
+        var previous = Normalised("今日", 10);
+        var current = Normalised("天気", 66);
+
+        Assert.Equal(16, current.LayoutBounds.X - previous.LayoutBounds.Right);
+        Assert.True(16 / 40.0 < SameLineGapThreshold.Fallback);
+        Assert.True(16 / 32.8 > SameLineGapThreshold.Fallback);
+
+        var grouped = OcrTextBlockGrouper.Group([previous, current]);
+
+        Assert.Equal("今日天気", Assert.Single(grouped).Text);
+    }
+
+    /// <summary>
+    /// And the capture that says its own spacing: eight menu entries set well apart, with one pair
+    /// of them closer than the fixed fallback would have allowed.
+    /// </summary>
+    [Fact]
+    public void SameLineGaps_AreJudgedAgainstTheSpacingOfThisCapture()
+    {
+        // Word spaces of 0.1 of a line and item spaces of 0.6, which the estimator splits between.
+        var boxes = new List<OcrTextBlock>();
+        double x = 0;
+        foreach (var (text, gap) in new (string, double)[]
+        {
+            ("Alpha", 0), ("beta", 4), ("Gamma", 24), ("delta", 4),
+            ("Epsilon", 24), ("zeta", 4), ("Eta", 24), ("theta", 4),
+        })
+        {
+            x += gap;
+            boxes.Add(new OcrTextBlock(text, new Rect(x, 10, 60, 40)).AsDetected());
+            x += 60;
+        }
+
+        var grouped = OcrTextBlockGrouper.Group(boxes);
+
+        Assert.Equal(
+            ["Alpha beta", "Gamma delta", "Epsilon zeta", "Eta theta"],
+            grouped.Select(block => block.Text));
+    }
 }

--- a/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeNaturalBackgroundTests.cs
@@ -142,10 +142,10 @@ public class RealtimeNaturalBackgroundTests
     {
         var upper = new TranslatedBlock(
             "like an explosive force", "像是一股爆炸力",
-            new System.Windows.Rect(300, 765, 569, 70), SourceGlyphHeight: 37);
+            new System.Windows.Rect(300, 765, 569, 70), RenderGlyphHeight: 37);
         var lower = new TranslatedBlock(
             "hurtling into the sky!", "衝向天空！",
-            new System.Windows.Rect(310, 827, 542, 74), SourceGlyphHeight: 37);
+            new System.Windows.Rect(310, 827, 542, 74), RenderGlyphHeight: 37);
 
         var targets = RealtimeNaturalBackground.EraseTargets([upper, lower]);
 
@@ -163,10 +163,10 @@ public class RealtimeNaturalBackgroundTests
     {
         var translated = new TranslatedBlock(
             "like an explosive force", "像是一股爆炸力",
-            new System.Windows.Rect(300, 765, 569, 70), SourceGlyphHeight: 37);
+            new System.Windows.Rect(300, 765, 569, 70), RenderGlyphHeight: 37);
         var untranslated = new TranslatedBlock(
             "hurtling into the sky!", "  ",
-            new System.Windows.Rect(310, 827, 542, 74), SourceGlyphHeight: 37);
+            new System.Windows.Rect(310, 827, 542, 74), RenderGlyphHeight: 37);
 
         var targets = RealtimeNaturalBackground.EraseTargets([translated, untranslated]);
 

--- a/tests/OverTranslate.Tests/SameLineGapThresholdTests.cs
+++ b/tests/OverTranslate.Tests/SameLineGapThresholdTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Linq;
+using OverTranslate.Services.Ocr;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class SameLineGapThresholdTests
+{
+    /// <summary>
+    /// The case it exists for: a capture holding both kinds of space. The line is drawn between
+    /// them rather than at the fixed number, which would be right for neither if this capture's
+    /// spacing happened to sit high or low.
+    /// </summary>
+    [Fact]
+    public void DrawsTheLineBetweenTwoKindsOfSpace()
+    {
+        double[] gaps = [0.10, 0.14, 0.18, 0.22, 0.60, 0.64, 0.68];
+
+        var threshold = SameLineGapThreshold.Estimate(gaps);
+
+        Assert.True(threshold.Adaptive, threshold.Reason);
+        Assert.Equal(0.41, threshold.Value, 3);
+    }
+
+    /// <summary>
+    /// The range is bounded above as well, and this is the trade it makes. A capture whose halves
+    /// split cleanly at 0.89 may really be one whose words are set that far apart — or it may be
+    /// two columns of a table, which is the same shape and the expensive mistake. Nothing measured
+    /// puts word spacing anywhere near here, so the fixed threshold wins and the cost is a wide
+    /// line left in pieces rather than two columns read as a sentence.
+    /// </summary>
+    [Fact]
+    public void FallsBackRatherThanOpenTheGateWide()
+    {
+        double[] gaps = [0.40, 0.44, 0.46, 0.48, 1.30, 1.42, 1.55];
+
+        var threshold = SameLineGapThreshold.Estimate(gaps);
+
+        Assert.False(threshold.Adaptive);
+        Assert.Equal(SameLineGapThreshold.Fallback, threshold.Value);
+    }
+
+    /// <summary>
+    /// One kind of space, unevenly measured, is not two kinds. Prose alone must not produce a split
+    /// somewhere in the middle of its own word gaps.
+    /// </summary>
+    [Fact]
+    public void RefusesToSplitOnePopulation()
+    {
+        double[] gaps = [0.10, 0.13, 0.16, 0.19, 0.22, 0.26, 0.30];
+
+        var threshold = SameLineGapThreshold.Estimate(gaps);
+
+        Assert.False(threshold.Adaptive);
+        Assert.Equal(SameLineGapThreshold.Fallback, threshold.Value);
+    }
+
+    /// <summary>
+    /// And a menu alone, which is the same argument from the other end: every gap here is an item
+    /// boundary, so the answer is to split all of them, not to pick one as a word gap.
+    /// </summary>
+    [Fact]
+    public void RefusesToSplitAMenuIntoWordsAndItems()
+    {
+        double[] gaps = [0.56, 0.63, 0.67, 0.70, 0.71, 0.72, 0.76];
+
+        var threshold = SameLineGapThreshold.Estimate(gaps);
+
+        Assert.False(threshold.Adaptive);
+        Assert.Equal(SameLineGapThreshold.Fallback, threshold.Value);
+    }
+
+    /// <summary>
+    /// Two boxes on a row say nothing about which kind of space sits between them, and neither do
+    /// five. The fixed threshold is the answer until a capture has enough to argue otherwise.
+    /// </summary>
+    [Fact]
+    public void FallsBackWhenThereIsTooLittleToGoOn()
+    {
+        var threshold = SameLineGapThreshold.Estimate([0.12, 0.70]);
+
+        Assert.False(threshold.Adaptive);
+        Assert.Equal(SameLineGapThreshold.Fallback, threshold.Value);
+    }
+
+    [Fact]
+    public void FallsBackOnACaptureWithNoGapsAtAll()
+    {
+        var threshold = SameLineGapThreshold.Estimate([]);
+
+        Assert.False(threshold.Adaptive);
+        Assert.Equal(SameLineGapThreshold.Fallback, threshold.Value);
+    }
+
+    /// <summary>
+    /// A split can be clean and still be the wrong two things — text against the distance across a
+    /// column, say. An answer no real word spacing occupies is evidence of that, not a threshold.
+    /// </summary>
+    [Fact]
+    public void FallsBackWhenTheAnswerIsOutsideAnyRealSpacing()
+    {
+        double[] gaps = [0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.90];
+
+        var threshold = SameLineGapThreshold.Estimate(gaps);
+
+        Assert.False(threshold.Adaptive);
+        Assert.Equal(SameLineGapThreshold.Fallback, threshold.Value);
+    }
+
+    /// <summary>
+    /// Distances across a layout are not spacing decisions and are left out, so a handful of them
+    /// cannot drag the loose half far enough to move the line between the two.
+    /// </summary>
+    [Fact]
+    public void IgnoresDistancesThatAreNotSpacing()
+    {
+        double[] near = [0.10, 0.14, 0.18, 0.22, 0.60, 0.64, 0.68];
+        double[] withFarApart = [.. near, 8.0, 12.0, 20.0];
+
+        Assert.Equal(
+            SameLineGapThreshold.Estimate(near).Value,
+            SameLineGapThreshold.Estimate(withFarApart).Value,
+            3);
+    }
+
+    /// <summary>
+    /// Same gaps, same answer, whatever order they arrive in — the split is searched exhaustively
+    /// rather than iterated from a seed, so there is nothing for the input order to influence.
+    /// </summary>
+    [Fact]
+    public void GivesTheSameAnswerWhateverOrderTheGapsArriveIn()
+    {
+        double[] gaps = [0.10, 0.14, 0.18, 0.22, 0.60, 0.64, 0.68];
+
+        Assert.Equal(
+            SameLineGapThreshold.Estimate(gaps).Value,
+            SameLineGapThreshold.Estimate([.. gaps.Reverse()]).Value,
+            6);
+    }
+}

--- a/tests/OverTranslate.Tests/SourceLanguageContractTests.cs
+++ b/tests/OverTranslate.Tests/SourceLanguageContractTests.cs
@@ -1,0 +1,162 @@
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using RapidOcrNet;
+using SkiaSharp;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The contract the whole layout-metric split exists for: one recognition model and one raw
+/// detection must produce the same geometry and the same grouping under 自動, 英文, 日文 and 中文.
+/// </summary>
+/// <remarks>
+/// This drives <see cref="OnnxOcrEngine.ApplyBlockFilters"/> — the real chain the engine runs
+/// between the library's raw blocks and the caller's — rather than calling its stages in order.
+/// That is deliberate. Both of the language dependencies this work removed were rules that looked
+/// language-neutral in isolation: the lone-ideograph cleanup was routed per language by its caller,
+/// and BoxShapeNoise read a Bounds that normalisation had already rewritten per script. Tests that
+/// covered those rules one at a time stayed green through both. A test that lists the stages has
+/// the same blind spot for whatever is added next; one that calls the chain does not.
+///
+/// No model is loaded. The fixtures are detector output, which is what the contract is about: the
+/// same raw detection, read four ways.
+/// </remarks>
+public class SourceLanguageContractTests
+{
+    /// <summary>Every source language the router accepts for this path, automatic included.</summary>
+    private static readonly string[] SourceLanguages = ["AUTO", "EN", "JA", "ZH"];
+
+    /// <summary>
+    /// A capture holding one of everything that has previously been read differently per language.
+    /// </summary>
+    /// <remarks>
+    /// Each entry earns its place:
+    ///
+    ///   闇 in a 74x40 box   — BoxShapeNoise. Untouched the ratio is 1.85 and it is kept; through
+    ///                         the CJK render normalisation the box is pulled to 0.82 of its height
+    ///                         and the ratio becomes 2.26, over the threshold. This is the block
+    ///                         that used to exist under 英文 and not under 日文.
+    ///   田Projects          — the icon cleanup, which used to run on Latin and automatic only.
+    ///   本Wikiについて       — the same cleanup's remainder gate: a heading, not noise, on all four.
+    ///   攻                  — a lone ideograph, kept, and Cjk to the layout side on all four.
+    ///   Confirm / Back      — two UI labels one line apart horizontally that must stay apart.
+    ///   the wrapped pair    — a sentence continuing onto a second line, which must join.
+    ///   Send / to           — a cross-script-free short word beside a long one, the size test's
+    ///                         own trap when it compared normalised heights.
+    /// </remarks>
+    private static TextBlock[] Capture() =>
+    [
+        Detected("Confirm", 40, 30, 96, 26),
+        Detected("Back", 260, 30, 62, 26),
+        Detected("The quick brown fox jumps over", 40, 90, 420, 28),
+        Detected("the lazy dog.", 40, 126, 170, 28),
+        Detected("Send", 40, 190, 74, 31),
+        Detected("to", 128, 195, 30, 25),
+        Detected("田Projects", 40, 250, 132, 30),
+        Detected("本Wikiについて", 240, 250, 168, 30),
+        Detected("攻", 460, 250, 34, 30),
+        Detected("闇", 540, 245, 74, 40),
+        Detected("ゲーム設定を変更します", 40, 320, 300, 30),
+        Detected("設定はいつでも戻せます", 40, 358, 300, 30),
+    ];
+
+    [Fact]
+    public void Auto_English_Japanese_Chinese_ProduceSameGrouping_ForAMixedCapture()
+    {
+        var results = SourceLanguages.ToDictionary(language => language, GroupAs);
+
+        var reference = results["AUTO"];
+        foreach (var language in SourceLanguages)
+        {
+            var actual = results[language];
+
+            Assert.Equal(reference.Count, actual.Count);
+            Assert.Equal(
+                reference.Select(block => block.Text),
+                actual.Select(block => block.Text));
+
+            // Bounds is deliberately NOT compared: it carries the render normalisation, which is
+            // allowed to differ per language and is the whole reason LayoutBounds exists.
+            Assert.Equal(
+                reference.Select(block => block.LayoutBounds),
+                actual.Select(block => block.LayoutBounds));
+            Assert.Equal(
+                reference.Select(block => block.LayoutScript),
+                actual.Select(block => block.LayoutScript));
+        }
+    }
+
+    /// <summary>
+    /// The same contract on a capture whose text is entirely Japanese, where the CJK render
+    /// normalisation applies to every block rather than a few.
+    /// </summary>
+    [Fact]
+    public void Auto_English_Japanese_Chinese_ProduceSameGrouping_ForAJapaneseParagraph()
+    {
+        TextBlock[] Paragraph() =>
+        [
+            Detected("吾輩は猫である。名前はまだ無い。", 40, 40, 460, 30),
+            Detected("どこで生まれたか頓と見当がつかぬ。", 40, 78, 490, 30),
+            Detected("決定", 40, 200, 68, 30),
+            Detected("もどる", 200, 200, 96, 30),
+        ];
+
+        var texts = SourceLanguages
+            .Select(language => GroupAs(language, Paragraph()).Select(block => block.Text).ToList())
+            .ToList();
+
+        Assert.All(texts, actual => Assert.Equal(texts[0], actual));
+    }
+
+    /// <summary>
+    /// A block that exists under one source language and not under another is the failure this
+    /// whole change was written for, so it gets its own assertion rather than being folded into
+    /// the text comparison above.
+    /// </summary>
+    [Fact]
+    public void TheSameRawDetection_KeepsTheSameBlocks_OnEverySourceLanguage()
+    {
+        var counts = SourceLanguages
+            .Select(language => OnnxOcrEngine.ApplyBlockFilters(
+                Capture(),
+                language,
+                OcrLanguageRouter.UsesCjkOnnx(language),
+                OcrLanguageRouter.UsesAutomaticLayout(language)).Count)
+            .ToList();
+
+        Assert.All(counts, count => Assert.Equal(counts[0], count));
+
+        // And the borderline box is one of the survivors, so the assertion above is not passing
+        // because everything was dropped everywhere.
+        var kept = OnnxOcrEngine.ApplyBlockFilters(
+            Capture(), "JA", useCjkRenderMetrics: true, usesAutomaticLayout: false);
+        Assert.Contains(kept, block => block.Text == "闇");
+    }
+
+    private static List<OcrTextBlock> GroupAs(string language) => GroupAs(language, Capture());
+
+    private static List<OcrTextBlock> GroupAs(string language, TextBlock[] capture) =>
+        OcrTextBlockGrouper.Group(OnnxOcrEngine.ApplyBlockFilters(
+            capture,
+            language,
+            OcrLanguageRouter.UsesCjkOnnx(language),
+            OcrLanguageRouter.UsesAutomaticLayout(language)));
+
+    /// <summary>One detector box, in the shape the library hands over.</summary>
+    private static TextBlock Detected(string text, int x, int y, int width, int height) =>
+        new()
+        {
+            BoxPoints =
+            [
+                new SKPointI(x, y),
+                new SKPointI(x + width, y),
+                new SKPointI(x + width, y + height),
+                new SKPointI(x, y + height),
+            ],
+            BoxScore = 0.9f,
+            Text = text,
+            Chars = [.. text.Select(c => c.ToString())],
+            CharScores = [.. text.Select(_ => 0.99f)],
+        };
+}

--- a/tests/OverTranslate.Tests/VerticalTextCaptureTests.cs
+++ b/tests/OverTranslate.Tests/VerticalTextCaptureTests.cs
@@ -38,7 +38,7 @@ public class VerticalTextCaptureTests
             new("中", new System.Windows.Rect(68, 12, 10, 60), Confidence: 0.6),
         };
 
-        var result = OcrService.MergeVerticalColumns(columns);
+        var result = OcrService.MergeVerticalColumns(columns.AsDetected());
 
         Assert.Equal(2, result.Count);
         Assert.Equal("右中左", result[0].Text);
@@ -58,7 +58,7 @@ public class VerticalTextCaptureTests
             new("左", new System.Windows.Rect(20, 10, 10, 60)),
         };
 
-        var result = OcrService.MergeVerticalColumns(columns);
+        var result = OcrService.MergeVerticalColumns(columns.AsDetected());
 
         Assert.Equal(2, result.Count);
         Assert.Equal(["右", "左"], result.Select(block => block.Text));
@@ -69,7 +69,7 @@ public class VerticalTextCaptureTests
     {
         var column = new OcrTextBlock("！", new System.Windows.Rect(10, 20, 30, 15));
 
-        var result = OcrService.MergeVerticalColumns([column]);
+        var result = OcrService.MergeVerticalColumns([column.AsDetected()]);
 
         var kept = Assert.Single(result);
         Assert.Equal(column.Text, kept.Text);
@@ -153,6 +153,99 @@ public class VerticalTextCaptureTests
 
         if (failure is not null)
             throw new Xunit.Sdk.XunitException(failure.ToString());
+    }
+
+    /// <summary>
+    /// The layout box has to turn with the picture, or the column merge below is comparing a
+    /// rectangle in the rotated frame against ones that are not.
+    /// </summary>
+    [Fact]
+    public async Task VerticalRecognition_MapsLayoutBoundsBackAsWellAsBounds()
+    {
+        using var source = new Bitmap(100, 60);
+        // As the CJK path hands it over: Bounds pulled in onto the glyphs, LayoutBounds untouched.
+        var recognized = new OcrTextBlock("縦書き", new System.Windows.Rect(10, 22, 30, 8))
+        {
+            LayoutBounds = new System.Windows.Rect(10, 20, 30, 12),
+            LayoutScript = OcrLayoutScript.Cjk,
+        };
+        using var engine = new RecordingOcrEngine(recognized);
+
+        var result = await OcrService.RecognizeVerticalAsync(
+            engine, source, "JA", CancellationToken.None);
+
+        var block = Assert.Single(result);
+        Assert.Equal(OcrService.MapVerticalBoundsBack(recognized.Bounds, source.Width), block.Bounds);
+        Assert.Equal(
+            OcrService.MapVerticalBoundsBack(recognized.LayoutBounds, source.Width),
+            block.LayoutBounds);
+        Assert.NotEqual(block.Bounds, block.LayoutBounds);
+
+        // Render contract: the overlay's own numbers are still the rotated row height and the
+        // mapped coverage box, untouched by any of the above.
+        Assert.Equal(recognized.Bounds.Height, block.RenderGlyphHeight);
+    }
+
+    [Theory]
+    // Vertical writing is not a script. A western title down the spine of a Japanese book is
+    // still Latin, and the layout side must be told so by the text rather than by the rotation.
+    [InlineData("縦書き", OcrLayoutScript.Cjk)]
+    [InlineData("Vertigo", OcrLayoutScript.Latin)]
+    [InlineData("BanG夢", OcrLayoutScript.Mixed)]
+    public async Task VerticalText_LayoutScript_FollowsActualText_NotOrientation(
+        string text, OcrLayoutScript expected)
+    {
+        using var source = new Bitmap(100, 60);
+        using var engine = new RecordingOcrEngine(
+            new OcrTextBlock(text, new System.Windows.Rect(10, 20, 30, 10)));
+
+        var result = await OcrService.RecognizeVerticalAsync(
+            engine, source, "JA", CancellationToken.None);
+
+        Assert.Equal(expected, Assert.Single(result).LayoutScript);
+    }
+
+    /// <summary>
+    /// The same shape as the wide-horizontal-text case above, but with the two rectangles landing
+    /// on opposite sides of the 1.4 candidate test: normalised, the strip looks narrow enough to be
+    /// a column and bridges the two real ones into a single group.
+    /// </summary>
+    [Fact]
+    public void MergeVerticalColumns_JudgesTheColumnShapeOnLayoutBounds()
+    {
+        var strip = new OcrTextBlock("橫排標題", new System.Windows.Rect(35, 8, 54, 40))
+        {
+            // 54 / 40 = 1.35, inside the 1.4 bar; the detector's own 66 / 40 = 1.65 is outside it.
+            LayoutBounds = new System.Windows.Rect(35, 8, 66, 40),
+        };
+        var columns = new List<OcrTextBlock>
+        {
+            new OcrTextBlock("右", new System.Windows.Rect(80, 10, 10, 60)).AsDetected(),
+            strip,
+            new OcrTextBlock("左", new System.Windows.Rect(20, 10, 10, 60)).AsDetected(),
+        };
+
+        var result = OcrService.MergeVerticalColumns(columns);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(["右", "左"], result.Select(block => block.Text));
+    }
+
+    /// <summary>A merged column group carries layout metrics on, so nothing downstream sees a gap.</summary>
+    [Fact]
+    public void MergeVerticalColumns_CarriesLayoutMetricsOntoTheGroup()
+    {
+        var columns = new List<OcrTextBlock>
+        {
+            new OcrTextBlock("右", new System.Windows.Rect(80, 10, 10, 60)),
+            new OcrTextBlock("中", new System.Windows.Rect(68, 12, 10, 60)),
+        }.AsDetected();
+
+        var merged = Assert.Single(OcrService.MergeVerticalColumns(columns));
+
+        Assert.Equal(OcrLayoutScript.Cjk, merged.LayoutScript);
+        Assert.Equal(new System.Windows.Rect(68, 10, 22, 62), merged.LayoutBounds);
+        Assert.NotNull(merged.LayoutGlyphHeight);
     }
 
     private sealed class RecordingOcrEngine(params OcrTextBlock[] blocks) : IOcrEngine

--- a/tests/OverTranslate.Tests/VerticalTextCaptureTests.cs
+++ b/tests/OverTranslate.Tests/VerticalTextCaptureTests.cs
@@ -22,7 +22,7 @@ public class VerticalTextCaptureTests
         Assert.Equal(new Size(60, 100), engine.RecognizedSize);
         var block = Assert.Single(result);
         Assert.Equal(new System.Windows.Rect(72, 10, 8, 30), block.Bounds);
-        Assert.Equal(8, block.SourceGlyphHeight);
+        Assert.Equal(8, block.RenderGlyphHeight);
         Assert.Equal(0.75, block.Confidence);
         Assert.Equal(4, block.Lines.Count);
     }

--- a/tests/OverTranslate.Tests/VerticalTextCaptureTests.cs
+++ b/tests/OverTranslate.Tests/VerticalTextCaptureTests.cs
@@ -165,7 +165,7 @@ public class VerticalTextCaptureTests
             CancellationToken cancellationToken = default)
         {
             RecognizedSize = bitmap.Size;
-            return Task.FromResult(blocks.ToList());
+            return Task.FromResult(blocks.AsDetected());
         }
 
         public Task<List<OcrTextBlock>?> TryRecognizeAsync(
@@ -173,7 +173,7 @@ public class VerticalTextCaptureTests
             string sourceLanguage,
             int? maxDetectSize = null,
             CancellationToken cancellationToken = default) =>
-            Task.FromResult<List<OcrTextBlock>?>(blocks.ToList());
+            Task.FromResult<List<OcrTextBlock>?>(blocks.AsDetected());
 
         public void Dispose()
         {

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -1067,6 +1067,16 @@ if (args[0] == "--group-explain")
         var grouped = OcrTextBlockGrouper.Group(raw, decisions);
 
         Console.WriteLine($"  lines read: {raw.Count}  ->  groups sent to translation: {grouped.Count}");
+
+        // One aggregatable line per image, so a whole corpus can be summed without re-reading the
+        // verdicts. The script census is on the lines as read, not on the groups, because that is
+        // the population the size test pairs off against each other.
+        int Census(OcrLayoutScript script) => raw.Count(block => block.LayoutScript == script);
+        Console.WriteLine(
+            $"SUMMARY	{path}	lang={harnessLanguage}	lines={raw.Count}	groups={grouped.Count}" +
+            $"	latin={Census(OcrLayoutScript.Latin)}	cjk={Census(OcrLayoutScript.Cjk)}" +
+            $"	mixed={Census(OcrLayoutScript.Mixed)}	unknown={Census(OcrLayoutScript.Unknown)}" +
+            $"	text={string.Join(" | ", grouped.Select(block => block.Text.Trim()))}");
         for (var i = 0; i < grouped.Count; i++)
             Console.WriteLine($"  [{i}] lines={grouped[i].Lines.Count}  {grouped[i].Text}");
 

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -35,10 +35,10 @@ if (args.Length == 0)
     Console.Error.WriteLine("       OcrHarness --margin-scale-grid <wholescreen.png> [more.png ...]");
     Console.Error.WriteLine("                  (CSV: the same subtitle at several margins, each read at every scale)");
     Console.Error.WriteLine("       OcrHarness --group-explain <image.png> [more.png ...]");
-    Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
+    Console.Error.WriteLine("                  (every same-line and next-line verdict with the geometry it judged on)");
     Console.Error.WriteLine("                  (screenshot flow by default; --realtime for the live one)");
     Console.Error.WriteLine("       OcrHarness --vertical-explain <image.png> [more.png ...]");
-    Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
+    Console.Error.WriteLine("                  (the vertical pipeline's columns and their text, which --group-explain never runs)");
     Console.Error.WriteLine("       OcrHarness --reject-audit <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (what the confidence filter drops, and what a line would have reclaimed)");
     Console.Error.WriteLine("       OcrHarness --xlate-test   (network translation/resilience check, no OCR)");
@@ -1136,14 +1136,25 @@ if (args[0] == "--group-explain")
         for (var i = 0; i < grouped.Count; i++)
             Console.WriteLine($"  [{i}] lines={grouped[i].Lines.Count}  {grouped[i].Text}");
 
-        Console.WriteLine("  --- next-line verdicts (gap/align in line heights) ---");
+        // Each kind printed with the labels for what it actually measured. The two share a record
+        // (see NextLineDecision) and fill several of its fields with different quantities, so one
+        // format for both would put a horizontal gap under a heading saying "vertical" and print
+        // two columns of zeroes that read as measurements. The threshold work on this branch is
+        // aggregated out of these lines, and a run that has to be split on Kind afterwards should
+        // say so on its face.
+        Console.WriteLine("  --- verdicts: row = same line left to right, next = the line below ---");
+        Console.WriteLine("  --- gaps and advances in line heights ---");
         foreach (var decision in decisions)
         {
-            Console.WriteLine(
-                $"  {decision.Kind,-4} {(decision.Joined ? "JOIN  " : "SPLIT ")} gap={decision.VerticalGap,6:0.00} " +
-                $"align={decision.LeftDelta,6:0.00} size={decision.TextSizeRatio:0.00} " +
-                $"width={decision.WidthRatio:0.00} adv={decision.LineAdvance,5:0.00} " +
-                $"script={decision.PreviousScript}/{decision.CurrentScript}  [{decision.Rule}]");
+            var verdict = decision.Joined ? "JOIN  " : "SPLIT ";
+            Console.WriteLine(decision.Kind == "row"
+                ? $"  row  {verdict} hgap={decision.VerticalGap,6:0.00} " +
+                  $"overlap={decision.LeftDelta,5:0.00} width={decision.WidthRatio:0.00} " +
+                  $"script={decision.PreviousScript}/{decision.CurrentScript}  [{decision.Rule}]"
+                : $"  next {verdict} vgap={decision.VerticalGap,6:0.00} " +
+                  $"align={decision.LeftDelta,6:0.00} size={decision.TextSizeRatio:0.00} " +
+                  $"width={decision.WidthRatio:0.00} adv={decision.LineAdvance,5:0.00} " +
+                  $"script={decision.PreviousScript}/{decision.CurrentScript}  [{decision.Rule}]");
             Console.WriteLine($"      \"{Shorten(decision.Previous)}\" + \"{Shorten(decision.Current)}\"");
         }
     }

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -1086,7 +1086,7 @@ if (args[0] == "--group-explain")
         foreach (var decision in decisions)
         {
             Console.WriteLine(
-                $"  {(decision.Joined ? "JOIN  " : "SPLIT ")} gap={decision.VerticalGap,6:0.00} " +
+                $"  {decision.Kind,-4} {(decision.Joined ? "JOIN  " : "SPLIT ")} gap={decision.VerticalGap,6:0.00} " +
                 $"align={decision.LeftDelta,6:0.00} size={decision.TextSizeRatio:0.00} " +
                 $"width={decision.WidthRatio:0.00} " +
                 $"script={decision.PreviousScript}/{decision.CurrentScript}  [{decision.Rule}]");

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -634,10 +634,10 @@ if (args[0] == "--margin-scale-grid")
 
                 var chars = kept.Sum(b => b.Text.Count(c => !char.IsWhiteSpace(c)));
 
-                // SourceGlyphHeight is the ink height and is null for CJK, where the box already is
+                // RenderGlyphHeight is the ink height and is null for CJK, where the box already is
                 // the glyph — taking one or the other rather than both is the #35 mistake, and it is
                 // worth a factor of two on Latin.
-                var glyphRegion = Median(kept.Select(b => b.SourceGlyphHeight ?? b.Bounds.Height).ToList());
+                var glyphRegion = Median(kept.Select(b => b.RenderGlyphHeight ?? b.Bounds.Height).ToList());
                 var glyphDetector = native > 0 ? glyphRegion * size / native : 0;
 
                 var textUnion = UnionOf(kept, 0, 0);

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -36,6 +36,8 @@ if (args.Length == 0)
     Console.Error.WriteLine("                  (CSV: the same subtitle at several margins, each read at every scale)");
     Console.Error.WriteLine("       OcrHarness --group-explain <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
+    Console.Error.WriteLine("       OcrHarness --vertical-explain <image.png> [more.png ...]");
+    Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
     Console.Error.WriteLine("       OcrHarness --reject-audit <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (what the confidence filter drops, and what a line would have reclaimed)");
     Console.Error.WriteLine("       OcrHarness --xlate-test   (network translation/resilience check, no OCR)");
@@ -1096,6 +1098,34 @@ if (args[0] == "--group-explain")
 
     static string Shorten(string text) =>
         text.Length <= 42 ? text : string.Concat(text.AsSpan(0, 40), "…");
+}
+
+// The vertical pipeline, which nothing else here can reach.
+//
+// Vertical writing is turned anticlockwise for the horizontal detector, grouped in that frame,
+// mapped back, and then merged a second time into columns. Only that second pass decides what a
+// reader of a Japanese page actually gets, and --group-explain never runs it: it calls the grouper
+// directly, which is the horizontal path. So every number this harness has ever printed for
+// vertical-image-ja was the horizontal pipeline's.
+if (args[0] == "--vertical-explain")
+{
+    using var verticalEngine = new OnnxOcrEngine();
+
+    foreach (var path in args.Skip(1))
+    {
+        if (!File.Exists(path)) { Console.WriteLine($"(missing) {path}"); continue; }
+
+        using var image = new Bitmap(path);
+        var columns = await OcrService.RecognizeVerticalAsync(
+            verticalEngine, image, harnessLanguage, CancellationToken.None);
+
+        Console.WriteLine(
+            $"VERTICAL	{path}	lang={harnessLanguage}	columns={columns.Count}" +
+            $"	scripts={string.Join(",", columns.Select(c => c.LayoutScript))}" +
+            $"	text={string.Join(" | ", columns.Select(c => c.Text.Trim()))}");
+    }
+
+    return 0;
 }
 
 // Where a change in the user's selection first becomes a change in the answer.

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -36,7 +36,7 @@ if (args.Length == 0)
     Console.Error.WriteLine("                  (CSV: the same subtitle at several margins, each read at every scale)");
     Console.Error.WriteLine("       OcrHarness --group-explain <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
-    Console.Error.WriteLine("                  (add --realtime for the live pipeline's confidence filter)");
+    Console.Error.WriteLine("                  (screenshot flow by default; --realtime for the live one)");
     Console.Error.WriteLine("       OcrHarness --vertical-explain <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
     Console.Error.WriteLine("       OcrHarness --reject-audit <image.png> [more.png ...]");
@@ -52,6 +52,31 @@ if (args.Length == 0)
 // dump as a panel would report the wrong half of RealtimeDetectorSize.
 var harnessMode = args.Contains("--panel") ? RealtimeBlockMode.Panel : RealtimeBlockMode.Subtitle;
 args = [.. args.Where(argument => argument != "--panel")];
+
+// WHICH FLOW --group-explain IS ASKED ABOUT, and it has to be asked because grouping serves two of
+// them at two different detector sizes:
+//
+//   截圖翻譯  OcrService.RecognizeAsync    ImgResize = 2048, which below 2048 is no downscale at all
+//   即時翻譯  OcrService.TryRecognizeAsync RealtimeDetectorSize.For(w, h, mode), which downscales
+//
+// That is not a detail. The detector's boxes are not stable across input scales — measured on the
+// old branch's corpus, reading the same 22 captures at the realtime sizes instead of the screenshot
+// one moves 37 of 78 multi-line groups and invents 34 others — so a verdict read at the wrong size
+// is a verdict about a layout the flow under test never sees. Measured again here on one framed
+// nav bar, the boundary is sharp to the pixel: a 2040px-wide frame comes back with three UI labels
+// fused into two boxes and a 2048px one with every label separate, the pixels being identical.
+//
+// This mode was written for the screenshot flow (the corpus is framed selections, and 截圖翻譯 is
+// what the grouping work serves), but it took RealtimeDetectorSize from --reject-audit next door,
+// where it is right: that mode is about a filter which runs on the realtime path only. So the
+// default moves to the screenshot flow and --realtime asks for the other, which --panel implies —
+// mode is a realtime concept and naming one is how you say which half of RealtimeDetectorSize.
+//
+// BASELINES TAKEN BEFORE THIS FLAG WERE REALTIME-SIZED. Anything compared against them has to be
+// regenerated rather than read across. --vertical-explain never had the problem: it goes through
+// OcrService.RecognizeVerticalAsync, which is the screenshot entry point already.
+var harnessRealtime = args.Contains("--realtime") || args.Contains("--panel");
+args = [.. args.Where(argument => argument != "--realtime")];
 
 // Which language to read as. It picks the recognition model, and that is not a detail on a Korean
 // dump: the general model carries no Hangul at all, so a Korean frame read as EN comes back as
@@ -1052,7 +1077,6 @@ if (args[0] == "--reject-audit")
 if (args[0] == "--group-explain")
 {
     using var explainEngine = new OnnxOcrEngine();
-    var explainRealtime = args.Contains("--realtime");
 
     foreach (var path in args.Skip(1))
     {
@@ -1062,15 +1086,32 @@ if (args[0] == "--group-explain")
         Console.WriteLine($"IMAGE: {path}");
 
         using var image = new Bitmap(path);
-        var size = harnessSize
-            ?? RealtimeDetectorSize.For(image.Width, image.Height, harnessMode).Primary;
-        var raw = await explainEngine.TryRecognizeAsync(image, harnessLanguage, size);
+
+        // Named on every image rather than once at the top, because these outputs get saved and
+        // diffed against each other months apart, and a file that does not say which flow it is
+        // about is a file that will eventually be compared with one about the other.
+        List<OcrTextBlock>? raw;
+        if (harnessRealtime || harnessSize is not null)
+        {
+            var size = harnessSize
+                ?? RealtimeDetectorSize.For(image.Width, image.Height, harnessMode).Primary;
+            Console.WriteLine($"FLOW: 即時翻譯 (detect={size})");
+            raw = await explainEngine.TryRecognizeAsync(image, harnessLanguage, size);
+        }
+        else
+        {
+            // The screenshot flow's own entry point, so the size comes from the same place the app
+            // gets it rather than from a number repeated here.
+            Console.WriteLine("FLOW: 截圖翻譯 (detect=screenshot)");
+            raw = await explainEngine.RecognizeAsync(image, harnessLanguage);
+        }
+
         if (raw is null || raw.Count == 0) { Console.WriteLine("  (nothing read)"); continue; }
 
-        // The detector size here is already the realtime one. What --realtime adds is the other
-        // half of that pipeline: the confidence floor OcrService applies before grouping, which the
-        // screenshot path deliberately does not have.
-        if (explainRealtime)
+        // The confidence floor OcrService applies before grouping on the realtime path only; the
+        // screenshot path deliberately keeps everything. A size named on its own asks for realtime
+        // sizing without claiming to be that pipeline, so it does not get the filter.
+        if (harnessRealtime)
         {
             var kept = OcrService.RejectUnconvincingBlocks(raw);
             Console.WriteLine($"  realtime confidence filter: {raw.Count} -> {kept.Count} lines");

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -36,6 +36,7 @@ if (args.Length == 0)
     Console.Error.WriteLine("                  (CSV: the same subtitle at several margins, each read at every scale)");
     Console.Error.WriteLine("       OcrHarness --group-explain <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
+    Console.Error.WriteLine("                  (add --realtime for the live pipeline's confidence filter)");
     Console.Error.WriteLine("       OcrHarness --vertical-explain <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
     Console.Error.WriteLine("       OcrHarness --reject-audit <image.png> [more.png ...]");
@@ -1051,6 +1052,7 @@ if (args[0] == "--reject-audit")
 if (args[0] == "--group-explain")
 {
     using var explainEngine = new OnnxOcrEngine();
+    var explainRealtime = args.Contains("--realtime");
 
     foreach (var path in args.Skip(1))
     {
@@ -1064,6 +1066,17 @@ if (args[0] == "--group-explain")
             ?? RealtimeDetectorSize.For(image.Width, image.Height, harnessMode).Primary;
         var raw = await explainEngine.TryRecognizeAsync(image, harnessLanguage, size);
         if (raw is null || raw.Count == 0) { Console.WriteLine("  (nothing read)"); continue; }
+
+        // The detector size here is already the realtime one. What --realtime adds is the other
+        // half of that pipeline: the confidence floor OcrService applies before grouping, which the
+        // screenshot path deliberately does not have.
+        if (explainRealtime)
+        {
+            var kept = OcrService.RejectUnconvincingBlocks(raw);
+            Console.WriteLine($"  realtime confidence filter: {raw.Count} -> {kept.Count} lines");
+            raw = kept;
+            if (raw.Count == 0) { Console.WriteLine("  (nothing survived)"); continue; }
+        }
 
         var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
         var grouped = OcrTextBlockGrouper.Group(raw, decisions);

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -34,6 +34,8 @@ if (args.Length == 0)
     Console.Error.WriteLine("                  (same text, blocks cropped tight around it vs left loose)");
     Console.Error.WriteLine("       OcrHarness --margin-scale-grid <wholescreen.png> [more.png ...]");
     Console.Error.WriteLine("                  (CSV: the same subtitle at several margins, each read at every scale)");
+    Console.Error.WriteLine("       OcrHarness --group-explain <image.png> [more.png ...]");
+    Console.Error.WriteLine("                  (every next-line verdict with the geometry it judged on)");
     Console.Error.WriteLine("       OcrHarness --reject-audit <image.png> [more.png ...]");
     Console.Error.WriteLine("                  (what the confidence filter drops, and what a line would have reclaimed)");
     Console.Error.WriteLine("       OcrHarness --xlate-test   (network translation/resilience check, no OCR)");
@@ -1030,6 +1032,60 @@ if (args[0] == "--reject-audit")
     Console.WriteLine($"  would have merged     : {wouldMerge}   <- what a narrowed rule would keep");
     Console.WriteLine($"  isolated              : {isolated}   <- what it would still drop");
     return 0;
+}
+
+// Every next-line verdict the grouper reached, with the geometry it judged on.
+//
+// The ordinary output shows which lines were joined and no more, so a paragraph that came back as
+// four separate translations says nothing about which threshold refused it, or by how much. These
+// thresholds are the whole of the grouper and they are tuned against real captures, so seeing the
+// near misses is what makes tuning something other than guesswork: a run of pairs refused on
+// "vertical gap" at 0.83 of a line is a different problem from one refused on "no continuation
+// evidence" with the gap at 0.2.
+//
+// Numbers are in line heights, not pixels, so captures of different sizes can be read side by side.
+// Each side's layout script is printed too, because that is what decides whether the size test
+// compared glyph heights or fell back to the raw detection boxes.
+if (args[0] == "--group-explain")
+{
+    using var explainEngine = new OnnxOcrEngine();
+
+    foreach (var path in args.Skip(1))
+    {
+        if (!File.Exists(path)) { Console.WriteLine($"(missing) {path}"); continue; }
+
+        Console.WriteLine(new string('=', 78));
+        Console.WriteLine($"IMAGE: {path}");
+
+        using var image = new Bitmap(path);
+        var size = harnessSize
+            ?? RealtimeDetectorSize.For(image.Width, image.Height, harnessMode).Primary;
+        var raw = await explainEngine.TryRecognizeAsync(image, harnessLanguage, size);
+        if (raw is null || raw.Count == 0) { Console.WriteLine("  (nothing read)"); continue; }
+
+        var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
+        var grouped = OcrTextBlockGrouper.Group(raw, decisions);
+
+        Console.WriteLine($"  lines read: {raw.Count}  ->  groups sent to translation: {grouped.Count}");
+        for (var i = 0; i < grouped.Count; i++)
+            Console.WriteLine($"  [{i}] lines={grouped[i].Lines.Count}  {grouped[i].Text}");
+
+        Console.WriteLine("  --- next-line verdicts (gap/align in line heights) ---");
+        foreach (var decision in decisions)
+        {
+            Console.WriteLine(
+                $"  {(decision.Joined ? "JOIN  " : "SPLIT ")} gap={decision.VerticalGap,6:0.00} " +
+                $"align={decision.LeftDelta,6:0.00} size={decision.TextSizeRatio:0.00} " +
+                $"width={decision.WidthRatio:0.00} " +
+                $"script={decision.PreviousScript}/{decision.CurrentScript}  [{decision.Rule}]");
+            Console.WriteLine($"      \"{Shorten(decision.Previous)}\" + \"{Shorten(decision.Current)}\"");
+        }
+    }
+
+    return 0;
+
+    static string Shorten(string text) =>
+        text.Length <= 42 ? text : string.Concat(text.AsSpan(0, 40), "…");
 }
 
 // Where a change in the user's selection first becomes a change in the answer.

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -1088,7 +1088,7 @@ if (args[0] == "--group-explain")
             Console.WriteLine(
                 $"  {decision.Kind,-4} {(decision.Joined ? "JOIN  " : "SPLIT ")} gap={decision.VerticalGap,6:0.00} " +
                 $"align={decision.LeftDelta,6:0.00} size={decision.TextSizeRatio:0.00} " +
-                $"width={decision.WidthRatio:0.00} " +
+                $"width={decision.WidthRatio:0.00} adv={decision.LineAdvance,5:0.00} " +
                 $"script={decision.PreviousScript}/{decision.CurrentScript}  [{decision.Rule}]");
             Console.WriteLine($"      \"{Shorten(decision.Previous)}\" + \"{Shorten(decision.Current)}\"");
         }


### PR DESCRIPTION
## 問題

同一張截圖、同一顆辨識模型，使用者在來源語言選「自動」「英文」「日文」「中文」，**送去翻譯的分組結果不同**。

275 張語料、截圖翻譯流程實測：

| | 自動 | 英文 | 日文 | 中文 | 逐組文字一致 |
|---|---|---|---|---|---|
| 合併前 | 2209 | 2165 | 2159 | 2209 | 192 / 256（75.0%）|
| 合併後 | 2285 | 2285 | 2285 | 2285 | **256 / 256（100%）** |

繁體中文額外驗證同樣一致；直排 8 張圖 74 欄五種模式逐欄相同。

### 成因

一個欄位（`SourceGlyphHeight`）與一個矩形（`Bounds`）同時服務兩個需求相反的消費者——**分組**要的是同一張圖裡各區塊可比，**疊圖渲染**要的是跨文字系統視覺一致——而兩者的正規化又依使用者選的來源語言分成三條路徑（除數 1.24 / 1.3 / 1.18）。

更麻煩的是，好幾個「看起來與語言無關」的規則其實讀到了**被語言改過的資料**：

- `OcrTextBlockGrouper` 有四處直接讀 `Bounds.Height`，而 CJK 的 `Bounds` 被替換成 `0.82 ×` 偵測框高、拉丁的原封不動
- `BoxShapeNoise` 是純幾何判斷，但它跑在正規化之後，因此**區塊的存在與否本身就隨來源語言改變**（12 / 252 張圖的行數會變）
- `StripLoneIdeographs` 只在英文與自動路徑執行

## 改法

把指標依消費者拆開：

| 欄位 | 給誰 |
|---|---|
| `LayoutBounds`（偵測器原始框）／ `LayoutScript` ／ `LayoutGlyphHeight` | 只給分組 |
| `Bounds` ／ `RenderGlyphHeight`（原 `SourceGlyphHeight`）| 只給疊圖與覆蓋區 |

`LayoutScript` 依 **block 自身文字**判定（`Latin` / `Cjk` / `Mixed` / `Unknown`），與來源語言無關。同 script 比 `LayoutGlyphHeight`，跨 script 退回 `LayoutBounds.Height`。

三個 `Layout*` 欄位不進入 `TranslatedBlock`——分組做完就沒有消費者，所以 provider 端只是改名。

**疊圖字級與覆蓋區語意完全不動**，三個 render 除數不統一。分組與渲染的需求相反，硬要一個數字同時服務兩者正是這次要修的病。

## 順帶修掉的既有缺陷

- **混合中英日的相鄰兩行永遠併不起來**。兩種文字的框被算成不同尺度，比值恆為 0.820，卡在 0.88 的門檻下——與內容、行距、對齊全部無關
- **並排的 UI 元件被接成一句送翻譯**：遊戲選單鍵、試算表儲存格、搜尋篩選器、發票表格、勾選清單。導覽列的誤併數 183 → 107
- 中日文路徑被噪音過濾多刪的區塊（語料中 18 個，一半是真標籤）

## 代價與已知問題

- 3 則字幕被切成兩段（截圖主場 2 件、即時語料 1 件）。同列門檻從 1.35 收到 0.45 換來 113 對正確分離，依「過度合併嚴重、過度切分可接受」的取捨接受
- 2 筆錯誤合併幾何上解不掉，需要顏色／背景這類非幾何證據
- `閣Lv100` 的誤刪：畫面上是合法的「闇」被 OCR 誤讀成「閣」，已在註解與專門的測試裡釘住
- 圖示雜訊清理改為**窄化後啟用**（剝完剩餘含 CJK 就不剝），四語一律相同；殘留垃圾字回到合併前水準

## 驗證

- 測試 **908 通過 / 2 略過**（合併前 844 / 2）
- 主契約有端到端測試守著：直接驅動 `ApplyBlockFilters`，四條語言路徑斷言組數、逐組文字、`LayoutBounds`、`LayoutScript` 全部相同。突變檢查確認——把圖示清理改回語言分流，**只有這支測試變紅**
- 對照語料三集：漫畫（全部該併）零變動、遊戲面板（一行都不該併）往正確方向、日文網頁（中間型態）+7 全部驗證為正確分離
- 兩個分組門檻在原生與縮放兩端都重驗過空帶仍在
- 實機驗收：截圖翻譯橫排／直排、即時翻譯字幕、疊圖字級皆無異常