### PR TITLE
新增 OCR 偵錯框線功能並調整設定頁偵錯工具排版

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ packages/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+.test-artifacts/
 
 # Publish output
 publish/

--- a/src/OverTranslate/Models/OcrDebugSettings.cs
+++ b/src/OverTranslate/Models/OcrDebugSettings.cs
@@ -18,6 +18,9 @@ namespace OverTranslate.Models;
 /// </remarks>
 public class OcrDebugSettings
 {
+    /// <summary>Keep source outlines visible while the translation is displayed too.</summary>
+    public bool ShowOnTranslation { get; set; } = false;
+
     /// <summary>Outlines each box the recogniser returned.</summary>
     public bool ShowLineBoxes { get; set; } = false;
 

--- a/src/OverTranslate/Resources/Strings.en.xaml
+++ b/src/OverTranslate/Resources/Strings.en.xaml
@@ -473,9 +473,9 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Settings.DebugTools">Debug tools</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">Show OCR debug information</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR boxes</sys:String>
-    <sys:String x:Key="S.Settings.OcrLineBoxesHint">Outlines each box the recogniser returned.</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">Show the source text regions detected by OCR.</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">Text group boxes</sys:String>
-    <sys:String x:Key="S.Settings.TextGroupBoxesHint">Outlines each group those boxes were joined into.</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">Show which source text is grouped together for translation.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">Exporting collects the log files, system information and your current settings into a diagnostic file you can attach to a problem report. Sensitive information such as API keys is not included, and no data is uploaded automatically.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">Export diagnostics</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">Open folder</sys:String>
@@ -560,4 +560,14 @@ The parameter is left out of the request when this is off. Models differ — fol
     <sys:String x:Key="S.Lang.Turkish">Turkish</sys:String>
     <sys:String x:Key="S.Lang.Ukrainian">Ukrainian</sys:String>
 
+    <sys:String x:Key="S.Toolbar.DebugAssist">Debug aids</sys:String>
+    <sys:String x:Key="S.Toolbar.DebugAssistHint">Show translation guide boxes to check text recognition and grouping.</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowMore">Show more</sys:String>
+    <sys:String x:Key="S.Debug.DisplayScope">Display scope</sys:String>
+    <sys:String x:Key="S.Debug.BoxDisplayScope">Box display scope</sys:String>
+    <sys:String x:Key="S.Debug.SourceOnly">Source only</sys:String>
+    <sys:String x:Key="S.Debug.SourceAndTranslation">Source and translation</sys:String>
+    <!-- Two lines, one per half of the switch. xml:space is what keeps the break: without it XAML
+         collapses the &#x0A; away and the two sentences run together. -->
+    <sys:String x:Key="S.Debug.ScopeHint" xml:space="preserve">Source only: outlines are drawn on the source view only.&#x0A;Source and translation: outlines are drawn on both the source view and the translation view</sys:String>
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.ja.xaml
+++ b/src/OverTranslate/Resources/Strings.ja.xaml
@@ -474,9 +474,9 @@
     <sys:String x:Key="S.Settings.DebugTools">デバッグツール</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">OCR デバッグ情報を表示</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 認識枠</sys:String>
-    <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR の認識結果の境界枠を表示します。</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR が検出した原文の文字範囲を表示します。</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">文字グループ枠</sys:String>
-    <sys:String x:Key="S.Settings.TextGroupBoxesHint">文字グループごとの境界枠を表示します。</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">翻訳時に同じグループにまとめられる原文を表示します。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">書き出すと、ログファイル・システム情報・現在の設定を 1 つの診断ファイルにまとめ、問題の報告に添付できます。API キーなどの機微な情報は含まれず、データが自動で送信されることもありません。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">診断情報を書き出す</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">フォルダーを開く</sys:String>
@@ -561,4 +561,14 @@
     <sys:String x:Key="S.Lang.Turkish">トルコ語</sys:String>
     <sys:String x:Key="S.Lang.Ukrainian">ウクライナ語</sys:String>
 
+    <sys:String x:Key="S.Toolbar.DebugAssist">認識補助</sys:String>
+    <sys:String x:Key="S.Toolbar.DebugAssistHint">翻訳補助枠を表示して、文字認識とグループ化の結果を確認できます。</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowMore">もっと表示</sys:String>
+    <sys:String x:Key="S.Debug.DisplayScope">表示範囲</sys:String>
+    <sys:String x:Key="S.Debug.BoxDisplayScope">枠の表示範囲</sys:String>
+    <sys:String x:Key="S.Debug.SourceOnly">原文のみ</sys:String>
+    <sys:String x:Key="S.Debug.SourceAndTranslation">原文と訳文</sys:String>
+    <!-- Two lines, one per half of the switch. xml:space is what keeps the break: without it XAML
+         collapses the &#x0A; away and the two sentences run together. -->
+    <sys:String x:Key="S.Debug.ScopeHint" xml:space="preserve">原文のみ：枠線は原文の画面にのみ表示します。&#x0A;原文と訳文：原文・訳文どちらの画面にも枠線を表示します</sys:String>
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.ko.xaml
+++ b/src/OverTranslate/Resources/Strings.ko.xaml
@@ -474,9 +474,9 @@
     <sys:String x:Key="S.Settings.DebugTools">디버그 도구</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">OCR 디버그 정보 표시</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 인식 상자</sys:String>
-    <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR 인식 결과의 경계 상자를 표시합니다.</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">OCR이 감지한 원문 텍스트 영역을 표시합니다.</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">텍스트 그룹 상자</sys:String>
-    <sys:String x:Key="S.Settings.TextGroupBoxesHint">텍스트 그룹 블록의 경계 상자를 표시합니다.</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">번역할 때 하나의 그룹으로 묶이는 원문을 표시합니다.</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">내보내면 로그 파일, 시스템 정보, 현재 설정을 하나의 진단 파일로 모아 문제 신고에 첨부할 수 있습니다. API 키 같은 민감한 정보는 포함되지 않으며, 어떤 데이터도 자동으로 업로드되지 않습니다.</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">진단 정보 내보내기</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">폴더 열기</sys:String>
@@ -561,4 +561,14 @@
     <sys:String x:Key="S.Lang.Turkish">튀르키예어</sys:String>
     <sys:String x:Key="S.Lang.Ukrainian">우크라이나어</sys:String>
 
+    <sys:String x:Key="S.Toolbar.DebugAssist">인식 보조</sys:String>
+    <sys:String x:Key="S.Toolbar.DebugAssistHint">번역 보조 테두리를 표시하여 문자 인식 및 그룹화 결과를 확인합니다.</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowMore">더 보기</sys:String>
+    <sys:String x:Key="S.Debug.DisplayScope">표시 범위</sys:String>
+    <sys:String x:Key="S.Debug.BoxDisplayScope">테두리 표시 범위</sys:String>
+    <sys:String x:Key="S.Debug.SourceOnly">원문만</sys:String>
+    <sys:String x:Key="S.Debug.SourceAndTranslation">원문과 번역</sys:String>
+    <!-- Two lines, one per half of the switch. xml:space is what keeps the break: without it XAML
+         collapses the &#x0A; away and the two sentences run together. -->
+    <sys:String x:Key="S.Debug.ScopeHint" xml:space="preserve">원문만: 테두리를 원문 화면에만 표시합니다.&#x0A;원문과 번역: 원문과 번역 화면 모두에 테두리를 표시합니다</sys:String>
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.zh-Hans.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hans.xaml
@@ -473,9 +473,9 @@
     <sys:String x:Key="S.Settings.DebugTools">调试工具</sys:String>
     <sys:String x:Key="S.Settings.OcrDebug">显示 OCR 调试信息</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 识别框</sys:String>
-    <sys:String x:Key="S.Settings.OcrLineBoxesHint">显示 OCR 识别结果的边界框。</sys:String>
+    <sys:String x:Key="S.Settings.OcrLineBoxesHint">显示 OCR 检测到的原文文字范围。</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">文字分组框</sys:String>
-    <sys:String x:Key="S.Settings.TextGroupBoxesHint">显示 OCR 文字分组区块的边界框。</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">显示哪些原文会合并为一组进行翻译。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">导出时会将日志文件、系统信息与当前设置整理成诊断文件，方便附在问题反馈中。API 密钥等敏感信息不会包含在内，也不会自动上传任何数据。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">导出诊断信息</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">打开文件夹</sys:String>
@@ -560,4 +560,14 @@
     <sys:String x:Key="S.Lang.Turkish">土耳其语</sys:String>
     <sys:String x:Key="S.Lang.Ukrainian">乌克兰语</sys:String>
 
+    <sys:String x:Key="S.Toolbar.DebugAssist">调试辅助</sys:String>
+    <sys:String x:Key="S.Toolbar.DebugAssistHint">显示翻译辅助框线，方便确认文字识别与组合结果。</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowMore">显示更多</sys:String>
+    <sys:String x:Key="S.Debug.DisplayScope">显示范围</sys:String>
+    <sys:String x:Key="S.Debug.BoxDisplayScope">框线显示范围</sys:String>
+    <sys:String x:Key="S.Debug.SourceOnly">仅原文</sys:String>
+    <sys:String x:Key="S.Debug.SourceAndTranslation">原文与译文</sys:String>
+    <!-- Two lines, one per half of the switch. xml:space is what keeps the break: without it XAML
+         collapses the &#x0A; away and the two sentences run together. -->
+    <sys:String x:Key="S.Debug.ScopeHint" xml:space="preserve">仅原文：框线只显示于原文画面&#x0A;原文与译文：原文、译文画面皆显示框线</sys:String>
 </ResourceDictionary>

--- a/src/OverTranslate/Resources/Strings.zh-Hant.xaml
+++ b/src/OverTranslate/Resources/Strings.zh-Hant.xaml
@@ -497,7 +497,7 @@
     <sys:String x:Key="S.Settings.OcrLineBoxes">OCR 辨識框</sys:String>
     <sys:String x:Key="S.Settings.OcrLineBoxesHint">顯示 OCR 偵測到的原文文字範圍。</sys:String>
     <sys:String x:Key="S.Settings.TextGroupBoxes">文字組合框</sys:String>
-    <sys:String x:Key="S.Settings.TextGroupBoxesHint">顯示原文組合範圍，方便使用者確認哪些文字會被歸為同一組翻譯。</sys:String>
+    <sys:String x:Key="S.Settings.TextGroupBoxesHint">顯示哪些原文會合併為一組進行翻譯。</sys:String>
     <sys:String x:Key="S.Settings.DiagnosticsHint">匯出時會將記錄檔、系統資訊與目前設定整理成診斷檔，方便附在問題回報中。API 金鑰等敏感資訊不會包含在內，也不會自動上傳任何資料。</sys:String>
     <sys:String x:Key="S.Settings.ExportDiagnostics">匯出診斷資訊</sys:String>
     <sys:String x:Key="S.Settings.OpenDiagnosticsFolder">開啟資料夾</sys:String>
@@ -580,4 +580,14 @@
     <sys:String x:Key="S.Lang.Turkish">土耳其文</sys:String>
     <sys:String x:Key="S.Lang.Ukrainian">烏克蘭文</sys:String>
 
+    <sys:String x:Key="S.Toolbar.DebugAssist">偵錯輔助</sys:String>
+    <sys:String x:Key="S.Toolbar.DebugAssistHint">顯示翻譯輔助框線，方便確認文字辨識與組合結果。</sys:String>
+    <sys:String x:Key="S.Toolbar.ShowMore">顯示更多</sys:String>
+    <sys:String x:Key="S.Debug.DisplayScope">顯示範圍</sys:String>
+    <sys:String x:Key="S.Debug.BoxDisplayScope">框線顯示範圍</sys:String>
+    <sys:String x:Key="S.Debug.SourceOnly">僅原文</sys:String>
+    <sys:String x:Key="S.Debug.SourceAndTranslation">原文與譯文</sys:String>
+    <!-- Two lines, one per half of the switch. xml:space is what keeps the break: without it XAML
+         collapses the &#x0A; away and the two sentences run together. -->
+    <sys:String x:Key="S.Debug.ScopeHint" xml:space="preserve">僅原文：框線只顯示於原文畫面&#x0A;原文與譯文：原文、譯文畫面皆顯示框線</sys:String>
 </ResourceDictionary>

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -186,7 +186,7 @@ internal static class OcrTextBlockGrouper
         var gaps = rows.SelectMany(AdjacentGaps).ToList();
         var threshold = SameLineGapThreshold.Estimate(gaps);
 
-        return rows.SelectMany(row => SplitRowIntoLines(row, threshold.Value, decisions, trace, blocks, profile)).ToList();
+        return rows.SelectMany(row => SplitRowIntoLines(row, threshold.Value, decisions, trace, blocks, profile, rows)).ToList();
     }
 
     /// <summary>
@@ -288,7 +288,7 @@ internal static class OcrTextBlockGrouper
     /// </summary>
     private static IEnumerable<OcrTextBlock> SplitRowIntoLines(
         List<OcrTextBlock> row, double threshold, List<NextLineDecision>? decisions, GroupingTrace? trace,
-        IReadOnlyList<OcrTextBlock> blocks, GroupingProfile profile)
+        IReadOnlyList<OcrTextBlock> blocks, GroupingProfile profile, IReadOnlyList<List<OcrTextBlock>> rows)
     {
         var lines = new List<OcrTextBlock>();
         var line = row[0];
@@ -305,6 +305,10 @@ internal static class OcrTextBlockGrouper
                 profile.SolidLineAdvanceWhenWrapped > SolidLineAdvance &&
                 HasSpanningProseContinuation(row[i - 1], row[i], blocks))
                 (joined, rule) = (true, "spanning prose continuation");
+            if (!joined && rule == "horizontal gap" &&
+                profile.SolidLineAdvanceWhenWrapped > SolidLineAdvance &&
+                HasParagraphRowEvidence(row, i, rows, threshold))
+                (joined, rule) = (true, "paragraph row evidence");
             decisions?.Add(SameLineDecision(row[i - 1], row[i], joined, rule, trace));
 
             if (joined)
@@ -344,6 +348,48 @@ internal static class OcrTextBlockGrouper
             Math.Abs(next.LayoutBounds.Right - row.Right) <= height * 0.75 &&
             next.LayoutBounds.Height >= height * 0.75 &&
             next.LayoutBounds.Height <= height * 1.35);
+    }
+
+    // Use several original visual rows, not the result of speculative merges. A complete
+    // nearby row anchors the column; changing cut positions suggest missed inline punctuation.
+    // A recurring gutter is counter-evidence even when a shared heading spans both columns.
+    private static bool HasParagraphRowEvidence(List<OcrTextBlock> row, int rightIndex,
+        IReadOnlyList<List<OcrTextBlock>> rows, double threshold)
+    {
+        var left = row[rightIndex - 1];
+        var right = row[rightIndex];
+        if (NormalizedGap(left, right) > 1.5 || !SharesVisualRow(left, right)) return false;
+        var bounds = RowBounds(row);
+        var height = bounds.Height;
+        if (bounds.Width < height * 12 || row.Any(b => b.LayoutScript != OcrLayoutScript.Latin)) return false;
+        var cut = (left.LayoutBounds.Right + right.LayoutBounds.Left) / 2;
+        var supporting = new List<List<OcrTextBlock>>();
+        foreach (var other in rows)
+        {
+            if (ReferenceEquals(row, other)) continue;
+            var box = RowBounds(other);
+            if (other.Any(b => b.LayoutScript != OcrLayoutScript.Latin) ||
+                box.Height < height * 0.75 || box.Height > height * 1.35 ||
+                Math.Abs(box.Top - bounds.Top) < height * 0.5 ||
+                Math.Abs(box.Top - bounds.Top) > height * 2.5 ||
+                Math.Abs(box.Left - bounds.Left) > height * 0.5 ||
+                Math.Abs(box.Right - bounds.Right) > height * 0.75) continue;
+            for (var i = 1; i < other.Count; i++)
+            {
+                var (joined, _) = JudgeSameLine(other[i - 1], other[i], threshold);
+                var otherCut = (other[i - 1].LayoutBounds.Right + other[i].LayoutBounds.Left) / 2;
+                if (!joined && Math.Abs(otherCut - cut) <= height) return false;
+            }
+            supporting.Add(other);
+        }
+        if (supporting.Count < 2 || !supporting.Any(r => r.Count == 1)) return false;
+        var tops = supporting.Select(RowBounds).Append(bounds).OrderBy(b => b.Top).ToArray();
+        for (var i = 1; i < tops.Length; i++)
+            if (tops[i].Top - tops[i - 1].Top > Math.Min(tops[i].Height, tops[i - 1].Height) * 1.45)
+                return false;
+        return true;
+
+        static Rect RowBounds(List<OcrTextBlock> r) => r.Select(b => b.LayoutBounds).Aggregate(Rect.Union);
     }
 
     private static (bool Joined, string Rule) JudgeSameLine(

--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -588,6 +588,29 @@ internal static class OcrTextBlockGrouper
         return true;
     }
 
+    // A rejected same-row fragment must not be skipped by a wrap into its horizontal span.
+    // Check both ends: a full line may also take only half of the next visual row. Separate
+    // columns remain independent when the continuation does not cross the neighbouring column.
+    private static bool HasUnresolvedRowFragment(
+        OcrTextBlock previous, OcrTextBlock current, IReadOnlyList<OcrTextBlock> lines)
+    {
+        foreach (var other in lines)
+        {
+            if (ReferenceEquals(other, previous) || ReferenceEquals(other, current)) continue;
+            if (Conflicts(previous, current, other) || Conflicts(current, previous, other)) return true;
+        }
+        return false;
+
+        static bool Conflicts(OcrTextBlock rowPart, OcrTextBlock continuation, OcrTextBlock other)
+        {
+            if (!SharesVisualRow(rowPart, other)) return false;
+            var overlap = Math.Min(continuation.LayoutBounds.Right, other.LayoutBounds.Right) -
+                          Math.Max(continuation.LayoutBounds.Left, other.LayoutBounds.Left);
+            // Ignore a few pixels of detector expansion at touching column edges.
+            return overlap > Math.Min(continuation.LayoutBounds.Height, other.LayoutBounds.Height) * 0.2;
+        }
+    }
+
     private static bool CanJoinNextLine(
         List<OcrTextBlock> group,
         OcrTextBlock current,
@@ -605,6 +628,8 @@ internal static class OcrTextBlockGrouper
         if (joined && paragraphFinal &&
             TextSizeRatio(previous, current) < Math.Min(MinTextSizeRatio, profile.TightlySetMinTextSizeRatio))
             rule = "paragraph final line";
+        if (joined && HasUnresolvedRowFragment(previous, current, lines))
+            (joined, rule) = (false, "unresolved row fragment");
         if (decisions is null)
             return joined;
 

--- a/src/OverTranslate/Services/SettingsService.cs
+++ b/src/OverTranslate/Services/SettingsService.cs
@@ -201,6 +201,22 @@ public class SettingsService
     internal static string Serialize(AppSettings settings) =>
         JsonSerializer.Serialize(settings, WriteOptions);
 
+    public event EventHandler? OcrDebugChanged;
+
+    public void UpdateOcrDebug(bool? showLines = null, bool? showGroups = null, bool? showOnTranslation = null)
+    {
+        var debug = Current.OcrDebug;
+        var lines = showLines ?? debug.ShowLineBoxes;
+        var groups = showGroups ?? debug.ShowGroupBoxes;
+        var onTranslation = showOnTranslation ?? debug.ShowOnTranslation;
+        if (lines == debug.ShowLineBoxes && groups == debug.ShowGroupBoxes && onTranslation == debug.ShowOnTranslation) return;
+        debug.ShowOnTranslation = onTranslation;
+        debug.ShowLineBoxes = lines;
+        debug.ShowGroupBoxes = groups;
+        Save();
+        OcrDebugChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     public void Save()
     {
         try

--- a/src/OverTranslate/Themes/SharedStyles.xaml
+++ b/src/OverTranslate/Themes/SharedStyles.xaml
@@ -1044,6 +1044,36 @@
     <!-- ═══════════════════════════════════════════ -->
     <!--  RADIO BUTTON (theme selector pill style)   -->
     <!-- ═══════════════════════════════════════════ -->
+    <Style x:Key="DebugScopeRadio" TargetType="RadioButton">
+        <Setter Property="Foreground" Value="{DynamicResource AppTextPrimary}"/>
+        <Setter Property="FontFamily" Value="{DynamicResource AppFont}"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RadioButton">
+                    <StackPanel Orientation="Horizontal" Background="Transparent">
+                        <Grid Width="18" Height="18" Margin="0,0,10,0">
+                            <Ellipse x:Name="Ring" Stroke="{DynamicResource AppInputBorder}" StrokeThickness="1.5"/>
+                            <Ellipse x:Name="Dot" Width="7" Height="7" Fill="{DynamicResource AppAccentFg}" Visibility="Collapsed"/>
+                        </Grid>
+                        <ContentPresenter VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Ring" Property="Fill" Value="{DynamicResource AppAccent}"/>
+                            <Setter TargetName="Ring" Property="Stroke" Value="{DynamicResource AppAccent}"/>
+                            <Setter TargetName="Dot" Property="Visibility" Value="Visible"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Ring" Property="Stroke" Value="{DynamicResource AppAccent}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="ThemeRadioButton" TargetType="RadioButton">
         <Setter Property="FontFamily"  Value="{DynamicResource AppFont}"/>
         <Setter Property="FontSize"    Value="{StaticResource AppFontSize}"/>
@@ -1158,52 +1188,6 @@
         <Setter Property="TextAlignment"       Value="Center"/>
         <!-- Fixed, so stepping never nudges the buttons in and out by a digit's width -->
         <Setter Property="MinWidth"            Value="28"/>
-    </Style>
-
-    <Style x:Key="SegmentedRadioButton" TargetType="RadioButton">
-        <Setter Property="FontFamily" Value="{DynamicResource AppFont}"/>
-        <Setter Property="FontSize"   Value="{StaticResource AppFontSize}"/>
-        <Setter Property="Foreground" Value="{DynamicResource AppTextPrimary}"/>
-        <Setter Property="Cursor"     Value="Hand"/>
-        <Setter Property="MinWidth"   Value="44"/>
-        <Setter Property="Height"     Value="32"/>
-        <Setter Property="Margin"     Value="0,0,6,0"/>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="RadioButton">
-                    <Border x:Name="Root"
-                            Background="{DynamicResource AppButtonBg}"
-                            BorderBrush="{DynamicResource AppButtonBorder}"
-                            BorderThickness="1"
-                            CornerRadius="6"
-                            Padding="12,0">
-                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                    </Border>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="Root" Property="Background"
-                                    Value="{DynamicResource AppAccent}"/>
-                            <Setter TargetName="Root" Property="BorderBrush"
-                                    Value="{DynamicResource AppAccent}"/>
-                            <Setter Property="Foreground" Value="{DynamicResource AppAccentFg}"/>
-                            <Setter Property="FontWeight" Value="SemiBold"/>
-                        </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsChecked" Value="False"/>
-                                <Condition Property="IsMouseOver" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="Root" Property="Background"
-                                    Value="{DynamicResource AppButtonHoverBg}"/>
-                        </MultiTrigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.45"/>
-                            <Setter Property="Cursor" Value="Arrow"/>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
     </Style>
 
     <!-- ═══════════════════════════════════════════ -->
@@ -1779,9 +1763,9 @@
          on the button can only appear and disappear — so a checked background here would cover it.
          The button contributes the label, the hover step, and nothing else.
 
-         SegmentedRadioButton is the same idea for a settings page and stays as it is: there the
-         options sit on a page with room to breathe and are separate outlined pills, which is the
-         right shape for a form and the wrong one for a bar the user meets over their own screen. -->
+         The 偵錯工具 card in 設定 now says its either/or the same way, with a style of its own for
+         the halves: same mechanism, but sized and spaced for a page rather than for a bar the
+         user meets over their own screen. -->
     <Style x:Key="ToolbarSegmentButton" TargetType="RadioButton">
         <Setter Property="FontFamily"         Value="{DynamicResource AppFont}"/>
         <Setter Property="FontSize"           Value="11"/>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml
@@ -512,11 +512,70 @@
                         </StackPanel>
                     </Button>
 
+                    <Button x:Name="DebugMoreBtn" Style="{StaticResource ToolbarIconButton}"
+                            Width="30" Height="30" Margin="2,0,0,0"
+                            ToolTip="{DynamicResource S.Toolbar.ShowMore}"
+                            AutomationProperties.Name="{DynamicResource S.Toolbar.ShowMore}"
+                            Click="DebugMoreBtn_Click">
+                        <TextBlock Text="&#xE712;" FontFamily="Segoe Fluent Icons, Segoe MDL2 Assets" FontSize="20"/>
+                    </Button>
+                    <Popup x:Name="DebugPopup" PlacementTarget="{Binding ElementName=BarSurface}"
+                           Placement="Bottom" VerticalOffset="6"
+                           AllowsTransparency="True" StaysOpen="False"
+                           Opened="DebugPopup_Opened" Closed="DebugPopup_Closed">
+                        <Border x:Name="DebugPanel" Width="580" Background="{DynamicResource ToolbarBg}"
+                                BorderBrush="{DynamicResource ToolbarBorder}" BorderThickness="1" CornerRadius="12"
+                                Padding="16" PreviewKeyDown="DebugPopup_KeyDown">
+                            <Grid>
+                                <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="Auto"/></Grid.RowDefinitions>
+                                <Grid Margin="0,0,0,16">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{DynamicResource S.Toolbar.DebugAssist}" FontSize="16" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource AppTextPrimary}" VerticalAlignment="Center"/>
+                                        <Border x:Name="DebugHelpIcon" Width="26" Height="26" Margin="4,0,0,0" Background="Transparent"
+                                                Cursor="Help" ToolTip="{DynamicResource S.Toolbar.DebugAssistHint}" ToolTipService.ShowDuration="30000">
+                                            <Border Width="15" Height="15" CornerRadius="7.5" BorderThickness="1"
+                                                    BorderBrush="{DynamicResource AppTextSecondary}">
+                                                <TextBlock Text="?" FontSize="11" Foreground="{DynamicResource AppTextSecondary}"
+                                                           HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                            </Border>
+                                        </Border>
+                                    </StackPanel>
+                                    <Button HorizontalAlignment="Right" Style="{StaticResource ToolbarIconButton}" Content="&#x2715;"
+                                            ToolTip="{DynamicResource S.Common.Close}" Click="DebugClose_Click"/>
+                                </Grid>
+                                <Grid Grid.Row="1">
+                                    <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="1"/><ColumnDefinition Width="210"/></Grid.ColumnDefinitions>
+                                    <StackPanel Margin="6,0,18,0">
+                                        <CheckBox x:Name="DebugGroupsSwitch" Style="{StaticResource ModernCheckBox}"
+                                                  Content="{DynamicResource S.Settings.TextGroupBoxes}"
+                                                  Checked="DebugGroupsSwitch_Changed" Unchecked="DebugGroupsSwitch_Changed"/>
+                                        <TextBlock Margin="24,5,0,14" Text="{DynamicResource S.Settings.TextGroupBoxesHint}" TextWrapping="Wrap"
+                                                   FontSize="12" Foreground="{DynamicResource AppTextSecondary}"/>
+                                        <CheckBox x:Name="DebugLinesSwitch" Style="{StaticResource ModernCheckBox}"
+                                                  Content="{DynamicResource S.Settings.OcrLineBoxes}"
+                                                  Checked="DebugLinesSwitch_Changed" Unchecked="DebugLinesSwitch_Changed"/>
+                                        <TextBlock Margin="24,5,0,0" Text="{DynamicResource S.Settings.OcrLineBoxesHint}" TextWrapping="Wrap"
+                                                   FontSize="12" Foreground="{DynamicResource AppTextSecondary}"/>
+                                    </StackPanel>
+                                    <Border Grid.Column="1" Background="{DynamicResource ToolbarDivider}"/>
+                                    <StackPanel Grid.Column="2" Margin="24,0,0,0">
+                                        <TextBlock Text="{DynamicResource S.Debug.DisplayScope}" Foreground="{DynamicResource AppTextPrimary}" Margin="0,0,0,12"/>
+                                        <RadioButton x:Name="DebugSourceOnly" GroupName="DebugScope" Style="{StaticResource DebugScopeRadio}"
+                                                     Content="{DynamicResource S.Debug.SourceOnly}" Checked="DebugScope_Changed" Margin="0,0,0,12"/>
+                                        <RadioButton x:Name="DebugSourceAndTranslation" GroupName="DebugScope" Style="{StaticResource DebugScopeRadio}"
+                                                     Content="{DynamicResource S.Debug.SourceAndTranslation}" Checked="DebugScope_Changed"/>
+                                    </StackPanel>
+                                </Grid>
+                            </Grid>
+                        </Border>
+                    </Popup>
+
                     <!-- Close, set apart by the gap: everything left of it acts inside the session. -->
                     <Button Content="&#x2715;"
                             Style="{StaticResource ToolbarIconButton}"
                             Width="30" Height="30"
-                            Margin="10,0,0,0"
+                            Margin="6,0,0,0"
                             ToolTip="{DynamicResource S.Toolbar.Close}"
                             AutomationProperties.Name="{DynamicResource S.Toolbar.Close}"
                             Click="CloseBtn_Click"/>

--- a/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
+++ b/src/OverTranslate/Views/Capture/ToolbarWindow.xaml.cs
@@ -48,6 +48,8 @@ public partial class ToolbarWindow : Window
     private bool _hasTranslated;
     private bool _initializingDirection = true;
     private bool _initializingLayoutMode = true;
+    private bool _syncingDebug = true;
+    private bool _ignoreDebugClick;
 
     // Whether there is recognised text to read, and whether it is being read right now. The voice
     // itself lives with the capture session, not here: this window only shows its state.
@@ -89,6 +91,15 @@ public partial class ToolbarWindow : Window
         _selPhysHeight = selPhysHeight;
 
         InitializeComponent();
+        SyncDebugSwitches(this, EventArgs.Empty);
+        SettingsService.Instance.OcrDebugChanged += SyncDebugSwitches;
+        Closed += (_, _) =>
+        {
+            DebugPopup.IsOpen = false;
+            SettingsService.Instance.OcrDebugChanged -= SyncDebugSwitches;
+        };
+        LocationChanged += (_, _) => DebugPopup.IsOpen = false;
+        DebugMoreBtn.MouseLeave += (_, _) => _ignoreDebugClick = false;
 
         bool verticalText = SettingsService.Instance.Current.Capture.VerticalText;
         HorizontalSeg.IsChecked = !verticalText;
@@ -646,6 +657,60 @@ public partial class ToolbarWindow : Window
             // rounding: half a pixel short is a whole character replaced by an ellipsis.
             return Math.Ceiling(widest) + 9 + 28 + 2 + 1;
         }
+    }
+
+    private void SyncDebugSwitches(object? sender, EventArgs e)
+    {
+        _syncingDebug = true;
+        DebugGroupsSwitch.IsChecked = SettingsService.Instance.Current.OcrDebug.ShowGroupBoxes;
+        DebugLinesSwitch.IsChecked = SettingsService.Instance.Current.OcrDebug.ShowLineBoxes;
+        DebugSourceOnly.IsChecked = !SettingsService.Instance.Current.OcrDebug.ShowOnTranslation;
+        DebugSourceAndTranslation.IsChecked = SettingsService.Instance.Current.OcrDebug.ShowOnTranslation;
+        _syncingDebug = false;
+    }
+
+    private void DebugGroupsSwitch_Changed(object sender, RoutedEventArgs e)
+    {
+        if (!_syncingDebug) SettingsService.Instance.UpdateOcrDebug(showGroups: DebugGroupsSwitch.IsChecked == true);
+    }
+
+    private void DebugLinesSwitch_Changed(object sender, RoutedEventArgs e)
+    {
+        if (!_syncingDebug) SettingsService.Instance.UpdateOcrDebug(showLines: DebugLinesSwitch.IsChecked == true);
+    }
+
+    private void DebugMoreBtn_Click(object sender, RoutedEventArgs e)
+    {
+        if (_ignoreDebugClick) { _ignoreDebugClick = false; return; }
+        DebugPopup.HorizontalOffset = Math.Max(0, BarSurface.ActualWidth - DebugPanel.Width);
+        DebugPopup.IsOpen = !DebugPopup.IsOpen;
+    }
+
+    private void DebugScope_Changed(object sender, RoutedEventArgs e)
+    {
+        if (!_syncingDebug)
+            SettingsService.Instance.UpdateOcrDebug(showOnTranslation: ReferenceEquals(sender, DebugSourceAndTranslation));
+    }
+
+    private void DebugClose_Click(object sender, RoutedEventArgs e) => DebugPopup.IsOpen = false;
+
+    private void DebugPopup_Opened(object? sender, EventArgs e)
+    {
+        SyncDebugSwitches(sender, e);
+    }
+
+    private void DebugPopup_Closed(object? sender, EventArgs e)
+    {
+        _ignoreDebugClick = DebugMoreBtn.IsMouseOver &&
+            System.Windows.Input.Mouse.LeftButton == System.Windows.Input.MouseButtonState.Pressed;
+    }
+
+    private void DebugPopup_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+    {
+        if (e.Key != System.Windows.Input.Key.Escape) return;
+        DebugPopup.IsOpen = false;
+        DebugMoreBtn.Focus();
+        e.Handled = true;
     }
 
     private void SaveCurrentLanguageSelection()

--- a/src/OverTranslate/Views/MainWindow.xaml.cs
+++ b/src/OverTranslate/Views/MainWindow.xaml.cs
@@ -618,6 +618,9 @@ public partial class MainWindow : Window
                 _lastSelPhysWidth  = selection.Width;
                 _lastSelPhysHeight = selection.Height;
                 _toolbarWindow?.FollowSelection(selection);
+                // OCR geometry belongs to the old crop until the user recognises this one.
+                _lastOcrBlocks = [];
+                _overlayWindow?.ShowOcrDebug([], selection.Left, selection.Top);
 
                 // The marks stay where they were drawn; what moves is the window onto them. See
                 // OverlayWindow.SetAnnotationBounds for why that is the way round it is.
@@ -908,8 +911,7 @@ public partial class MainWindow : Window
                 _lastSelPhysHeight,
                 LocalizationService.Get("S.Main.Translating"));
 
-            // The reading is known now, and the debug boxes describe the reading — so they go up
-            // here rather than with the translation, and stay up if the translation never arrives.
+            // Recognition is available even while translation is still pending.
             _overlayWindow?.ShowOcrDebug(_lastOcrBlocks, _lastSelPhysLeft, _lastSelPhysTop);
 
             var (translated, _) = await AppServices.Translation.TranslateAsync(
@@ -1119,6 +1121,7 @@ public partial class MainWindow : Window
                 return;
 
             _lastOcrBlocks = recognizedBlocks;
+            _overlayWindow?.ShowOcrDebug(_lastOcrBlocks, _lastSelPhysLeft, _lastSelPhysTop);
             if (_lastOcrBlocks.Count == 0)
             {
                 ShowBalloon(

--- a/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
+++ b/src/OverTranslate/Views/Overlay/OverlayWindow.xaml.cs
@@ -39,6 +39,7 @@ public partial class OverlayWindow : Window
     private static readonly System.Windows.Media.Color TextGroupBoxColor = System.Windows.Media.Color.FromRgb(0xFF, 0xB4, 0x54);
 
     private bool _isLoaded;
+    private bool _translationVisible;
     private List<TranslatedBlock> _currentBlocks;
     private IReadOnlyList<OcrTextBlock> _currentOcrBlocks;
     private double _currentSelectionScreenX;
@@ -62,6 +63,7 @@ public partial class OverlayWindow : Window
     {
         InitializeComponent();
         _currentBlocks = blocks;
+        _translationVisible = blocks.Count > 0;
         _currentOcrBlocks = ocrBlocks;
         _currentSelectionScreenX = selectionScreenX;
         _currentSelectionScreenY = selectionScreenY;
@@ -70,6 +72,8 @@ public partial class OverlayWindow : Window
         _currentSourceLanguage = sourceLanguage;
         _currentTargetLanguage = targetLanguage;
         _currentVerticalText = verticalText;
+        SettingsService.Instance.OcrDebugChanged += OnOcrDebugChanged;
+        Closed += (_, _) => SettingsService.Instance.OcrDebugChanged -= OnOcrDebugChanged;
 
         // Provisional: OnSourceInitialized pins the window to _physBounds instead.
         Left   = SystemParameters.VirtualScreenLeft;
@@ -139,6 +143,9 @@ public partial class OverlayWindow : Window
     // Shows a centered status card and clears old bubbles so the indicator is unobstructed.
     public void ShowProcessing(double selPhysX, double selPhysY, double selPhysW, double selPhysH, string statusText)
     {
+        _currentOcrBlocks = [];
+        _translationVisible = false;
+        UpdateDebugVisibility();
         BubbleBackgroundCanvas.Children.Clear();
         BubbleTextCanvas.Children.Clear();
         DebugCanvas.Children.Clear();
@@ -179,6 +186,8 @@ public partial class OverlayWindow : Window
         IReadOnlyList<OcrTextBlock> ocrBlocks, double selScreenX, double selScreenY)
     {
         _currentOcrBlocks = ocrBlocks;
+        _currentSelectionScreenX = selScreenX;
+        _currentSelectionScreenY = selScreenY;
         if (_isLoaded)
             BuildDebugBoxes(selScreenX, selScreenY);
     }
@@ -793,24 +802,34 @@ public partial class OverlayWindow : Window
 
     private void SetTranslationLayersVisible(bool visible)
     {
+        _translationVisible = visible && _currentBlocks.Count > 0;
         var visibility = visible ? Visibility.Visible : Visibility.Collapsed;
         BubbleBackgroundCanvas.Visibility = visibility;
         BubbleTextCanvas.Visibility = visibility;
-        // DebugCanvas is deliberately not switched with them. These boxes are drawn around the
-        // source text, so 顯示原文 is the moment they are most worth seeing — the boxes and the words
-        // they were measured from, together.
+        UpdateDebugVisibility();
     }
 
-    /// <summary>
-    /// Draws the OCR geometry the debug setting asks for, in the selection's own coordinates.
-    /// </summary>
-    /// <remarks>
-    /// Groups first so the lines land on top of them: where the two coincide the finer box is the
-    /// one worth reading, and it is the one that says what the recogniser actually returned.
-    /// </remarks>
+    private void UpdateDebugVisibility()
+    {
+        DebugCanvas.Visibility = !_translationVisible || SettingsService.Instance.Current.OcrDebug.ShowOnTranslation
+            ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void OnOcrDebugChanged(object? sender, EventArgs e)
+    {
+        if (!Dispatcher.CheckAccess())
+        {
+            Dispatcher.Invoke(() => OnOcrDebugChanged(sender, e));
+            return;
+        }
+        if (_isLoaded) BuildDebugBoxes(_currentSelectionScreenX, _currentSelectionScreenY);
+    }
+
+    /// <summary>Draws the current source lines and groups, with lines on top of group outlines.</summary>
     private void BuildDebugBoxes(double selScreenX, double selScreenY)
     {
         DebugCanvas.Children.Clear();
+        UpdateDebugVisibility();
 
         var debug = SettingsService.Instance.Current.OcrDebug;
         if (_currentOcrBlocks.Count == 0) return;

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml
@@ -25,6 +25,41 @@
             <Setter Property="VerticalAlignment" Value="Top"/>
             <Setter Property="Margin"            Value="10,1,10,0"/>
         </Style>
+        <!-- One half of the sliding two-way switch in 偵錯工具. It paints no background of its own,
+             checked or not: the marker behind it is what says which half is chosen, and a fill here
+             would cover it. The button contributes the label, the hover step, and nothing else.
+             Nothing about the text changes with the state either — a weight that thickened on the
+             chosen half would widen its column and shift the switch under the pointer. -->
+        <Style x:Key="SegmentedTrackRadio" TargetType="RadioButton">
+            <Setter Property="FontFamily" Value="{DynamicResource AppFont}"/>
+            <Setter Property="FontSize"   Value="{StaticResource AppFontSize}"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppTextSecondary}"/>
+            <Setter Property="Cursor"     Value="Hand"/>
+            <Setter Property="Height"     Value="28"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="RadioButton">
+                        <!-- Transparent rather than unpainted, so the whole half takes the click
+                             and not just the glyphs of the label. -->
+                        <Border Background="Transparent" Padding="16,0">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsChecked" Value="True">
+                    <Setter Property="Foreground" Value="{DynamicResource AppAccentFg}"/>
+                </Trigger>
+                <MultiTrigger>
+                    <MultiTrigger.Conditions>
+                        <Condition Property="IsChecked"   Value="False"/>
+                        <Condition Property="IsMouseOver" Value="True"/>
+                    </MultiTrigger.Conditions>
+                    <Setter Property="Foreground" Value="{DynamicResource AppTextPrimary}"/>
+                </MultiTrigger>
+            </Style.Triggers>
+        </Style>
         <Style x:Key="CardFoldFocusVisual">
             <Setter Property="Control.Template">
                 <Setter.Value>
@@ -1355,43 +1390,96 @@
                                                    Text="&#xE890;"
                                                    Style="{StaticResource OptionGlyph}"
                                                    Margin="0,1,10,0"/>
+                                        <!-- Two points over the settings under it, because it is the
+                                             heading they hang off rather than a fourth option in the
+                                             list; at the page's body size it read as one of them. -->
                                         <TextBlock Grid.Column="1"
                                                    Text="{DynamicResource S.Settings.OcrDebug}"
-                                                   Style="{StaticResource OptionTitle}"/>
+                                                   Style="{StaticResource OptionTitle}"
+                                                   FontSize="15"/>
                                     </Grid>
 
-                                    <Grid Margin="25,14,0,0">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="Auto"/>
-                                        </Grid.RowDefinitions>
-                                        <CheckBox  Grid.Row="1" Grid.Column="0" x:Name="OcrLineBoxesCheckBox"
-                                                   Style="{StaticResource ModernCheckBox}"
-                                                   VerticalAlignment="Top"
-                                                   Checked="OcrDebugBoxes_Toggled"
-                                                   Unchecked="OcrDebugBoxes_Toggled"/>
-                                        <StackPanel Grid.Row="1" Grid.Column="1">
-                                            <TextBlock Text="{DynamicResource S.Settings.OcrLineBoxes}"
-                                                       Style="{StaticResource OptionTitle}"/>
-                                            <TextBlock Text="{DynamicResource S.Settings.OcrLineBoxesHint}"
-                                                       Style="{StaticResource OptionDescription}"/>
-                                        </StackPanel>
-                                        <CheckBox  Grid.Row="0" Grid.Column="0" x:Name="TextGroupBoxesCheckBox"
-                                                   Style="{StaticResource ModernCheckBox}"
-                                                   VerticalAlignment="Top"
-                                                   Checked="OcrDebugBoxes_Toggled"
-                                                   Unchecked="OcrDebugBoxes_Toggled"/>
-                                        <StackPanel Grid.Row="0" Grid.Column="1" Margin="0,0,0,12">
-                                            <TextBlock Text="{DynamicResource S.Settings.TextGroupBoxes}"
-                                                       Style="{StaticResource OptionTitle}"/>
-                                            <TextBlock Text="{DynamicResource S.Settings.TextGroupBoxesHint}"
-                                                       Style="{StaticResource OptionDescription}"/>
-                                        </StackPanel>
-                                    </Grid>
+                                    <StackPanel Margin="25,14,0,0">
+                                        <!-- Each sentence under the box it explains rather than
+                                             beside it: the pair then reads as two blocks down the
+                                             column instead of a two-column table, and a longer
+                                             translation wraps into the width of the card rather
+                                             than into a narrow second column. -->
+                                        <CheckBox x:Name="TextGroupBoxesCheckBox" Content="{DynamicResource S.Settings.TextGroupBoxes}"
+                                                  Style="{StaticResource ModernCheckBox}"
+                                                  Checked="OcrDebugBoxes_Toggled" Unchecked="OcrDebugBoxes_Toggled"/>
+                                        <!-- Indented past the tick and its gap, so the sentence
+                                             starts under the name it belongs to. -->
+                                        <TextBlock Text="{DynamicResource S.Settings.TextGroupBoxesHint}"
+                                                   Style="{StaticResource OptionDescription}" Margin="24,5,0,0"/>
+                                        <CheckBox x:Name="OcrLineBoxesCheckBox" Content="{DynamicResource S.Settings.OcrLineBoxes}"
+                                                  Style="{StaticResource ModernCheckBox}" Margin="0,14,0,0"
+                                                  Checked="OcrDebugBoxes_Toggled" Unchecked="OcrDebugBoxes_Toggled"/>
+                                        <TextBlock Text="{DynamicResource S.Settings.OcrLineBoxesHint}"
+                                                   Style="{StaticResource OptionDescription}" Margin="24,5,0,0"/>
+                                        <Border BorderBrush="{DynamicResource AppBorder}" BorderThickness="0,1,0,0"
+                                                Margin="0,16,0,0" Padding="0,12,0,0">
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{DynamicResource S.Debug.BoxDisplayScope}" Style="{StaticResource OptionTitle}" VerticalAlignment="Center"/>
+                                                <Border Width="15" Height="15" CornerRadius="7.5" BorderThickness="1" Cursor="Help"
+                                                        ToolTip="{DynamicResource S.Debug.ScopeHint}" BorderBrush="{DynamicResource AppTextSecondary}"
+                                                        VerticalAlignment="Center" Margin="10,0,20,0" Background="Transparent">
+                                                    <TextBlock Text="?" FontSize="11" Foreground="{DynamicResource AppTextSecondary}"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                </Border>
+                                                <!-- One control with two halves rather than two buttons:
+                                                     the pair is a single either/or, and a tray with a
+                                                     marker sliding between the halves says that, where
+                                                     two separately outlined pills say two things that
+                                                     happen to sit side by side. The marker also carries
+                                                     the change - the choice travels from one half to the
+                                                     other instead of being repainted in place. -->
+                                                <Border Background="{DynamicResource AppButtonBg}"
+                                                        BorderBrush="{DynamicResource AppButtonBorder}"
+                                                        BorderThickness="1"
+                                                        CornerRadius="8"
+                                                        Padding="3"
+                                                        VerticalAlignment="Center"
+                                                        Grid.IsSharedSizeScope="True">
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <!-- Shared for the reason the capture toolbar's
+                                                                 trays share theirs: an even split is what
+                                                                 lets the marker travel one fixed distance,
+                                                                 and it is the marker's own width. Star would
+                                                                 not do it — the tray is only as wide as it
+                                                                 asks to be, so star columns settle at each
+                                                                 label's own width and the shorter half comes
+                                                                 out narrower than the marker needs. -->
+                                                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsDebugScopeSegment"/>
+                                                            <ColumnDefinition Width="Auto" SharedSizeGroup="SettingsDebugScopeSegment"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <!-- Behind the labels and one half wide. It has to be
+                                                             an element of its own: a background on the checked
+                                                             button can only appear and disappear, and this one
+                                                             has to travel. -->
+                                                        <Border x:Name="DebugScopeThumb"
+                                                                Grid.Column="0"
+                                                                Background="{DynamicResource AppAccent}"
+                                                                CornerRadius="6"
+                                                                SizeChanged="DebugScopeThumb_SizeChanged">
+                                                            <Border.RenderTransform>
+                                                                <TranslateTransform x:Name="DebugScopeThumbShift"/>
+                                                            </Border.RenderTransform>
+                                                        </Border>
+                                                        <RadioButton x:Name="DebugSourceOnlyRadio" Grid.Column="0" GroupName="SettingsDebugScope"
+                                                                     Style="{StaticResource SegmentedTrackRadio}"
+                                                                     Content="{DynamicResource S.Debug.SourceOnly}"
+                                                                     Checked="OcrDebugScope_Changed"/>
+                                                        <RadioButton x:Name="DebugSourceAndTranslationRadio" Grid.Column="1" GroupName="SettingsDebugScope"
+                                                                     Style="{StaticResource SegmentedTrackRadio}"
+                                                                     Content="{DynamicResource S.Debug.SourceAndTranslation}"
+                                                                     Checked="OcrDebugScope_Changed"/>
+                                                    </Grid>
+                                                </Border>
+                                            </StackPanel>
+                                        </Border>
+                                    </StackPanel>
                                 </StackPanel>
                             </Border>
                         </StackPanel>

--- a/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
+++ b/src/OverTranslate/Views/Settings/SettingsPage.xaml.cs
@@ -158,10 +158,16 @@ public partial class SettingsPage : UserControl
         // Unloaded without re-subscribing on Loaded would leave it deaf from the first time the
         // user navigated away. A static event holding an instance handler also has to be let go
         // of at some point, which rules out subscribing only once.
-        Loaded   += (_, _) => LocalizationService.LanguageChanged += OnLanguageChanged;
+        Loaded   += (_, _) =>
+        {
+            LocalizationService.LanguageChanged += OnLanguageChanged;
+            SettingsService.Instance.OcrDebugChanged += OnOcrDebugChanged;
+            OnOcrDebugChanged(this, EventArgs.Empty);
+        };
         Unloaded += (_, _) =>
         {
             LocalizationService.LanguageChanged -= OnLanguageChanged;
+            SettingsService.Instance.OcrDebugChanged -= OnOcrDebugChanged;
             StopRecording();
         };
 
@@ -220,6 +226,8 @@ public partial class SettingsPage : UserControl
 
             OcrLineBoxesCheckBox.IsChecked = s.OcrDebug.ShowLineBoxes;
             TextGroupBoxesCheckBox.IsChecked = s.OcrDebug.ShowGroupBoxes;
+            DebugSourceOnlyRadio.IsChecked = !s.OcrDebug.ShowOnTranslation;
+            DebugSourceAndTranslationRadio.IsChecked = s.OcrDebug.ShowOnTranslation;
 
             RefreshServiceTiles();
             UpdateScreenshotPathVisibility();
@@ -618,12 +626,76 @@ public partial class SettingsPage : UserControl
 
         bool lines = OcrLineBoxesCheckBox.IsChecked == true;
         bool groups = TextGroupBoxesCheckBox.IsChecked == true;
-        Persist(s =>
-        {
-            s.OcrDebug.ShowLineBoxes = lines;
-            s.OcrDebug.ShowGroupBoxes = groups;
-        });
+        SettingsService.Instance.UpdateOcrDebug(lines, groups);
+        FlashSaved();
     }
+
+    private void OnOcrDebugChanged(object? sender, EventArgs e)
+    {
+        var loading = _loading;
+        _loading = true;
+        try
+        {
+            OcrLineBoxesCheckBox.IsChecked = SettingsService.Instance.Current.OcrDebug.ShowLineBoxes;
+            TextGroupBoxesCheckBox.IsChecked = SettingsService.Instance.Current.OcrDebug.ShowGroupBoxes;
+            DebugSourceOnlyRadio.IsChecked = !SettingsService.Instance.Current.OcrDebug.ShowOnTranslation;
+            DebugSourceAndTranslationRadio.IsChecked = SettingsService.Instance.Current.OcrDebug.ShowOnTranslation;
+        }
+        finally { _loading = loading; }
+    }
+
+    private void OcrDebugScope_Changed(object sender, RoutedEventArgs e)
+    {
+        // Ahead of the guard, because the marker has to follow the choice however it was made —
+        // including the write coming back from the capture toolbar, which arrives with _loading set.
+        MoveDebugScopeThumb(animate: true);
+
+        if (_loading) return;
+        SettingsService.Instance.UpdateOcrDebug(showOnTranslation: ReferenceEquals(sender, DebugSourceAndTranslationRadio));
+        FlashSaved();
+    }
+
+    /// <summary>
+    /// Puts the marker under the chosen half of the 框線顯示範圍 switch.
+    /// </summary>
+    /// <remarks>
+    /// The travel is the marker's own width, because the two halves share a column size — see the
+    /// tray's ColumnDefinitions. Measured rather than fixed: the halves are sized to the longer of
+    /// two labels, which is a different number in every language.
+    /// </remarks>
+    private void MoveDebugScopeThumb(bool animate)
+    {
+        var target = DebugSourceAndTranslationRadio.IsChecked == true
+            ? DebugScopeThumb.ActualWidth
+            : 0;
+
+        // Before the tray has been laid out there is no distance to travel and nothing to see; the
+        // marker's own SizeChanged runs this again once the shared columns have their final width.
+        if (!animate || DebugScopeThumb.ActualWidth <= 0 || !SystemParameters.ClientAreaAnimation)
+        {
+            DebugScopeThumbShift.BeginAnimation(TranslateTransform.XProperty, null);
+            DebugScopeThumbShift.X = target;
+            return;
+        }
+
+        DebugScopeThumbShift.BeginAnimation(
+            TranslateTransform.XProperty,
+            new DoubleAnimation(target, DebugScopeSlideDuration) { EasingFunction = DebugFoldEasing });
+    }
+
+    /// <summary>
+    /// The capture toolbar's trays, so the same control does not travel at two speeds in one app.
+    /// Shorter than the fold: this is a marker crossing a gap, not a card opening.
+    /// </summary>
+    private static readonly Duration DebugScopeSlideDuration = new(TimeSpan.FromMilliseconds(220));
+
+    /// <summary>
+    /// The half's width is not known until the card has been opened once and laid out, so the marker
+    /// is placed again whenever that number arrives or changes — without animating, since this is
+    /// the switch being measured rather than the choice being changed.
+    /// </summary>
+    private void DebugScopeThumb_SizeChanged(object sender, SizeChangedEventArgs e) =>
+        MoveDebugScopeThumb(animate: false);
 
     /// <summary>
     /// An environment variable outranks this setting, so when one is set the checkbox says so rather

--- a/tests/OverTranslate.Tests/Fixtures/WebParagraphs/split-rows.json
+++ b/tests/OverTranslate.Tests/Fixtures/WebParagraphs/split-rows.json
@@ -1,0 +1,209 @@
+[
+  {
+    "Image": ".ai/test-images/web-v4/2.png",
+    "Flow": "screenshot",
+    "Language": "EN",
+    "Blocks": [
+      {
+        "Text": "Compared as a version rather than for equality, so it silences that release and nothing later:",
+        "Bounds": [
+          2,
+          3,
+          666,
+          21
+        ],
+        "LayoutBounds": [
+          2,
+          3,
+          666,
+          21
+        ],
+        "Script": 1,
+        "Glyph": 10.959493670886078,
+        "Render": 10.959493670886078,
+        "Confidence": 0.9999268054962158,
+        "Ink": 7
+      },
+      {
+        "Text": "1.9.1",
+        "Bounds": [
+          157,
+          19,
+          42,
+          20
+        ],
+        "LayoutBounds": [
+          157,
+          19,
+          42,
+          20
+        ],
+        "Script": 1,
+        "Glyph": 10.920000000000002,
+        "Render": 10.920000000000002,
+        "Confidence": 0.9965400695800781,
+        "Ink": null
+      },
+      {
+        "Text": "skipping 1.9.0 leaves",
+        "Bounds": [
+          1,
+          20,
+          157,
+          21
+        ],
+        "LayoutBounds": [
+          1,
+          20,
+          157,
+          21
+        ],
+        "Script": 1,
+        "Glyph": 10.742105263157896,
+        "Render": 10.742105263157896,
+        "Confidence": 0.9977436065673828,
+        "Ink": null
+      },
+      {
+        "Text": "free to",
+        "Bounds": [
+          198,
+          21,
+          59,
+          18
+        ],
+        "LayoutBounds": [
+          198,
+          21,
+          59,
+          18
+        ],
+        "Script": 1,
+        "Glyph": 12.783333333333335,
+        "Render": 12.783333333333335,
+        "Confidence": 0.9999198317527771,
+        "Ink": null
+      },
+      {
+        "Text": "prompt again. It",
+        "Bounds": [
+          250,
+          22,
+          129,
+          18
+        ],
+        "LayoutBounds": [
+          250,
+          22,
+          129,
+          18
+        ],
+        "Script": 1,
+        "Glyph": 11.978571428571428,
+        "Render": 11.978571428571428,
+        "Confidence": 0.9959279894828796,
+        "Ink": null
+      },
+      {
+        "Text": "suppresses only the startup dialog",
+        "Bounds": [
+          371,
+          22,
+          248,
+          18
+        ],
+        "LayoutBounds": [
+          371,
+          22,
+          248,
+          18
+        ],
+        "Script": 1,
+        "Glyph": 10.746666666666668,
+        "Render": 10.746666666666668,
+        "Confidence": 0.9997453689575195,
+        "Ink": 9
+      },
+      {
+        "Text": "the",
+        "Bounds": [
+          642,
+          22,
+          25,
+          16
+        ],
+        "LayoutBounds": [
+          642,
+          22,
+          25,
+          16
+        ],
+        "Script": 1,
+        "Glyph": 8,
+        "Render": 8,
+        "Confidence": 0.9999714493751526,
+        "Ink": null
+      },
+      {
+        "Text": "nav rail still offers the update",
+        "Bounds": [
+          2,
+          38,
+          233,
+          18
+        ],
+        "LayoutBounds": [
+          2,
+          38,
+          233,
+          18
+        ],
+        "Script": 1,
+        "Glyph": 11.218518518518518,
+        "Render": 11.218518518518518,
+        "Confidence": 0.9997214674949646,
+        "Ink": 10
+      },
+      {
+        "Text": "because what the user declined was being interrupted, not",
+        "Bounds": [
+          256,
+          39,
+          404,
+          18
+        ],
+        "LayoutBounds": [
+          256,
+          39,
+          404,
+          18
+        ],
+        "Script": 1,
+        "Glyph": 10.718367346938775,
+        "Render": 10.718367346938775,
+        "Confidence": 0.9953911900520325,
+        "Ink": 10
+      },
+      {
+        "Text": "the update itself. See \u003Csee cref=\u0022Services.UpdateNotifier\u0022/\u003E",
+        "Bounds": [
+          3,
+          55,
+          427,
+          17
+        ],
+        "LayoutBounds": [
+          3,
+          55,
+          427,
+          17
+        ],
+        "Script": 1,
+        "Glyph": 10.092727272727274,
+        "Render": 10.092727272727274,
+        "Confidence": 0.9987576007843018,
+        "Ink": 10
+      }
+    ]
+  }
+]

--- a/tests/OverTranslate.Tests/OcrDebugLiveUpdateTests.cs
+++ b/tests/OverTranslate.Tests/OcrDebugLiveUpdateTests.cs
@@ -1,0 +1,137 @@
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Xml.Linq;
+using OverTranslate.Services;
+using OverTranslate.Views.Overlay;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class OcrDebugLiveUpdateTests
+{
+    [Fact]
+    public void CachedRecognitionAppearsImmediatelyAndClearsForANewSelection() => OnSta(() =>
+    {
+        var settings = SettingsService.Instance;
+        var debug = settings.Current.OcrDebug;
+        var oldLines = debug.ShowLineBoxes;
+        var oldGroups = debug.ShowGroupBoxes;
+        debug.ShowLineBoxes = debug.ShowGroupBoxes = false;
+        var window = new OverlayWindow([], [], 0, 0, 100, 100, "EN", "ZH-HANT", false);
+        var eventField = typeof(SettingsService).GetField("OcrDebugChanged", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        void Notify() => ((EventHandler?)eventField.GetValue(settings))?.Invoke(settings, EventArgs.Empty);
+        try
+        {
+            typeof(OverlayWindow).GetField("_isLoaded", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, true);
+            var canvas = (Canvas)window.FindName("DebugCanvas");
+            window.ShowOcrDebug([new OcrTextBlock("recognized but not translated", new Rect(2, 3, 50, 20),
+                [new Rect(2, 3, 50, 9), new Rect(2, 14, 50, 9)])], 120, 230);
+            Assert.Empty(canvas.Children);
+            // Deliver the real settings notification without writing the user's settings file.
+            debug.ShowGroupBoxes = true;
+            Notify();
+            Assert.Single(canvas.Children.Cast<UIElement>());
+            debug.ShowLineBoxes = true;
+            Notify();
+            Assert.Equal(3, canvas.Children.Count);
+            var box = (FrameworkElement)canvas.Children[0];
+            Assert.True(double.IsFinite(Canvas.GetLeft(box)));
+            Assert.Null(window.RenderOverlayForSelection(120, 230, 100, 100));
+            window.SetBubblesVisible(false);
+            Assert.Equal(Visibility.Visible, canvas.Visibility);
+            debug.ShowGroupBoxes = false;
+            Notify();
+            Assert.Equal(2, canvas.Children.Count);
+            window.ShowOcrDebug([], 500, 600);
+            Notify();
+            Assert.Empty(canvas.Children);
+        }
+        finally
+        {
+            window.Close();
+            debug.ShowLineBoxes = oldLines;
+            debug.ShowGroupBoxes = oldGroups;
+        }
+        Assert.DoesNotContain(((EventHandler?)eventField.GetValue(settings))?.GetInvocationList() ?? [],
+            handler => ReferenceEquals(handler.Target, window));
+    });
+
+    [Fact]
+    public void PopupDismissesOutsideAndUsesTheSharedSettingsSwitches()
+    {
+        XNamespace x = "http://schemas.microsoft.com/winfx/2006/xaml";
+        var document = XDocument.Load(Path.Combine(StringsParityTests.ProjectDirectory(), "Views", "Capture", "ToolbarWindow.xaml"));
+        var popup = document.Descendants().Single(e => (string?)e.Attribute(x + "Name") == "DebugPopup");
+        Assert.Equal("False", (string?)popup.Attribute("StaysOpen"));
+        Assert.Equal("{Binding ElementName=BarSurface}", (string?)popup.Attribute("PlacementTarget"));
+        Assert.Equal("Bottom", (string?)popup.Attribute("Placement"));
+        Assert.Equal("6", (string?)popup.Attribute("VerticalOffset"));
+        Assert.DoesNotContain(popup.Descendants(), e => (string?)e.Attribute(x + "Name") == "DebugPointer");
+        var more = document.Descendants().Single(e => (string?)e.Attribute(x + "Name") == "DebugMoreBtn");
+        Assert.Equal("{StaticResource ToolbarIconButton}", (string?)more.Attribute("Style"));
+        Assert.Null(more.Attribute("Background"));
+        Assert.Equal("30", (string?)more.Attribute("Width"));
+        Assert.Equal("30", (string?)more.Attribute("Height"));
+        Assert.Equal("{DynamicResource S.Toolbar.ShowMore}", (string?)more.Attribute("ToolTip"));
+        var help = popup.Descendants().Single(e => (string?)e.Attribute(x + "Name") == "DebugHelpIcon");
+        Assert.Equal("Border", help.Name.LocalName);
+        Assert.Equal("Help", (string?)help.Attribute("Cursor"));
+        Assert.Equal("{DynamicResource S.Toolbar.DebugAssistHint}", (string?)help.Attribute("ToolTip"));
+        Assert.Null(help.Attribute("Click"));
+        Assert.Equal(new[] { "DebugGroupsSwitch", "DebugLinesSwitch" },
+            popup.Descendants().Where(e => e.Name.LocalName == "CheckBox").Select(e => (string?)e.Attribute(x + "Name")));
+    }
+
+    [Fact]
+    public void ScopeSwitchesImmediatelyBetweenSourceAndTranslation() => OnSta(() =>
+    {
+        var settings = SettingsService.Instance;
+        var debug = settings.Current.OcrDebug;
+        var oldScope = debug.ShowOnTranslation;
+        var oldGroups = debug.ShowGroupBoxes;
+        debug.ShowOnTranslation = false;
+        debug.ShowGroupBoxes = true;
+        var bounds = new Rect(2, 3, 50, 20);
+        var window = new OverlayWindow([new TranslatedBlock("source", "translation", bounds)], [], 0, 0, 100, 100, "EN", "ZH-HANT", false);
+        var eventField = typeof(SettingsService).GetField("OcrDebugChanged", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        try
+        {
+            typeof(OverlayWindow).GetField("_isLoaded", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, true);
+            var canvas = (Canvas)window.FindName("DebugCanvas");
+            window.ShowOcrDebug([new OcrTextBlock("source", bounds)], 0, 0);
+            Assert.NotEmpty(canvas.Children.Cast<UIElement>());
+            Assert.Equal(Visibility.Collapsed, canvas.Visibility);
+            window.SetBubblesVisible(false);
+            Assert.Equal(Visibility.Visible, canvas.Visibility);
+            window.SetBubblesVisible(true);
+            Assert.Equal(Visibility.Collapsed, canvas.Visibility);
+            debug.ShowOnTranslation = true;
+            ((EventHandler?)eventField.GetValue(settings))?.Invoke(settings, EventArgs.Empty);
+            Assert.Equal(Visibility.Visible, canvas.Visibility);
+            debug.ShowOnTranslation = false;
+            ((EventHandler?)eventField.GetValue(settings))?.Invoke(settings, EventArgs.Empty);
+            Assert.Equal(Visibility.Collapsed, canvas.Visibility);
+            window.ShowProcessing(0, 0, 100, 100, "processing");
+            window.ShowOcrDebug([new OcrTextBlock("new source", bounds)], 0, 0);
+            Assert.Equal(Visibility.Visible, canvas.Visibility);
+        }
+        finally
+        {
+            window.Close();
+            debug.ShowOnTranslation = oldScope;
+            debug.ShowGroupBoxes = oldGroups;
+        }
+    });
+
+    private static void OnSta(Action action)
+    {
+        Exception? error = null;
+        var thread = new Thread(() => { try { action(); } catch (Exception ex) { error = ex; } });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (error is not null) ExceptionDispatchInfo.Capture(error).Throw();
+    }
+}

--- a/tests/OverTranslate.Tests/ParagraphRowEvidenceTests.cs
+++ b/tests/OverTranslate.Tests/ParagraphRowEvidenceTests.cs
@@ -1,0 +1,85 @@
+using System.Windows;
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class ParagraphRowEvidenceTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void StaggeredCutsUnderACompleteRowRejoinInVisualOrder(bool reversedInput)
+    {
+        var input = Article();
+        var expected = string.Join(" ", input.Select(b => b.Text));
+        if (reversedInput) Array.Reverse(input);
+        var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
+        var output = OcrTextBlockGrouper.Group(input, GroupingProfile.General, decisions);
+        Assert.Equal(expected, Assert.Single(output).Text);
+        Assert.Equal(2, decisions.Count(d => d.Joined && d.Rule == "paragraph row evidence"));
+    }
+
+    [Theory]
+    [InlineData("no-anchor")]
+    [InlineData("large-heading")]
+    [InlineData("repeated-gutter")]
+    [InlineData("wide-gap")]
+    [InlineData("loose-rows")]
+    [InlineData("mixed-script")]
+    public void InsufficientOrColumnLikeEvidenceDoesNotEnableNewRowMerges(string variant)
+    {
+        var input = Article();
+        switch (variant)
+        {
+            case "no-anchor": input = input.Skip(1).ToArray(); break;
+            case "large-heading": input[0] = B(input[0].Text, 0, -15, 660, 35); break;
+            case "repeated-gutter":
+                input[3] = B(input[3].Text, 0, 40, 610);
+                input[4] = B(input[4].Text, 634, 40, 26);
+                break;
+            case "wide-gap":
+                input[1] = B(input[1].Text, 0, 20, 580);
+                input[3] = B(input[3].Text, 0, 40, 180);
+                break;
+            case "loose-rows":
+                input[3] = B(input[3].Text, 0, 60, 230);
+                input[4] = B(input[4].Text, 254, 60, 406);
+                break;
+            case "mixed-script": input[0] = input[0] with { LayoutScript = OcrLayoutScript.Mixed }; break;
+        }
+        var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
+        var trace = new GroupingTrace();
+        OcrTextBlockGrouper.Group(input, GroupingProfile.General, decisions, trace);
+        Assert.DoesNotContain(decisions, d => d.Joined && d.Rule == "paragraph row evidence");
+        // In particular, the short right fragment on row two must remain separate.
+        var right = Array.FindIndex(input, b => b.Text == "the");
+        Assert.Contains(trace.Lines, line => line.SourceIds.SequenceEqual(new[] { $"b{right}" }));
+    }
+
+    [Fact]
+    public void NonGeneralProfilesKeepTheirExistingRowDecisions()
+    {
+        foreach (var profile in new[] { GroupingProfile.Interface, GroupingProfile.Realtime })
+        {
+            var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
+            OcrTextBlockGrouper.Group(Article(), profile, decisions);
+            Assert.DoesNotContain(decisions, d => d.Rule == "paragraph row evidence");
+        }
+    }
+
+    private static OcrTextBlock[] Article() => [
+        B("A complete line establishes the edges of this ordinary paragraph", 0, 0, 660),
+        B("The next line continues until the missing separator before", 0, 20, 610),
+        B("the", 634, 20, 26),
+        B("next part continues", 0, 40, 230),
+        B("with the rest of this last sentence.", 254, 40, 406)];
+
+    private static OcrTextBlock B(string text, double x, double y, double width, double height = 20)
+    {
+        var box = new Rect(x, y, width, height);
+        return new(text, box, LayoutBounds: box, LayoutScript: OcrLayoutScript.Latin,
+            LayoutGlyphHeight: 12, RenderGlyphHeight: 12);
+    }
+}

--- a/tests/OverTranslate.Tests/ReadingOrderGroupingTests.cs
+++ b/tests/OverTranslate.Tests/ReadingOrderGroupingTests.cs
@@ -10,10 +10,11 @@ namespace OverTranslate.Tests;
 public class ReadingOrderGroupingTests
 {
     [Theory]
-    [InlineData(0.5)]
-    [InlineData(1.0)]
-    [InlineData(2.0)]
-    public void CapturedArticleRetainsEveryFragmentInReadingOrder(double scale)
+    [InlineData(0.5, false)]
+    [InlineData(1.0, false)]
+    [InlineData(2.0, false)]
+    [InlineData(1.0, true)]
+    public void CapturedArticleRetainsEveryFragmentInReadingOrder(double scale, bool interfaceMode)
     {
         using var json = JsonDocument.Parse(File.ReadAllText(Path.Combine(AppContext.BaseDirectory,
             "Fixtures", "WebParagraphs", "split-rows.json")));
@@ -32,14 +33,18 @@ public class ReadingOrderGroupingTests
         }).ToArray();
         var trace = new GroupingTrace();
         var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
-        var groups = OcrTextBlockGrouper.Group(blocks, GroupingProfile.General, decisions, trace);
+        var profile = interfaceMode ? GroupingProfile.Interface : GroupingProfile.General;
+        var groups = OcrTextBlockGrouper.Group(blocks, profile, decisions, trace);
         var sources = trace.Lines.ToDictionary(line => line.Id, line => line.SourceIds);
         Assert.Equal(new[] { "b0", "b2", "b1", "b3", "b4", "b5", "b6", "b7", "b8", "b9" },
             trace.Groups.SelectMany(group => group.SelectMany(id => sources[id])));
         Assert.Equal(string.Join(" ", new[] { 0, 2, 1, 3, 4, 5, 6, 7, 8, 9 }.Select(i => blocks[i].Text)),
             string.Join(" ", groups.Select(g => g.Text)));
-        Assert.Contains(decisions, d => !d.Joined && d.Rule == "unresolved row fragment");
-        Assert.Equal(groups.Select(g => g.Text), OcrTextBlockGrouper.Group(blocks, GroupingProfile.General).Select(g => g.Text));
+        if (interfaceMode)
+            Assert.Contains(decisions, d => !d.Joined && d.Rule == "unresolved row fragment");
+        else
+            Assert.Single(groups);
+        Assert.Equal(groups.Select(g => g.Text), OcrTextBlockGrouper.Group(blocks, profile).Select(g => g.Text));
     }
 
     [Fact]

--- a/tests/OverTranslate.Tests/ReadingOrderGroupingTests.cs
+++ b/tests/OverTranslate.Tests/ReadingOrderGroupingTests.cs
@@ -1,0 +1,102 @@
+using System.Windows;
+using System.IO;
+using System.Text.Json;
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class ReadingOrderGroupingTests
+{
+    [Theory]
+    [InlineData(0.5)]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public void CapturedArticleRetainsEveryFragmentInReadingOrder(double scale)
+    {
+        using var json = JsonDocument.Parse(File.ReadAllText(Path.Combine(AppContext.BaseDirectory,
+            "Fixtures", "WebParagraphs", "split-rows.json")));
+        var blocks = json.RootElement[0].GetProperty("Blocks").EnumerateArray().Select(item =>
+        {
+            Rect Box(string name)
+            {
+                var a = item.GetProperty(name).EnumerateArray().Select(v => v.GetDouble() * scale).ToArray();
+                return new(a[0], a[1], a[2], a[3]);
+            }
+            double? Metric(string name) => item.GetProperty(name).ValueKind == JsonValueKind.Null
+                ? null : item.GetProperty(name).GetDouble() * scale;
+            return new OcrTextBlock(item.GetProperty("Text").GetString()!, Box("Bounds"),
+                LayoutBounds: Box("LayoutBounds"), LayoutScript: (OcrLayoutScript)item.GetProperty("Script").GetInt32(),
+                LayoutGlyphHeight: Metric("Glyph"), RenderGlyphHeight: Metric("Render")) { LayoutInkHeight = Metric("Ink") };
+        }).ToArray();
+        var trace = new GroupingTrace();
+        var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
+        var groups = OcrTextBlockGrouper.Group(blocks, GroupingProfile.General, decisions, trace);
+        var sources = trace.Lines.ToDictionary(line => line.Id, line => line.SourceIds);
+        Assert.Equal(new[] { "b0", "b2", "b1", "b3", "b4", "b5", "b6", "b7", "b8", "b9" },
+            trace.Groups.SelectMany(group => group.SelectMany(id => sources[id])));
+        Assert.Equal(string.Join(" ", new[] { 0, 2, 1, 3, 4, 5, 6, 7, 8, 9 }.Select(i => blocks[i].Text)),
+            string.Join(" ", groups.Select(g => g.Text)));
+        Assert.Contains(decisions, d => !d.Joined && d.Rule == "unresolved row fragment");
+        Assert.Equal(groups.Select(g => g.Text), OcrTextBlockGrouper.Group(blocks, GroupingProfile.General).Select(g => g.Text));
+    }
+
+    [Fact]
+    public void EmptyCornerOfAParagraphDoesNotAbsorbAnIndependentLabel()
+    {
+        var blocks = new[] {
+            B("A wide first line of an ordinary paragraph", 0, 0, 500, 18),
+            B("a shorter concluding sentence.", 0, 20, 240, 18),
+            B("TEST!!!", 430, 22, 60, 12) };
+        var groups = OcrTextBlockGrouper.Group(blocks, GroupingProfile.General);
+        Assert.Contains(groups, g => g.Text == "TEST!!!");
+        Assert.DoesNotContain(groups, g => g.Text.Contains("paragraph") && g.Text.Contains("TEST!!!"));
+    }
+
+    [Theory]
+    [InlineData(0.5, false)]
+    [InlineData(1.0, false)]
+    [InlineData(2.0, false)]
+    [InlineData(1.0, true)]
+    public void SplitVisualRowCannotBeSkippedByAWrappingLine(double scale, bool interfaceMode)
+    {
+        var blocks = new[] {
+            B("nav rail still offers the update", 2, 38, 233, 18, scale),
+            B("because what the user declined was being interrupted, not", 256, 39, 404, 18, scale),
+            B("the update itself. See the reference.", 3, 55, 427, 17, scale) };
+        var groups = OcrTextBlockGrouper.Group(blocks, interfaceMode ? GroupingProfile.Interface : GroupingProfile.General);
+        Assert.Equal(string.Join(" ", blocks.Select(b => b.Text)), string.Join(" ", groups.Select(b => b.Text)));
+    }
+
+    [Fact]
+    public void SpanningPreviousLineCannotTakeOnlyOneHalfOfTheFollowingRow()
+    {
+        var blocks = new[] {
+            B("A long introductory sentence continues with these details", 2, 20, 658, 18),
+            B("nav rail still offers the update", 2, 38, 233, 18),
+            B("because what the user declined was being interrupted, not", 256, 39, 404, 18) };
+        var groups = OcrTextBlockGrouper.Group(blocks, GroupingProfile.General);
+        Assert.Equal(3, groups.Count);
+    }
+
+    [Fact]
+    public void IndependentColumnsCanStillContinueDownward()
+    {
+        var blocks = new[] {
+            B("The left column has a long opening line", 0, 0, 300, 18),
+            B("The right column has its own opening", 400, 0, 300, 18),
+            B("and continues in the left column.", 0, 19, 280, 18),
+            B("and continues in the right column.", 400, 19, 280, 18) };
+        var groups = OcrTextBlockGrouper.Group(blocks, GroupingProfile.General);
+        Assert.Equal(new[] { blocks[0].Text + " " + blocks[2].Text, blocks[1].Text + " " + blocks[3].Text }, groups.Select(g => g.Text));
+    }
+
+    private static OcrTextBlock B(string text, double x, double y, double w, double h, double scale = 1)
+    {
+        var box = new Rect(x * scale, y * scale, w * scale, h * scale);
+        var script = LayoutScriptDetection.For(text);
+        return new(text, box, LayoutScript: script, LayoutBounds: box,
+            LayoutGlyphHeight: OnnxOcrEngine.LayoutGlyphHeightFor(script, box, text));
+    }
+}

--- a/tools/LayoutProbe/DebugPanelLayout.cs
+++ b/tools/LayoutProbe/DebugPanelLayout.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using OverTranslate.Services;
+using OverTranslate.Views.Capture;
+using OverTranslate.Views.Settings;
+
+namespace LayoutProbe;
+
+internal static class DebugPanelLayout
+{
+    internal static void Report(string outputDirectory)
+    {
+        Directory.CreateDirectory(outputDirectory);
+        foreach (var theme in new[] { "Dark", "Light" })
+        {
+            Application.Current.Resources.MergedDictionaries[0] = new ResourceDictionary
+            {
+                Source = new Uri($"pack://application:,,,/OverTranslate;component/Themes/{theme}Theme.xaml")
+            };
+            var toolbar = new ToolbarWindow(0, 0, 680, 100, "EN", "ZH-HANT");
+            try
+            {
+                var popup = (Popup)toolbar.FindName("DebugPopup");
+                var panel = (FrameworkElement)popup.Child;
+                panel.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                panel.Arrange(new Rect(panel.DesiredSize));
+                panel.UpdateLayout();
+                Save(panel, Path.Combine(outputDirectory, $"debug-panel-{theme}.png"));
+                var bar = (FrameworkElement)toolbar.Content;
+                bar.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                bar.Arrange(new Rect(bar.DesiredSize));
+                bar.UpdateLayout();
+                Save(bar, Path.Combine(outputDirectory, $"toolbar-{theme}.png"));
+                Console.WriteLine($"{theme}: panel={panel.ActualWidth}x{panel.ActualHeight}; dismissOutside={!popup.StaysOpen}");
+                // Both halves of 框線顯示範圍, because the marker's far end is where it can come out
+                // the wrong width and the stored choice shows only one of the two.
+                //
+                // A fresh page for each, rather than one page with the switch clicked over: the
+                // halves are shared-size columns, and re-measuring a tree that was already arranged
+                // and is not in a window puts them through a path they never take in the app. Each
+                // page reads the stored choice as it is built, so flipping the setting either side
+                // of the second one is what a page opened on that choice sees; it is put back before
+                // leaving, and the settings file ends on the value it started on.
+                var stored = SettingsService.Instance.Current.OcrDebug.ShowOnTranslation;
+                try
+                {
+                    SaveDebugCard(stored, outputDirectory, $"debug-settings-{theme}.png");
+                    SettingsService.Instance.UpdateOcrDebug(showOnTranslation: !stored);
+                    SaveDebugCard(!stored, outputDirectory, $"debug-settings-{theme}-scope-flipped.png");
+                }
+                finally { SettingsService.Instance.UpdateOcrDebug(showOnTranslation: stored); }
+            }
+            finally { toolbar.Close(); }
+        }
+    }
+
+    /// <summary>
+    /// Renders the 偵錯工具 card of a page built just now, with its fold forced open — the fold is
+    /// shut on every visit and animated open, and neither state is what this is here to look at.
+    /// </summary>
+    private static void SaveDebugCard(bool showOnTranslation, string outputDirectory, string fileName)
+    {
+        var settings = new SettingsPage();
+        var fold = (FrameworkElement)settings.FindName("DebugToolsFold");
+        fold.Visibility = Visibility.Visible;
+        fold.Height = double.NaN;
+        var body = (FrameworkElement)settings.FindName("DebugToolsBody");
+        body.Opacity = 1;
+        body.RenderTransform = Transform.Identity;
+        var card = (FrameworkElement)settings.FindName("DebugToolsCard");
+        card.Measure(new Size(720, double.PositiveInfinity));
+        card.Arrange(new Rect(0, 0, 720, card.DesiredSize.Height));
+        card.UpdateLayout();
+
+        // States what the picture is of, so a wrong file name cannot pass for a wrong layout.
+        Console.WriteLine($"  {fileName}: showOnTranslation={showOnTranslation}");
+        Save(card, Path.Combine(outputDirectory, fileName));
+    }
+
+    private static void Save(FrameworkElement visual, string path)
+    {
+        var bitmap = new RenderTargetBitmap((int)Math.Ceiling(visual.ActualWidth),
+            (int)Math.Ceiling(visual.ActualHeight), 96, 96, PixelFormats.Pbgra32);
+        bitmap.Render(visual);
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+        using var stream = File.Create(path);
+        encoder.Save(stream);
+    }
+}

--- a/tools/LayoutProbe/Program.cs
+++ b/tools/LayoutProbe/Program.cs
@@ -47,6 +47,9 @@ internal static class Program
                       Opens a real ToolbarWindow and prints its size, which mode it opened on, the
                       two segmented controls' halves and pill travel, and the resolved tooltips.
 
+                  LayoutProbe debug-panel [output-directory]
+                      Renders the debug panel and toolbar offscreen in both themes without changing settings.
+
                 Both read the application's own settings file, so the toolbar opens on whatever mode
                 is stored on this machine.
                 """);
@@ -77,6 +80,9 @@ internal static class Program
                     break;
                 case "toolbar":
                     ToolbarLayout.Report();
+                    break;
+                case "debug-panel":
+                    DebugPanelLayout.Report(args.Length > 1 ? args[1] : ".test-artifacts/debug-panel");
                     break;
                 default:
                     Console.Error.WriteLine($"unknown command '{args[0]}'");


### PR DESCRIPTION
## 內容

分成兩塊：OCR 偵錯框線功能，以及設定頁 偵錯工具 卡片的排版。

### OCR 偵錯框線

- `OcrDebugSettings` 三個值（文字組合框、OCR 辨識框、框線顯示範圍）全部進 appsettings，預設都是關閉、範圍為「僅原文」。
- 設定頁與截圖工具列走同一條路：都呼叫 `SettingsService.UpdateOcrDebug()`，該方法存檔後發 `OcrDebugChanged`，兩邊各自回寫控制項，疊圖層同步重畫。兩處任一改動都會即時反映到另一處。

### 設定頁排版

- 「顯示 OCR 偵錯資訊」字級 13 → 15。它是底下設定掛的標題，原本與選項同字級，讀起來像第四個選項。
- 兩段說明文字從右側欄位移到各自 checkbox 底下，縮排對齊勾選框後的文字起點。長翻譯現在折進整張卡的寬度，而不是折進一個窄的第二欄。
- 「僅原文／原文與譯文」從兩顆獨立按鈕改成滑塊式分段控制，沿用截圖工具列既有的機制：`Grid.IsSharedSizeScope` ＋ `SharedSizeGroup` 讓兩半等寬，滑塊自身寬度即為位移距離，220ms CubicEaseOut 與工具列一致。
- `S.Debug.ScopeHint` 五語系改寫並強制斷成兩行（每半一行）。

## 兩個實作上的坑

- 分段控制原先用 `*` 欄寬。托盤本身只有它想要的寬度，星號欄在這種情況下不會平分，兩半各自停在自己標籤的寬度，滑塊滑到右邊就包不住較長的標籤。改用 shared-size 欄位解決。
- 資源字串裡單放 `&#x0A;` 是無效的，XAML 編譯時會把它當空白摺掉，兩句會直接黏在一起。需要 `xml:space="preserve"`；資源檔已留註解說明，避免日後被當成多餘屬性移除。

## 驗證

- `LayoutProbe debug-panel` 擴充成兩種 `框線顯示範圍` 狀態都出圖 —— 滑塊的另一端正是會出錯而看不到的地方。每張圖各建一個新的 SettingsPage：shared-size 欄位在已 arrange 過又不在視窗裡的樹上重新 measure，會走到 app 裡不會走的路徑，版面會爛掉。跑完會把設定值放回原狀。
- 深淺兩色 × 兩種選擇共四張圖確認正確；`&#x0A;` 的問題是把編譯後字串印出來查證的。
- 1054 個測試全過。
