### PR TITLE
fix: 修正語音播放失敗後靜默失效

### DIFF
--- a/src/OverTranslate/Services/TtsService.cs
+++ b/src/OverTranslate/Services/TtsService.cs
@@ -14,7 +14,8 @@ public class TtsService : IDisposable
     private readonly MicrosoftTranslator  _microsoft = new();
     private readonly BingTranslator       _bing      = new();
     private readonly YandexTranslator     _yandex    = new();
-    private readonly MediaPlayer _player = new();
+    private MediaPlayer? _player;
+    private string? _currentFile;
     private CancellationTokenSource? _cts;
     private bool _active;
 
@@ -24,11 +25,52 @@ public class TtsService : IDisposable
     /// <summary>Raised (on the UI thread) whenever playback starts, ends, fails, or is stopped.</summary>
     public event EventHandler? StateChanged;
 
-    public TtsService()
+    /// <summary>
+    /// Creates the player on demand. A MediaPlayer that has raised MediaFailed cannot be trusted to
+    /// play again — depending on the error it can go silently dead, and then every later Open/Play on
+    /// that instance does nothing at all, which is exactly the "no sound until I reopen 取詞翻譯" the
+    /// user is left with. So a failed player is thrown away and the next request gets a fresh one.
+    /// UI thread only.
+    /// </summary>
+    private MediaPlayer EnsurePlayer()
     {
+        if (_player != null) return _player;
+
+        var player = new MediaPlayer();
         // Natural end / playback error must flip the button back to "play".
-        _player.MediaEnded  += (_, _) => SetActive(false);
-        _player.MediaFailed += (_, _) => SetActive(false);
+        player.MediaEnded += (_, _) =>
+        {
+            if (!ReferenceEquals(_player, player)) return;
+            // Close() releases the temp file, which the player holds open until its next Open().
+            player.Close();
+            DeleteCurrentFile();
+            SetActive(false);
+        };
+        player.MediaFailed += (_, e) =>
+        {
+            Log.Warn(e.ErrorException, "TTS playback failed, discarding player");
+            player.Close();
+            if (ReferenceEquals(_player, player))
+            {
+                _player = null;
+                DeleteCurrentFile();
+            }
+            SetActive(false);
+        };
+
+        _player = player;
+        return player;
+    }
+
+    /// <summary>Stops playback and releases the file the player was holding. UI thread only.</summary>
+    private void ClosePlayer()
+    {
+        if (_player != null)
+        {
+            _player.Stop();
+            _player.Close();
+        }
+        DeleteCurrentFile();
     }
 
     private void SetActive(bool value)
@@ -38,14 +80,48 @@ public class TtsService : IDisposable
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    private static readonly string TempFile =
-        Path.Combine(Path.GetTempPath(), "overtranslate_tts.mp3");
+    private const string TempPrefix = "overtranslate_tts_";
+    private static int _staleFilesSwept;
+
+    /// <summary>
+    /// Every playback gets its own file: the player keeps the previous one open, and re-opening the
+    /// same path also runs into the media stack caching that URI.
+    /// </summary>
+    private static string NewTempFile() =>
+        Path.Combine(Path.GetTempPath(), $"{TempPrefix}{Guid.NewGuid():N}.mp3");
+
+    private void DeleteCurrentFile()
+    {
+        var file = Interlocked.Exchange(ref _currentFile, null);
+        if (file == null) return;
+        try { File.Delete(file); }
+        catch (Exception ex) { Log.Debug(ex, "Could not delete TTS temp file {File}", file); }
+    }
+
+    /// <summary>Removes files an earlier crash left behind. Old enough that no live player holds them.</summary>
+    private static void SweepStaleFilesOnce()
+    {
+        if (Interlocked.Exchange(ref _staleFilesSwept, 1) != 0) return;
+        try
+        {
+            var cutoff = DateTime.UtcNow - TimeSpan.FromHours(1);
+            foreach (var file in Directory.EnumerateFiles(Path.GetTempPath(), TempPrefix + "*.mp3"))
+            {
+                try
+                {
+                    if (File.GetLastWriteTimeUtc(file) < cutoff) File.Delete(file);
+                }
+                catch { /* still in use by another process, or already gone */ }
+            }
+        }
+        catch (Exception ex) { Log.Debug(ex, "TTS temp sweep failed"); }
+    }
 
     /// <summary>Stops any in-flight fetch and playback.</summary>
     public void Stop()
     {
         _cts?.Cancel();
-        System.Windows.Application.Current.Dispatcher.Invoke(() => { _player.Stop(); _player.Close(); });
+        System.Windows.Application.Current.Dispatcher.Invoke(ClosePlayer);
         SetActive(false);
     }
 
@@ -58,8 +134,10 @@ public class TtsService : IDisposable
         _cts = new CancellationTokenSource();
         var token = _cts.Token;
 
-        System.Windows.Application.Current.Dispatcher.Invoke(() => { _player.Stop(); _player.Close(); });
+        System.Windows.Application.Current.Dispatcher.Invoke(ClosePlayer);
         SetActive(true);
+
+        SweepStaleFilesOnce();
 
         var providers = BuildProviders(text, langCode);
         Exception? lastEx = null;
@@ -75,12 +153,16 @@ public class TtsService : IDisposable
 
                 using var ms = new MemoryStream();
                 await stream.CopyToAsync(ms, token);
-                await File.WriteAllBytesAsync(TempFile, ms.ToArray(), token);
+                var file = NewTempFile();
+                await File.WriteAllBytesAsync(file, ms.ToArray(), token);
 
                 System.Windows.Application.Current.Dispatcher.Invoke(() =>
                 {
-                    _player.Open(new Uri(TempFile));
-                    _player.Play();
+                    DeleteCurrentFile();
+                    _currentFile = file;
+                    var player = EnsurePlayer();
+                    player.Open(new Uri(file));
+                    player.Play();
                 });
 
                 Log.Debug("TTS success via {Provider}", name);
@@ -187,6 +269,6 @@ public class TtsService : IDisposable
         _microsoft.Dispose();
         _bing.Dispose();
         _yandex.Dispose();
-        System.Windows.Application.Current.Dispatcher.Invoke(() => { _player.Stop(); _player.Close(); });
+        System.Windows.Application.Current.Dispatcher.Invoke(ClosePlayer);
     }
 }


### PR DESCRIPTION
## 背景

使用者回報「選詞翻譯按語音有時沒聲音，要把選詞翻譯關掉重開才正常」。診斷包 E2R-WEC 的六份 log 完全沒有 WARN/ERROR，代表音檔有抓到、也有寫進 temp，是播放端無聲——而現行程式對這段完全沒有可觀測性。

## 改了什麼

- **MediaFailed 現在會記錄**：原本只把按鈕狀態翻回「播放」，失敗原因完全不落地；現在以 `Log.Warn` 附上 `ErrorException`（Warn 不受「記錄詳細資訊」開關影響，一定會寫進 log）。
- **失敗的 MediaPlayer 直接丟棄**：`_player` 改為延遲建立，MediaFailed 後把該實例作廢，下一次請求建新的。這正對應「關掉重開才會好」＝換一個新的 MediaPlayer。
- **暫存檔改為每次唯一檔名**：原本三個 TtsService 實例共用固定的 `overtranslate_tts.mp3`，互相卡檔案，也踩到相同 URI 的快取行為；現在每次播放一個 `overtranslate_tts_<guid>.mp3`。
- **播完 / 停止 / Dispose 都會 Close() 並刪檔**：播放器不再一直握住暫存檔。另外啟動後掃一次一小時前的殘留檔（更早的當機留下的），只掃自己的檔名前綴。

## 測試

- 既有測試套件全綠（1054 passed / 9 skipped）。
- 另以拋棄式 WPF probe 實際跑過真實語音播放，六項全過：暫存檔每次不同、播完自動刪除、餵壞檔會落 Warn log（`COMException 0xC00D11B1`）並作廢播放器、失敗後下一次播放在新播放器上正常播到結束、Stop/Dispose 不留檔、殘留檔掃除不會誤刪剛建立的檔。
- 附帶實測：在本機上壞檔造成的 MediaFailed 之後，重用同一個 MediaPlayer 其實還播得出來。也就是說「播放器死掉」在這台機器上沒能重現，本 PR 不宣稱已抓到根因；但失敗路徑現在會留下證據，下一包 log 就能直接分辨是抓檔失敗還是播放端失效。