### PR TITLE
修正即時翻譯對話模式的行首漏字與跨行不合併

### DIFF
--- a/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
+++ b/src/OverTranslate/Services/Ocr/OcrTextBlockGrouper.cs
@@ -478,7 +478,7 @@ internal static class OcrTextBlockGrouper
             LayoutGlyphHeight: CombineLayoutGlyphHeight(layoutScript, [previous, current]));
     }
 
-    private static string JoinInlineText(string left, string right)
+    internal static string JoinInlineText(string left, string right)
     {
         left = left.TrimEnd();
         right = right.TrimStart();
@@ -1379,7 +1379,8 @@ internal static class OcrTextBlockGrouper
         return hasDigit;
     }
 
-    private static OcrTextBlock BuildGroup(List<OcrTextBlock> blocks)
+    // Aggregation only, shared with dialogue. No joining decision is made by this method.
+    internal static OcrTextBlock BuildGroup(List<OcrTextBlock> blocks)
     {
         if (blocks.Count == 1)
             return blocks[0];

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -800,15 +800,15 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// The clock reading is superseded for the same reason — with the geometry exact the border no
     /// longer counts towards anything, and dropping it is 10% FASTER rather than slower.
     ///
-    /// Re-swept with the geometry fixed, the border comes out worthless-to-harmful: see
-    /// <c>DetectorPadding</c>, which is now 0.
+    /// Re-swept with the geometry fixed, the border wants to be small rather than absent: see
+    /// <c>DetectorPadding</c>, which is now 8.
     ///
-    /// ITS COLOUR IS SETTLED, at 0. With no border the library never composites, so the stride
+    /// ITS COLOUR ONLY MATTERS AT ZERO. With no border the library never composites, so the stride
     /// strip <see cref="AlignForDetector"/> leaves on the right and bottom reaches normalisation as
-    /// stored premultiplied transparent, which is black. Painting it white instead costs 2.6 points
-    /// of F1 on region-subtitle-mixed-boxshape (99.9% to 97.3%); painting it black scores
-    /// identically to leaving it transparent, as it must. So the shipped behaviour is right, and it
-    /// is worth knowing it is a consequence rather than a choice.
+    /// stored premultiplied transparent, which is black; painting it white instead cost 2.6 points
+    /// of F1 on region-subtitle-mixed-boxshape (99.9% to 97.3%) and painting it black scored
+    /// identically to leaving it transparent, as it must. At any non-zero border the library's own
+    /// MakePadding runs, clears white and composites, so the strip is white and this is moot.
     /// </remarks>
     internal static int? DetectorPaddingOverride { get; set; }
 
@@ -1491,10 +1491,26 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// Re-swept once the geometry is exact and the border is finally an independent variable, on
     /// the six ja-game frames that lose their leading word: 0 and 8 recover all six, 16 recovers
     /// two, 24 three, 32 two, 50 none, 64 one. Shipped recovered none. On the subtitle corpora 0
-    /// and 8 are within noise of each other and both beat 50; 0 is also 10% faster and keeps the
-    /// leading bracket on ja-game-2-roi, which 8 drops.
+    /// and 8 are within noise of each other in F1 and both beat 50, and 0 is 10% faster — which is
+    /// why this was 0 first.
+    ///
+    /// 8 rather than 0 because those six frames were the wrong tiebreak. A user framing a dialogue
+    /// BOX rather than the text in it is the case that opened all of this, and swept properly —
+    /// the same game screen, the selection nudged over a 45-point grid of +-8px in each axis, which
+    /// is the amount a hand-drawn box moves — the two are not close:
+    ///
+    /// <code>
+    ///   border                 0      8
+    ///   leading word read   22/45  44/45
+    /// </code>
+    ///
+    /// It holds at every detector size (0.85x, 1.0x, 1.15x, 1.3x of the fraction: 30/45, 22/45,
+    /// 14/45, 15/45 at zero against 45, 44, 43, 43 at eight), so it is the border and not an
+    /// interaction with the scale. 0 loses nothing measurable on the corpora and everything on the
+    /// one workload the fix exists for; the six-frame tie could not see that because all six were
+    /// framed tight around the text.
     /// </remarks>
-    private const int DetectorPadding = 0;
+    private const int DetectorPadding = 8;
 
     /// <summary>
     /// An ImgResize the library can never act on, so its resize stays the identity.

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -12,32 +12,34 @@ using SkiaSharp;
 namespace OverTranslate.Services.Ocr;
 
 /// <summary>
-/// KNOWN LIMITATION: the detector sometimes returns a box that starts part way along a line, and the
-/// characters before it are lost with nothing in the log to say they existed. Closed as unfixable in
-/// #69; do not spend another round looking for the setting that causes it, because it is not one.
+/// The detector used to return boxes that start part way along a line, losing the characters before
+/// them with nothing in the log to say they existed. It was the detector input's geometry, not the
+/// model — see <see cref="CreateDetectorFrame"/> and the note above <c>DetectorAlignment</c>.
 /// </summary>
 /// <remarks>
-/// Ruled out, each with a measurement rather than an argument: the recognition confidence floor (the
-/// leading box is never returned, so nothing filters it), all three detector box thresholds
-/// (<see cref="DetectorThresholdOverride"/> — dropping BoxScoreThresh to 0.10, which discards
-/// nothing, changes not one character; #71 later found all three were on the wrong values anyway and
-/// corrected them, see <see cref="ExportedThresholds"/>, and this symptom survived that too), the
-/// border (<see cref="DetectorPaddingOverride"/>, 0 to 96),
-/// the normalisation statistics (<see cref="ShippedDetector"/>), the detector size
-/// (<c>--scale-sweep</c>), and how tightly the user framed the capture (<c>--margin-series</c> over
-/// 27 whole screens: 1.1% apart, and the tightest framing is the worst of them).
+/// #69 closed this as unfixable and said not to look for the setting that causes it, which was
+/// right in its own terms: it is not a setting, it is how the image was being resized. Everything
+/// that round ruled out stays ruled out, and each was ruled out with a measurement — the
+/// recognition confidence floor (the leading box is never returned, so nothing filters it), all
+/// three detector box thresholds (<see cref="DetectorThresholdOverride"/> — dropping BoxScoreThresh
+/// to 0.10, which discards nothing, changes not one character), the normalisation statistics
+/// (<see cref="ShippedDetector"/>), the detector size (<c>--scale-sweep</c>), and how tightly the
+/// user framed the capture (<c>--margin-series</c> over 27 whole screens: 1.1% apart).
 ///
-/// What it actually is: the response is knife-edge, and only along the short axis. On the reported
-/// frame, cropping one pixel off the top takes the reading from 5 characters to 6, and four pixels
-/// takes it to 10 — while cropping up to eight pixels off the side changes nothing at all. Appending
-/// blank rows below the picture, which touches no content whatsoever, walks the reading between 5 and
-/// 10 characters with no pattern: +4px reads 10, +20px reads 6, +24px reads 9. The capture the user
-/// happened to draw lands where it lands.
+/// The border (<see cref="DetectorPaddingOverride"/>, 0 to 96) was ruled out there too and should
+/// not have been: it was swept while the distortion was still in place, where it is an input to the
+/// aligned dimensions and so changes the squash along with itself. See
+/// <c>DetectorPadding</c> for the re-sweep.
 ///
-/// So a frame either reads or does not, and the deciding factor is a few pixels of height that
-/// nobody chose. Replacing the detector is the only lever left and #33 already measured that
-/// trade — PP-OCRv6_det_medium costs 90ms per recognition and 62MB to save roughly one line every
-/// two and a half minutes — and rejected it.
+/// #69's own best evidence is what names the cause, read the other way round. It found the response
+/// knife-edge ALONG THE SHORT AXIS ONLY: cropping one pixel off the top took the reading from 5
+/// characters to 6 and four pixels took it to 10, while cropping eight off the side changed nothing;
+/// appending blank rows below the picture, which touches no content at all, walked it between 5 and
+/// 10 with no pattern. That is a 32-pixel quantisation step on the short axis being crossed and
+/// re-crossed — a few pixels of height nobody chose deciding how far the image gets squashed. The
+/// conclusion drawn at the time ("a frame either reads or does not, replacing the detector is the
+/// only lever left", and #33's rejection of PP-OCRv6_det_medium at 90ms and 62MB) followed from
+/// reading that as model behaviour.
 /// </remarks>
 internal sealed class OnnxOcrEngine : IOcrEngine
 {
@@ -234,10 +236,10 @@ internal sealed class OnnxOcrEngine : IOcrEngine
                 runtime.ModelName,
                 ThreadCount);
 
-            var options = CreateOptions(maxDetectSize);
             using var skBitmap = ConvertToSkBitmap(bitmap);
-            using var detectorInput = AlignForDetector(skBitmap, options.Padding);
-            var result = runtime.Engine.Detect(detectorInput, options);
+            using var frame = CreateDetectorFrame(skBitmap, maxDetectSize);
+            var result = runtime.Engine.Detect(frame.Bitmap, frame.Options);
+            frame.MapToSource(result.TextBlocks);
             var blocks = ApplyBlockFilters(result.TextBlocks, normalizedLanguage, useCjkRenderMetrics, usesAutomaticLayout);
 
             // Counts and lengths only — enough to tell "found nothing" from "found the wrong thing"
@@ -306,20 +308,11 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         var runtime = AcquireRuntime(OcrLanguageRouter.Normalize(sourceLanguage));
         try
         {
-            var options = CreateOptions(maxDetectSize);
             using var skBitmap = ConvertToSkBitmap(bitmap);
-            using var detectorInput = AlignForDetector(skBitmap, options.Padding);
+            using var frame = CreateDetectorFrame(skBitmap, maxDetectSize);
 
-            return runtime.Engine.DetectBoxes(detectorInput, options)
-                .Select(box =>
-                {
-                    var xs = box.BoxPoints.Select(point => point.X).ToList();
-                    var ys = box.BoxPoints.Select(point => point.Y).ToList();
-                    return (
-                        new System.Windows.Rect(
-                            xs.Min(), ys.Min(), xs.Max() - xs.Min(), ys.Max() - ys.Min()),
-                        box.Score);
-                })
+            return runtime.Engine.DetectBoxes(frame.Bitmap, frame.Options)
+                .Select(box => (frame.ToSourceBounds(box.BoxPoints), box.Score))
                 .ToList();
         }
         finally
@@ -374,7 +367,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         private readonly RapidOcr _engine;
         private readonly string _language;
         private readonly SKBitmap _skBitmap;
-        private readonly SKBitmap _aligned;
+        private readonly DetectorFrame _frame;
         // Boxed, because the type is internal to the library and cannot be named here.
         private readonly object _detectorInput;
         private readonly SKBitmap _detectorBitmap;
@@ -391,11 +384,11 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             _owner = owner;
             _engine = runtime.Engine;
             _language = normalizedLanguage;
-            _options = CreateOptions(maxDetectSize);
             _skBitmap = ConvertToSkBitmap(bitmap);
-            _aligned = AlignForDetector(_skBitmap, _options.Padding);
+            _frame = CreateDetectorFrame(_skBitmap, maxDetectSize);
+            _options = _frame.Options;
 
-            _detectorInput = PrepareDetectorInputMethod.Invoke(null, new object[] { _aligned, _options })!;
+            _detectorInput = PrepareDetectorInputMethod.Invoke(null, new object[] { _frame.Bitmap, _options })!;
             _detectorBitmap = (SKBitmap)DetectorInputBitmapField.GetValue(_detectorInput)!;
             var scale = (ScaleParam)DetectorInputScaleField.GetValue(_detectorInput)!;
 
@@ -411,12 +404,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
                 {
                     var points = (SKPointI[])box.BoxPoints.Clone();
                     MapToOriginalMethod.Invoke(_detectorInput, new object[] { points });
-                    var xs = points.Select(point => point.X).ToList();
-                    var ys = points.Select(point => point.Y).ToList();
-                    return (
-                        Bounds: new System.Windows.Rect(
-                            xs.Min(), ys.Min(), xs.Max() - xs.Min(), ys.Max() - ys.Min()),
-                        box.Score);
+                    return (Bounds: _frame.ToSourceBounds(points), box.Score);
                 })
                 .ToList();
         }
@@ -452,6 +440,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
 
                     var points = (SKPointI[])chosen[i].BoxPoints.Clone();
                     MapToOriginalMethod.Invoke(_detectorInput, new object[] { points });
+                    _frame.MapToSource(points);
 
                     textBlocks.Add(new TextBlock
                     {
@@ -480,7 +469,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         public void Dispose()
         {
             ((IDisposable)_detectorInput).Dispose();
-            _aligned.Dispose();
+            _frame.Dispose();
             _skBitmap.Dispose();
             _owner.ReleaseRuntime();
         }
@@ -802,15 +791,24 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     /// no border failed to find: the detector's own input is the same size either way, because
     /// <c>ImgResize</c> caps the long side after the border is added.
     ///
-    /// ITS COLOUR IS NOT A KNOB, AND THE QUESTION IS OPEN. The library fills the border itself and
-    /// exposes no colour, so the only way to try another one is to draw the border here and ask for
-    /// none — and that turned out not to be the same experiment. Reproducing the shipped
-    /// composition by hand (align with transparent pixels, then a white border, then
-    /// <c>Padding = 0</c>) still read less than the shipped path does, so something in how the
-    /// library builds its own border is not accounted for, and every colour measured that way is
-    /// measuring that difference as much as the colour. Worth knowing because subtitles are white
-    /// text and a white border is the one combination nobody chose — but it needs the library's
-    /// source, not another harness mode.
+    /// EVERYTHING ABOVE WAS MEASURED WHILE THE DETECTOR INPUT WAS STILL BEING SQUASHED, and the
+    /// paragraph that says "that is AlignForDetector showing through" is the reason it cannot be
+    /// read as a ranking of borders. The border feeds <c>AlignedLength</c>, so moving it moved the
+    /// aligned dimensions and therefore how far each axis was quantised down; what the table ranks
+    /// is which border happened to land on the least distorted geometry, and 50 winning "in every
+    /// category with both neighbours worse" is the shape of that rather than of a border optimum.
+    /// The clock reading is superseded for the same reason — with the geometry exact the border no
+    /// longer counts towards anything, and dropping it is 10% FASTER rather than slower.
+    ///
+    /// Re-swept with the geometry fixed, the border comes out worthless-to-harmful: see
+    /// <c>DetectorPadding</c>, which is now 0.
+    ///
+    /// ITS COLOUR IS SETTLED, at 0. With no border the library never composites, so the stride
+    /// strip <see cref="AlignForDetector"/> leaves on the right and bottom reaches normalisation as
+    /// stored premultiplied transparent, which is black. Painting it white instead costs 2.6 points
+    /// of F1 on region-subtitle-mixed-boxshape (99.9% to 97.3%); painting it black scores
+    /// identically to leaving it transparent, as it must. So the shipped behaviour is right, and it
+    /// is worth knowing it is a consequence rather than a choice.
     /// </remarks>
     internal static int? DetectorPaddingOverride { get; set; }
 
@@ -893,7 +891,7 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         {
             ImgResize = maxDetectSize ?? ScreenshotDetectSize,
             DoAngle = false,
-            Padding = DetectorPaddingOverride ?? RapidOcrOptions.Default.Padding,
+            Padding = DetectorPaddingOverride ?? DetectorPadding,
         };
 
         var thresholds = DetectorThresholdOverride ?? ExportedThresholds;
@@ -1457,13 +1455,167 @@ internal sealed class OnnxOcrEngine : IOcrEngine
     // the selection size. Captures that large therefore behave exactly as they did before this
     // change, residual squash included.
     //
-    // Doing that downscale ourselves, uniformly, would remove the squash at every size. It was
-    // measured and did not pay: on a ground-truth benchmark of a real capture across five canvas
-    // sizes it scored 111/120 against 115/120 for leaving the library to it (and 110/120 with a
-    // sharper resampler). That is inside the benchmark's noise, so the honest reading is "no
-    // measurable gain" rather than "worse" — but an unmeasurable gain does not justify changing
-    // how every large capture is fed. Revisit only with a benchmark strong enough to resolve it.
+    // THE PARAGRAPH ABOVE DESCRIBED A GUARANTEE THIS METHOD NEVER HAD, and it is why the leading
+    // characters of a line kept going missing. Detect() targets
+    // min(ImgResize, aligned long side) + 2 * Padding, and ImgResize is computed from the size
+    // BEFORE alignment — Realtime.RealtimeDetectorSize is asked about the region the user framed.
+    // Alignment then grows that bitmap by up to 31px, so the target lands just UNDER the padded
+    // long side, the ratio is no longer 1.0, and the quantisation runs after all. On a 465x76
+    // dialogue box the aligned 576x192 reached the detector as 512x128: 0.89x across, 0.67x down.
+    // Under it, "「うん、" was never detected at all.
+    //
+    // So the downscale is done here instead, isotropically, and ImgResize is then set above the
+    // input so the library's own resize is the identity — see CreateDetectorFrame. Both prepared
+    // dimensions are multiples of DetectorAlignment by construction at that point, which is the
+    // one case ScaleParam leaves alone. The detector finally sees the aspect ratio it was handed.
+    //
+    // The measurement that turned this down before ("111/120 against 115/120 on a ground-truth
+    // benchmark, inside the noise") compared doing the downscale ourselves against leaving it to
+    // the library WHILE KEEPING the 50px border, which is the half of the change that loses: with
+    // the geometry exact, the border is the worst value in the sweep rather than the best. See
+    // .ai/realtime-dialogue/ocr-detector-geometry.md for the corpus numbers and for what was
+    // measured and turned down (the library's v6/PythonCompat presets, stride rounding alone,
+    // re-tuning StripFraction, painting the alignment strip white).
     private const int DetectorAlignment = 32;
+
+    /// <summary>
+    /// Border to surround the detector input with. Zero: the geometry is exact, so there is none.
+    /// </summary>
+    /// <remarks>
+    /// The library's own default is 50, and a sweep of 0–96 once made it look like a peak with both
+    /// neighbours worse. That sweep could not have said otherwise: the border is an input to
+    /// <see cref="AlignedLength"/>, so changing it changed the aligned dimensions and therefore the
+    /// squash, and what it was really ranking was which border happened to land on the least
+    /// distorted geometry. <see cref="DetectorPaddingOverride"/>'s note says as much in passing.
+    ///
+    /// Re-swept once the geometry is exact and the border is finally an independent variable, on
+    /// the six ja-game frames that lose their leading word: 0 and 8 recover all six, 16 recovers
+    /// two, 24 three, 32 two, 50 none, 64 one. Shipped recovered none. On the subtitle corpora 0
+    /// and 8 are within noise of each other and both beat 50; 0 is also 10% faster and keeps the
+    /// leading bracket on ja-game-2-roi, which 8 drops.
+    /// </remarks>
+    private const int DetectorPadding = 0;
+
+    /// <summary>
+    /// An ImgResize the library can never act on, so its resize stays the identity.
+    /// </summary>
+    /// <remarks>
+    /// Not a magic large number for its own sake: Detect() takes min(ImgResize, long side), so
+    /// anything above the largest input the app can hand it makes that min pick the input and the
+    /// scale ratio come out exactly 1. A screen capture is at most a few thousand pixels.
+    /// </remarks>
+    private const int NoLibraryResize = 65536;
+
+    /// <summary>
+    /// The pixels to detect on, and how to get from a box on them back to the caller's bitmap.
+    /// </summary>
+    /// <remarks>
+    /// The two axes carry their own ratio because the isotropic resize rounds each dimension to a
+    /// whole pixel, so they differ by a fraction of a percent. Mapping with one of them would put
+    /// a box a pixel or two out on tall captures, and block bounds are what the overlay sizes its
+    /// font and background from.
+    /// </remarks>
+    internal readonly struct DetectorFrame : IDisposable
+    {
+        internal required SKBitmap Bitmap { get; init; }
+        internal required RapidOcrOptions Options { get; init; }
+        internal required double RatioX { get; init; }
+        internal required double RatioY { get; init; }
+
+        // Null-tolerant because a struct can always be default-constructed, and a measurement that
+        // holds one in a variable it does not always fill should not blow up on the way out.
+        public void Dispose() => Bitmap?.Dispose();
+
+        /// <summary>Rewrites detector-space points into the caller's coordinates, in place.</summary>
+        internal void MapToSource(SKPointI[] points)
+        {
+            if (RatioX >= 1.0 && RatioY >= 1.0)
+                return;
+
+            for (var i = 0; i < points.Length; i++)
+            {
+                points[i] = new SKPointI(
+                    (int)Math.Round(points[i].X / RatioX),
+                    (int)Math.Round(points[i].Y / RatioY));
+            }
+        }
+
+        internal void MapToSource(TextBlock[] blocks)
+        {
+            foreach (var block in blocks)
+            {
+                if (block.BoxPoints is { Length: > 0 } points)
+                    MapToSource(points);
+            }
+        }
+
+        internal System.Windows.Rect ToSourceBounds(SKPointI[] detectorSpacePoints)
+        {
+            var points = (SKPointI[])detectorSpacePoints.Clone();
+            MapToSource(points);
+
+            var xs = points.Select(point => point.X).ToList();
+            var ys = points.Select(point => point.Y).ToList();
+            return new System.Windows.Rect(
+                xs.Min(), ys.Min(), xs.Max() - xs.Min(), ys.Max() - ys.Min());
+        }
+    }
+
+    /// <summary>
+    /// Builds the detector's input: the isotropic downscale the caller asked for, aligned to the
+    /// detector's stride, with the library told not to resize it again.
+    /// </summary>
+    /// <param name="maxDetectSize">
+    /// Longest side to give the detector, or null for the screenshot default — as
+    /// <see cref="CreateOptions"/>. It is honoured exactly here, which is the point: it used to be
+    /// a request the library rounded down twice, by a different amount on each axis.
+    /// </param>
+    internal static DetectorFrame CreateDetectorFrame(SKBitmap source, int? maxDetectSize)
+    {
+        var requested = CreateOptions(maxDetectSize);
+        var longest = Math.Max(source.Width, source.Height);
+
+        // ImgResize only ever downscales, so a request at or above the input is no request at all.
+        var ratio = requested.ImgResize <= 0 || requested.ImgResize >= longest
+            ? 1.0
+            : (double)requested.ImgResize / longest;
+
+        var scaled = ratio >= 1.0 ? null : Downscale(source, ratio);
+        try
+        {
+            var body = scaled ?? source;
+            return new DetectorFrame
+            {
+                Bitmap = AlignForDetector(body, requested.Padding),
+                Options = requested with { ImgResize = NoLibraryResize },
+                RatioX = (double)body.Width / source.Width,
+                RatioY = (double)body.Height / source.Height,
+            };
+        }
+        finally
+        {
+            scaled?.Dispose();
+        }
+    }
+
+    // Mitchell because that is what the library resizes with (OcrUtils' NetworkSampling), so
+    // moving the resize out here changes where it happens and not how the glyphs come out.
+    private static SKBitmap Downscale(SKBitmap source, double ratio)
+    {
+        var width = Math.Max(1, (int)Math.Round(source.Width * ratio));
+        var height = Math.Max(1, (int)Math.Round(source.Height * ratio));
+        var scaled = new SKBitmap(width, height, source.ColorType, source.AlphaType);
+
+        using (var canvas = new SKCanvas(scaled))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var image = SKImage.FromBitmap(source);
+            canvas.DrawImage(
+                image, new SKRect(0, 0, width, height), new SKSamplingOptions(SKCubicResampler.Mitchell));
+        }
+
+        return scaled;
+    }
 
     internal static SKBitmap AlignForDetector(SKBitmap src, int detectPadding)
     {

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -70,11 +70,14 @@ public class OcrService : IDisposable
     /// For callers watching a live screen, where a queued pass would be answering a frame that has
     /// already been replaced — see <see cref="IOcrEngine.TryRecognizeAsync"/>.
     /// </summary>
+    /// <param name="mode">The live region's mode. Panel preserves the historical path for callers
+    /// that do not specify one; the application always passes its region's explicit mode.</param>
     public async Task<List<OcrTextBlock>?> TryRecognizeAsync(
         Bitmap bitmap,
         string sourceLanguage,
         int? maxDetectSize = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        Realtime.RealtimeBlockMode mode = Realtime.RealtimeBlockMode.Panel)
     {
         if (!OcrLanguageRouter.IsSupported(sourceLanguage))
             throw new NotSupportedException(OcrLanguageRouter.GetUnsupportedLanguageMessage(sourceLanguage));
@@ -96,7 +99,20 @@ public class OcrService : IDisposable
         // There is no toolbar in front of a running video, so there is no CaptureLayoutMode to
         // honour here; taking one would mean a mode the user chose for a still capture silently
         // steering frames it was never asked about.
-        return OcrTextBlockGrouper.Group(RejectUnconvincingBlocks(blocks), GroupingProfile.Realtime);
+        return GroupRealtime(blocks, bitmap.Height, mode);
+    }
+
+    internal static List<OcrTextBlock> GroupRealtime(List<OcrTextBlock> blocks, double frameHeight,
+        Realtime.RealtimeBlockMode mode, GroupingTrace? trace = null)
+    {
+        var filtered = RejectUnconvincingBlocks(blocks);
+        if (mode != Realtime.RealtimeBlockMode.Subtitle)
+            return OcrTextBlockGrouper.Group(filtered, GroupingProfile.Realtime, null, trace);
+        trace?.RegisterBlocks(blocks);
+        // Remove scene-sized noise before it can contaminate a real dialogue row. Confident
+        // single letters (such as a split "I") may still join; isolated ones are filtered later.
+        filtered = filtered.Where(b => !Realtime.CollapsedDetection.IsCollapsed(b.Bounds.Height, frameHeight, b.Text)).ToList();
+        return Realtime.DialogueTextGrouper.Group(filtered, trace);
     }
 
     // Scenery the recogniser was not sure about. Only on this path: it is the realtime one, where

--- a/src/OverTranslate/Services/OcrService.cs
+++ b/src/OverTranslate/Services/OcrService.cs
@@ -102,17 +102,23 @@ public class OcrService : IDisposable
         return GroupRealtime(blocks, bitmap.Height, mode);
     }
 
+    /// <param name="decisions">
+    /// Diagnostic only, and null everywhere but OcrHarness. Passed to whichever grouper this mode
+    /// really uses, so <c>--group-explain --realtime</c> reports the branch that ran rather than
+    /// the other one.
+    /// </param>
     internal static List<OcrTextBlock> GroupRealtime(List<OcrTextBlock> blocks, double frameHeight,
-        Realtime.RealtimeBlockMode mode, GroupingTrace? trace = null)
+        Realtime.RealtimeBlockMode mode, GroupingTrace? trace = null,
+        List<OcrTextBlockGrouper.NextLineDecision>? decisions = null)
     {
         var filtered = RejectUnconvincingBlocks(blocks);
         if (mode != Realtime.RealtimeBlockMode.Subtitle)
-            return OcrTextBlockGrouper.Group(filtered, GroupingProfile.Realtime, null, trace);
+            return OcrTextBlockGrouper.Group(filtered, GroupingProfile.Realtime, decisions, trace);
         trace?.RegisterBlocks(blocks);
         // Remove scene-sized noise before it can contaminate a real dialogue row. Confident
         // single letters (such as a split "I") may still join; isolated ones are filtered later.
         filtered = filtered.Where(b => !Realtime.CollapsedDetection.IsCollapsed(b.Bounds.Height, frameHeight, b.Text)).ToList();
-        return Realtime.DialogueTextGrouper.Group(filtered, trace);
+        return Realtime.DialogueTextGrouper.Group(filtered, trace, decisions);
     }
 
     // Scenery the recogniser was not sure about. Only on this path: it is the realtime one, where

--- a/src/OverTranslate/Services/Realtime/DialogueReadingTracker.cs
+++ b/src/OverTranslate/Services/Realtime/DialogueReadingTracker.cs
@@ -1,0 +1,156 @@
+using System.Windows;
+
+namespace OverTranslate.Services.Realtime;
+
+/// <summary>Temporal evidence for dialogue only. A small ending gets one confirming OCR pass.</summary>
+internal sealed class DialogueReadingTracker
+{
+    private Dictionary<(int Index, string Text), (string Text, Rect Bounds)> _pending = new();
+    private OcrTextBlock[] _placed = [];
+    private Dictionary<(int Index, string Text), Rect> _pendingPlacement = new();
+    private bool _settleRead;
+    private int _confirmationReads;
+    private bool _confirmationInFlight;
+    internal const int MaxConfirmationReads = 3;
+    public bool NeedsConfirmation => _confirmationReads < MaxConfirmationReads &&
+        (_settleRead || _pending.Count > 0 || _pendingPlacement.Count > 0);
+
+    public bool TryTakeConfirmation()
+    {
+        if (!NeedsConfirmation) return false;
+        _confirmationReads++;
+        _confirmationInFlight = true;
+        return true;
+    }
+
+    public void RecognitionUnavailable()
+    {
+        if (_confirmationInFlight) _confirmationReads--;
+        _confirmationInFlight = false;
+    }
+
+    // New pixel evidence can earn another bounded confirmation window. Rejected OCR wording
+    // alone cannot reset the budget, otherwise alternating false tails would renew it forever.
+    public void ObservePixelChange()
+    {
+        if (_confirmationReads >= MaxConfirmationReads)
+        {
+            _pending.Clear();
+            _pendingPlacement.Clear();
+        }
+        _confirmationReads = 0;
+    }
+
+    public ReadingMerge Merge(IReadOnlyList<RenderedLine> shown, IReadOnlyList<OcrTextBlock> read)
+    {
+        _confirmationInFlight = false;
+        var result = RealtimeReadingMerge.Merge(shown, read);
+        var pending = new Dictionary<(int Index, string Text), (string Text, Rect Bounds)>();
+        int confirmed = 0;
+        for (int i = 0; i < read.Count; i++)
+        {
+            var old = result.Lines[i];
+            var next = read[i];
+            if (TextSimilarity.IsSameWording(old.Text, next.Text) || (next.Confidence ?? 1) < 0.8)
+                continue;
+            // Exact prefix, not fuzzy similarity: do not turn every OCR correction into growth.
+            var prefix = Compact(old.Text);
+            var full = Compact(next.Text);
+            if (prefix.Length == 0 || full.Length <= prefix.Length || !full.StartsWith(prefix, StringComparison.Ordinal))
+                continue;
+            var key = (i, old.Text);
+            if (_pending.TryGetValue(key, out var previous) && previous.Text == full &&
+                !Moved(previous.Bounds, next.Bounds))
+            {
+                result.Blocks[i] = next;
+                result.Lines[i] = new RenderedLine(next.Text, next.Confidence ?? 1);
+                confirmed++;
+            }
+            else pending[key] = (full, next.Bounds);
+        }
+        _pending = pending;
+        // One final read even if the last few appearing glyphs were too small to change the
+        // frame fingerprint. Once an unchanged reading confirms it, the idle path is free again.
+        _settleRead = result.Changed || confirmed > 0;
+        if (_settleRead) _confirmationReads = 0;
+        bool moved = false;
+        var placement = new Dictionary<(int Index, string Text), Rect>();
+        for (int i = 0; _placed.Length == read.Count && i < read.Count; i++)
+        {
+            var block = result.Blocks[i];
+            var previous = _placed[i];
+            if (!TextSimilarity.IsSameWording(previous.Text, block.Text)) continue;
+            var a = previous.Bounds;
+            var b = block.Bounds;
+            double tolerance = Math.Max(2, Math.Min(a.Height, b.Height) * 0.25);
+            double dx = b.X + b.Width / 2 - a.X - a.Width / 2;
+            double dy = b.Y + b.Height / 2 - a.Y - a.Height / 2;
+            bool shifted = Math.Abs(dx) > tolerance || Math.Abs(dy) > tolerance;
+            bool resized = Math.Abs(a.Width - b.Width) > Math.Max(2, a.Width * 0.25) ||
+                Math.Abs(a.Height - b.Height) > Math.Max(2, a.Height * 0.25);
+            var key = (i, block.Text);
+            // Confirm size independently of position: a moving subtitle can hold a stable new
+            // size without ever returning to the same coordinates.
+            bool sizeConfirmed = resized && _pendingPlacement.TryGetValue(key, out var candidate) &&
+                SameSize(candidate, b);
+            if (sizeConfirmed || (!resized && shifted)) moved = true;
+            else
+            {
+                if (resized) placement[key] = b;
+                // Keep the accepted size and font metrics, but let the whole layout follow its
+                // new center immediately. Frozen child-line coordinates would still misplace text.
+                var held = previous with { Text = block.Text, Confidence = block.Confidence };
+                if (shifted)
+                {
+                    held = held with {
+                        Bounds = Translate(held.Bounds, dx, dy),
+                        LayoutBounds = held.LayoutBounds.IsEmpty || held.LayoutBounds == default
+                            ? held.LayoutBounds : Translate(held.LayoutBounds, dx, dy),
+                        SourceLineBounds = held.SourceLineBounds?.Select(r => Translate(r, dx, dy)).ToArray()
+                    };
+                    moved = true;
+                }
+                result.Blocks[i] = held;
+            }
+        }
+        _pendingPlacement = placement;
+        if (result.Changed || confirmed > 0 || moved)
+            _placed = result.Blocks.ToArray();
+        if (_confirmationReads >= MaxConfirmationReads)
+        {
+            _pending.Clear();
+            _pendingPlacement.Clear();
+        }
+        return result with { Improved = result.Improved + confirmed, Kept = result.Kept - confirmed, Repositioned = moved };
+    }
+
+    public void Reset()
+    {
+        _pending.Clear();
+        _pendingPlacement.Clear();
+        _settleRead = false;
+        _confirmationReads = 0;
+        _confirmationInFlight = false;
+        _placed = [];
+    }
+
+    private static string Compact(string text) => new(text.Where(c => !char.IsWhiteSpace(c)).ToArray());
+    private static Rect Translate(Rect bounds, double dx, double dy)
+    {
+        bounds.Offset(dx, dy);
+        return bounds;
+    }
+
+    private static bool SameSize(Rect a, Rect b)
+    {
+        double tolerance = Math.Max(2, Math.Min(a.Height, b.Height) * 0.25);
+        return Math.Abs(a.Width - b.Width) <= tolerance && Math.Abs(a.Height - b.Height) <= tolerance;
+    }
+
+    private static bool Moved(Rect a, Rect b)
+    {
+        double tolerance = Math.Max(2, Math.Min(a.Height, b.Height) * 0.25);
+        return Math.Abs(a.X - b.X) > tolerance || Math.Abs(a.Y - b.Y) > tolerance ||
+               Math.Abs(a.Width - b.Width) > tolerance || Math.Abs(a.Height - b.Height) > tolerance;
+    }
+}

--- a/src/OverTranslate/Services/Realtime/DialogueTextGrouper.cs
+++ b/src/OverTranslate/Services/Realtime/DialogueTextGrouper.cs
@@ -1,0 +1,111 @@
+using System.Windows;
+using OverTranslate.Services.Ocr;
+
+namespace OverTranslate.Services.Realtime;
+
+/// <summary>
+/// Dialogue-box geometry, independent of screenshot paragraph, punctuation and heading rules.
+/// Horizontal rows are completed first. An unresolved row is never partially joined vertically.
+/// </summary>
+internal static class DialogueTextGrouper
+{
+    internal static List<OcrTextBlock> Group(IReadOnlyList<OcrTextBlock> input, GroupingTrace? trace = null)
+    {
+        if (trace is not null && trace.Blocks.Count == 0) trace.RegisterBlocks(input);
+        if (input.Count <= 1)
+        {
+            foreach (var b in input) trace?.RegisterLine(b, [b]);
+            trace?.OrderLines(input);
+            trace?.RegisterGroups(input.Select(b => (IReadOnlyList<OcrTextBlock>)new[] { b }).ToList());
+            return input.ToList();
+        }
+        var rows = new List<List<OcrTextBlock>>();
+        foreach (var block in input.OrderBy(b => b.LayoutBounds.X).ThenBy(b => b.LayoutBounds.Y))
+        {
+            var row = rows.FirstOrDefault(r => r.Any(b => SameRow(b.LayoutBounds, block.LayoutBounds)));
+            if (row is null) rows.Add([block]);
+            else row.Add(block);
+        }
+        var lines = new List<(OcrTextBlock Block, bool Unresolved)>();
+        foreach (var row in rows)
+        {
+            var segments = new List<List<OcrTextBlock>>();
+            foreach (var block in row)
+            {
+                if (segments.Count == 0 || !Adjacent(segments[^1][^1].LayoutBounds, block.LayoutBounds))
+                    segments.Add([block]);
+                else segments[^1].Add(block);
+            }
+            // Single-character detections need a real text fragment as an anchor. Joining only
+            // isolated symbols would manufacture enough length to evade the downstream filter.
+            segments = segments.SelectMany(s => s.Count > 1 && s.All(b => b.Text.Count(c => !char.IsWhiteSpace(c)) < 2)
+                ? s.Select(b => new List<OcrTextBlock> { b }) : new[] { s }).ToList();
+            foreach (var segment in segments)
+            {
+                var line = OcrTextBlockGrouper.BuildGroup(segment);
+                if (segment.Count > 1)
+                    line = line with { Text = segment.Select(b => b.Text.Trim()).Aggregate(OcrTextBlockGrouper.JoinInlineText) };
+                trace?.RegisterLine(line, segment);
+                lines.Add((line, segments.Count > 1));
+            }
+        }
+        var groups = new List<List<OcrTextBlock>>();
+        var open = new List<bool>();
+        trace?.OrderLines(lines.OrderBy(l => l.Block.LayoutBounds.Y).ThenBy(l => l.Block.LayoutBounds.X).Select(l => l.Block).ToList());
+        foreach (var line in lines.OrderBy(l => l.Block.LayoutBounds.Y).ThenBy(l => l.Block.LayoutBounds.X))
+        {
+            int target = -1;
+            double nearest = double.MaxValue;
+            for (int i = 0; !line.Unresolved && i < groups.Count; i++)
+            {
+                if (!open[i]) continue;
+                var previous = groups[i][^1].LayoutBounds;
+                var current = line.Block.LayoutBounds;
+                if (!NextRow(previous, current)) continue;
+                var distance = current.Y - previous.Y;
+                if (distance < nearest) { target = i; nearest = distance; }
+            }
+            // A line we did not join is a boundary for older overlapping text. Do not later
+            // jump across a speaker label or a differently sized line to resume that group.
+            for (int i = 0; i < groups.Count; i++)
+            {
+                if (i == target) continue;
+                var previous = groups[i][^1].LayoutBounds;
+                var current = line.Block.LayoutBounds;
+                if (current.Y > previous.Y && Math.Min(previous.Right, current.Right) > Math.Max(previous.Left, current.Left))
+                    open[i] = false;
+            }
+            if (target < 0) { groups.Add([line.Block]); open.Add(!line.Unresolved); }
+            else groups[target].Add(line.Block);
+        }
+        trace?.RegisterGroups(groups);
+        return groups.Select(OcrTextBlockGrouper.BuildGroup).ToList();
+    }
+
+    private static bool SameRow(Rect a, Rect b) =>
+        Math.Min(a.Bottom, b.Bottom) - Math.Max(a.Top, b.Top) >= Math.Min(a.Height, b.Height) * 0.6 &&
+        Math.Abs((a.Top + a.Bottom - b.Top - b.Bottom) / 2) <= Math.Max(a.Height, b.Height) * 0.35;
+
+    private static bool Adjacent(Rect a, Rect b) =>
+        SameRow(a, b) && Math.Min(a.Height, b.Height) >= Math.Max(a.Height, b.Height) * 0.6 &&
+        b.Left - a.Right <= Math.Max(a.Height, b.Height) * 1.5;
+
+    private static bool NextRow(Rect a, Rect b)
+    {
+        double height = Math.Max(a.Height, b.Height);
+        // Long subtitle rows can have quite different detector padding even at the same font
+        // size. Give two substantial, similarly wide rows extra height tolerance; a short name
+        // or isolated symbol cannot borrow it from the dialogue beside it.
+        bool substantialRows = a.Width >= a.Height * 6 && b.Width >= b.Height * 6 &&
+            Math.Min(a.Width, b.Width) >= Math.Max(a.Width, b.Width) * 0.5;
+        if (height <= 0 || b.Y <= a.Y || SameRow(a, b) ||
+            Math.Min(a.Height, b.Height) < height * (substantialRows ? 0.6 : 0.75) ||
+            b.Top - a.Bottom > height * 0.65 || b.Top - a.Bottom < -height * 0.25)
+            return false;
+        var overlap = Math.Min(a.Right, b.Right) - Math.Max(a.Left, b.Left);
+        if (overlap < Math.Min(a.Width, b.Width) * 0.5) return false;
+        var alignment = Math.Min(Math.Abs(a.Left - b.Left), Math.Min(Math.Abs(a.Right - b.Right),
+            Math.Abs((a.Left + a.Right - b.Left - b.Right) / 2)));
+        return alignment <= height * 1.25;
+    }
+}

--- a/src/OverTranslate/Services/Realtime/DialogueTextGrouper.cs
+++ b/src/OverTranslate/Services/Realtime/DialogueTextGrouper.cs
@@ -9,7 +9,17 @@ namespace OverTranslate.Services.Realtime;
 /// </summary>
 internal static class DialogueTextGrouper
 {
-    internal static List<OcrTextBlock> Group(IReadOnlyList<OcrTextBlock> input, GroupingTrace? trace = null)
+    /// <param name="decisions">
+    /// Collects why each pair was joined or refused, for <c>OcrHarness --group-explain --realtime</c>.
+    /// Null everywhere but the harness, and read by no rule: a pass with one and a pass without
+    /// reach the same verdicts. The record is shared with the screenshot grouper, so several of its
+    /// fields have no dialogue meaning and are left at zero; the ones filled are named in the
+    /// harness's own legend.
+    /// </param>
+    internal static List<OcrTextBlock> Group(
+        IReadOnlyList<OcrTextBlock> input,
+        GroupingTrace? trace = null,
+        List<OcrTextBlockGrouper.NextLineDecision>? decisions = null)
     {
         if (trace is not null && trace.Blocks.Count == 0) trace.RegisterBlocks(input);
         if (input.Count <= 1)
@@ -32,8 +42,9 @@ internal static class DialogueTextGrouper
             var segments = new List<List<OcrTextBlock>>();
             foreach (var block in row)
             {
-                if (segments.Count == 0 || !Adjacent(segments[^1][^1].LayoutBounds, block.LayoutBounds))
-                    segments.Add([block]);
+                var joinsRow = segments.Count > 0 && Adjacent(segments[^1][^1].LayoutBounds, block.LayoutBounds);
+                if (segments.Count > 0) RecordRow(decisions, segments[^1][^1], block, joinsRow);
+                if (!joinsRow) segments.Add([block]);
                 else segments[^1].Add(block);
             }
             // Single-character detections need a real text fragment as an anchor. Joining only
@@ -61,7 +72,9 @@ internal static class DialogueTextGrouper
                 if (!open[i]) continue;
                 var previous = groups[i][^1].LayoutBounds;
                 var current = line.Block.LayoutBounds;
-                if (!NextRow(previous, current)) continue;
+                var joins = NextRow(previous, current, out var rule);
+                RecordNext(decisions, groups[i][^1], line.Block, joins, rule);
+                if (!joins) continue;
                 var distance = current.Y - previous.Y;
                 if (distance < nearest) { target = i; nearest = distance; }
             }
@@ -90,20 +103,25 @@ internal static class DialogueTextGrouper
         SameRow(a, b) && Math.Min(a.Height, b.Height) >= Math.Max(a.Height, b.Height) * 0.6 &&
         b.Left - a.Right <= Math.Max(a.Height, b.Height) * 1.5;
 
-    private static bool NextRow(Rect a, Rect b)
+    private static bool NextRow(Rect a, Rect b, out string rule)
     {
+        rule = "stacked";
         double height = Math.Max(a.Height, b.Height);
         // Long subtitle rows can have quite different detector padding even at the same font
         // size. Give two substantial, similarly wide rows extra height tolerance; a short name
         // or isolated symbol cannot borrow it from the dialogue beside it.
         bool substantialRows = a.Width >= a.Height * 6 && b.Width >= b.Height * 6 &&
             Math.Min(a.Width, b.Width) >= Math.Max(a.Width, b.Width) * 0.5;
-        if (height <= 0 || b.Y <= a.Y || SameRow(a, b) ||
-            Math.Min(a.Height, b.Height) < height * (substantialRows ? 0.6 : 0.75) ||
-            b.Top - a.Bottom > height * 0.65 || b.Top - a.Bottom < -height * 0.25)
-            return false;
+        // Named one test at a time rather than as a single condition, so a refusal can say which
+        // test refused it. The order and the numbers are unchanged.
+        if (height <= 0 || b.Y <= a.Y) { rule = "not-below"; return false; }
+        if (SameRow(a, b)) { rule = "same-row"; return false; }
+        if (Math.Min(a.Height, b.Height) < height * (substantialRows ? 0.6 : 0.75))
+        { rule = "height-mismatch"; return false; }
+        if (b.Top - a.Bottom > height * 0.65) { rule = "gap-too-wide"; return false; }
+        if (b.Top - a.Bottom < -height * 0.25) { rule = "overlaps-above"; return false; }
         var overlap = Math.Min(a.Right, b.Right) - Math.Max(a.Left, b.Left);
-        if (overlap < Math.Min(a.Width, b.Width) * 0.5) return false;
+        if (overlap < Math.Min(a.Width, b.Width) * 0.5) { rule = "no-column-overlap"; return false; }
         var alignment = Math.Min(Math.Abs(a.Left - b.Left), Math.Min(Math.Abs(a.Right - b.Right),
             Math.Abs((a.Left + a.Right - b.Left - b.Right) / 2)));
         // Two substantial, similarly wide rows get the same benefit of the doubt on alignment that
@@ -111,6 +129,63 @@ internal static class DialogueTextGrouper
         // well to the right of the row above it — measured at 138px on a 64px line, 2.2 heights —
         // and refusing to stack them there turns one missing word into two overlay boxes. A short
         // name or an isolated symbol still cannot borrow this.
-        return alignment <= height * (substantialRows ? 2.5 : 1.25);
+        if (alignment > height * (substantialRows ? 2.5 : 1.25)) { rule = "alignment"; return false; }
+        rule = substantialRows ? "stacked-substantial" : "stacked";
+        return true;
+    }
+
+    // The two verdicts, in the record the harness already knows how to print. "row" puts the
+    // HORIZONTAL gap in VerticalGap and the vertical overlap in LeftDelta, because that is what the
+    // row printer labels those two columns; "next" fills the three alignment deltas and the one the
+    // gate actually read. Anything left at zero is a quantity the dialogue rules never compute, and
+    // the harness prints its own legend saying so.
+    private static void RecordRow(
+        List<OcrTextBlockGrouper.NextLineDecision>? decisions,
+        OcrTextBlock previous, OcrTextBlock current, bool joined)
+    {
+        if (decisions is null) return;
+        Rect a = previous.LayoutBounds, b = current.LayoutBounds;
+        double height = Math.Max(a.Height, b.Height);
+        if (height <= 0) return;
+        var rule = !SameRow(a, b) ? "not-same-row"
+            : Math.Min(a.Height, b.Height) < height * 0.6 ? "row-height-mismatch"
+            : b.Left - a.Right > height * 1.5 ? "row-gap-too-wide"
+            : "adjacent";
+        decisions.Add(new OcrTextBlockGrouper.NextLineDecision(
+            "row", previous.Text, current.Text, previous.LayoutScript, current.LayoutScript,
+            VerticalGap: (b.Left - a.Right) / height,
+            LeftDelta: (Math.Min(a.Bottom, b.Bottom) - Math.Max(a.Top, b.Top))
+                / Math.Max(1, Math.Min(a.Height, b.Height)),
+            CenterDelta: 0, RightDelta: 0, AlignmentDelta: 0,
+            TextSizeRatio: Math.Min(a.Height, b.Height) / height,
+            WidthRatio: Math.Min(a.Width, b.Width) / Math.Max(1, Math.Max(a.Width, b.Width)),
+            LineAdvance: 0, LeadingBar: 0, SolidBar: 0, Joined: joined, Rule: rule));
+    }
+
+    private static void RecordNext(
+        List<OcrTextBlockGrouper.NextLineDecision>? decisions,
+        OcrTextBlock previous, OcrTextBlock current, bool joined, string rule)
+    {
+        if (decisions is null) return;
+        Rect a = previous.LayoutBounds, b = current.LayoutBounds;
+        double height = Math.Max(a.Height, b.Height);
+        if (height <= 0) return;
+        double left = Math.Abs(a.Left - b.Left), right = Math.Abs(a.Right - b.Right);
+        double centre = Math.Abs((a.Left + a.Right - b.Left - b.Right) / 2);
+        bool substantialRows = a.Width >= a.Height * 6 && b.Width >= b.Height * 6 &&
+            Math.Min(a.Width, b.Width) >= Math.Max(a.Width, b.Width) * 0.5;
+        decisions.Add(new OcrTextBlockGrouper.NextLineDecision(
+            "next", previous.Text, current.Text, previous.LayoutScript, current.LayoutScript,
+            VerticalGap: (b.Top - a.Bottom) / height,
+            LeftDelta: left / height, CenterDelta: centre / height, RightDelta: right / height,
+            AlignmentDelta: Math.Min(left, Math.Min(right, centre)) / height,
+            TextSizeRatio: Math.Min(a.Height, b.Height) / height,
+            WidthRatio: Math.Min(a.Width, b.Width) / Math.Max(1, Math.Max(a.Width, b.Width)),
+            LineAdvance: (b.Y - a.Y) / height,
+            // The two gates this grouper actually runs, in the columns the screenshot flow uses for
+            // its own: the height floor it was judged against, and the alignment ceiling.
+            LeadingBar: substantialRows ? 0.6 : 0.75,
+            SolidBar: substantialRows ? 2.5 : 1.25,
+            Joined: joined, Rule: rule));
     }
 }

--- a/src/OverTranslate/Services/Realtime/DialogueTextGrouper.cs
+++ b/src/OverTranslate/Services/Realtime/DialogueTextGrouper.cs
@@ -106,6 +106,11 @@ internal static class DialogueTextGrouper
         if (overlap < Math.Min(a.Width, b.Width) * 0.5) return false;
         var alignment = Math.Min(Math.Abs(a.Left - b.Left), Math.Min(Math.Abs(a.Right - b.Right),
             Math.Abs((a.Left + a.Right - b.Left - b.Right) / 2)));
-        return alignment <= height * 1.25;
+        // Two substantial, similarly wide rows get the same benefit of the doubt on alignment that
+        // they already get on height. A dialogue row whose leading word the detector missed starts
+        // well to the right of the row above it — measured at 138px on a 64px line, 2.2 heights —
+        // and refusing to stack them there turns one missing word into two overlay boxes. A short
+        // name or an isolated symbol still cannot borrow this.
+        return alignment <= height * (substantialRows ? 2.5 : 1.25);
     }
 }

--- a/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeDetectorSize.cs
@@ -74,6 +74,19 @@ namespace OverTranslate.Services.Realtime;
 /// spend its budget raising the detector size for small text, which is the case that was already
 /// reading well. Issue #89 was closed on this rather than carried into an implementation.
 ///
+/// EVERY TABLE ABOVE WAS MEASURED WHILE THE FRACTION WAS NOT WHAT THE DETECTOR GOT. Until the
+/// geometry fix (<c>OnnxOcrEngine.CreateDetectorFrame</c>) the size asked for here was a request the
+/// library rounded down twice, by a different amount on each axis: a strip asked for at 0.85 reached
+/// the detector at 0.84 across and 0.73 down. So "1.00 reads worse than 0.85" compared two distorted
+/// readings, and the row labelled 1.00 was never a native read.
+///
+/// The fractions themselves survive it. Re-swept on region-subtitle-mixed-boxshape (123 frames, the
+/// corpus whose distortion ranged widest — 1.15x to 1.34x) with the geometry exact, at 0.85x, 1.0x
+/// and 1.15x of what this type returns: 97.7%, 99.8% and 98.5% character F1. 1.0x — that is, leaving
+/// <see cref="StripFraction"/> at 0.85 — is the peak with both neighbours worse, so there is nothing
+/// to re-tune here and no reason to spend another sweep on it. What did change is that the fraction
+/// now means the same thing whatever size the user's box happens to be.
+///
 /// Three stories were tried and did not survive, which is why this note is longer than its
 /// conclusion: "the model wants ~30px" is PP-OCRv5 folklore; "bigger keeps helping, saturating at
 /// 40–50px" is what the strictest success criterion alone shows on one corpus, and the same data

--- a/src/OverTranslate/Services/Realtime/RealtimeReadingMerge.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeReadingMerge.cs
@@ -22,7 +22,8 @@ internal readonly record struct ReadingMerge(
     int Dropped)
 {
     /// <summary>Whether anything the reader can see is different from what is on screen now.</summary>
-    public bool Changed => Improved > 0 || Added > 0 || Dropped > 0;
+    public bool Repositioned { get; init; }
+    public bool Changed => Improved > 0 || Added > 0 || Dropped > 0 || Repositioned;
 }
 
 /// <summary>

--- a/src/OverTranslate/Services/Realtime/RealtimeRegionState.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeRegionState.cs
@@ -83,6 +83,7 @@ internal sealed class RealtimeRegionState
     private int _unsettledPolls;
     private int _pollsSinceFullScan;
     private int _emptyPasses;
+    internal DialogueReadingTracker Dialogue { get; } = new();
 
     /// <summary>
     /// What the region shows, one entry per line, each with the score it was read at — so a later
@@ -122,16 +123,18 @@ internal sealed class RealtimeRegionState
     /// policy with fingerprints it builds by hand.
     /// </param>
     /// <returns>Whether the frame should be recognised now.</returns>
-    public bool Observe(Func<IReadOnlyList<Rectangle>?, FrameFingerprint> capture)
+    public bool Observe(Func<IReadOnlyList<Rectangle>?, FrameFingerprint> capture, bool dialogue = false)
     {
+        if (dialogue && Dialogue.TryTakeConfirmation()) return true;
         var current = capture(IsWatchingText ? _watchBands : null);
 
         if (current.Differs(_rendered))
         {
+            if (dialogue) Dialogue.ObservePixelChange();
             // Changed, and not yet the same twice running. Give it a poll to settle so a line that
             // is still fading in is read once it has arrived — but only up to the cap, or content
             // that never holds still would never be read at all.
-            var cap = IsWatchingText ? MaxTextUnsettledPolls : MaxUnsettledPolls;
+            var cap = IsWatchingText ? (dialogue ? 0 : MaxTextUnsettledPolls) : MaxUnsettledPolls;
             if (current.Differs(_pending) && _unsettledPolls < cap)
             {
                 _pending = current;
@@ -156,7 +159,9 @@ internal sealed class RealtimeRegionState
         if (++_pollsSinceFullScan < FullRescanPolls) return false;
 
         _pollsSinceFullScan = 0;
-        return capture(null).Differs(_renderedFull);
+        bool changed = capture(null).Differs(_renderedFull);
+        if (dialogue && changed) Dialogue.ObservePixelChange();
+        return changed;
     }
 
     /// <summary>
@@ -244,6 +249,7 @@ internal sealed class RealtimeRegionState
     /// </remarks>
     public void Invalidate()
     {
+        Dialogue.Reset();
         _rendered = null;
         _renderedFull = null;
         _pending = null;

--- a/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
+++ b/src/OverTranslate/Services/Realtime/RealtimeTranslationSession.cs
@@ -361,7 +361,7 @@ public sealed class RealtimeTranslationSession
                 // consulting a policy whose whole job is deciding which polls are worth paying for.
                 // A reading caught mid-change is not lost either — the next pass keeps the better of
                 // the two, see RealtimeReadingMerge.
-                if (!demanded && !state.Observe(Capture))
+                if (!demanded && !state.Observe(Capture, region.Mode == RealtimeBlockMode.Subtitle))
                 {
                     skippedPolls++;
                     continue;
@@ -490,9 +490,10 @@ public sealed class RealtimeTranslationSession
         // would hold this region's loop shut while it did. Skipping costs one poll.
         var (primarySize, fallbackSizes) =
             RealtimeDetectorSize.For(frame.Width, frame.Height, region.Mode);
-        var recognized = await _ocr.TryRecognizeAsync(frame, sourceLanguage, primarySize, token);
+        var recognized = await _ocr.TryRecognizeAsync(frame, sourceLanguage, primarySize, token, region.Mode);
         if (recognized is null)
         {
+            state.Dialogue.RecognitionUnavailable();
             // Once per session at Warn, the rest at Debug — the same rule the grab and translation
             // sides use. Skipping is the whole recovery and the next poll is 250ms away, so this is
             // not an error; it is the one thing that would explain a region updating far less often
@@ -540,7 +541,7 @@ public sealed class RealtimeTranslationSession
         {
             if (recognized.Count > 0) break;
 
-            var retried = await _ocr.TryRecognizeAsync(frame, sourceLanguage, retrySize, token);
+            var retried = await _ocr.TryRecognizeAsync(frame, sourceLanguage, retrySize, token, region.Mode);
             if (retried is null) break;   // no free slot; the next poll can try again
 
             retried = RejectCollapsedBlocks(retried, frame.Height, region.Id);
@@ -576,6 +577,7 @@ public sealed class RealtimeTranslationSession
         // further: this is the case that keeps a session over moving content off the network.
         if (recognized.Count == 0)
         {
+            state.Dialogue.Reset();
             // Checked before the "same text" shortcut below, because both are the empty string once
             // the region has genuinely gone quiet and only this branch counts that towards clearing.
             RealtimeFrameDump.SaveUnread(frame, region.Id);
@@ -594,7 +596,9 @@ public sealed class RealtimeTranslationSession
         // readings, and a sentence nothing on screen answers to is simply new. Doing this per pass
         // instead — one weighted average against another — is what let a correctly read sentence be
         // thrown away because the line beside it had wobbled; see RealtimeReadingMerge.
-        var merged = RealtimeReadingMerge.Merge(state.RenderedLines, recognized);
+        var merged = region.Mode == RealtimeBlockMode.Subtitle
+            ? state.Dialogue.Merge(state.RenderedLines, recognized)
+            : RealtimeReadingMerge.Merge(state.RenderedLines, recognized);
         var shownBefore = state.RenderedText.Length;
 
         // Whether this pass read the region differently at all, as opposed to reading it the same
@@ -643,7 +647,7 @@ public sealed class RealtimeTranslationSession
     }
 
     /// <summary>Drops boxes the detector threw across the whole block — see CollapsedDetection.</summary>
-    private static List<OcrTextBlock> RejectCollapsedBlocks(
+    internal static List<OcrTextBlock> RejectCollapsedBlocks(
         List<OcrTextBlock> blocks, double blockHeight, int regionId)
     {
         List<OcrTextBlock>? kept = null;
@@ -685,7 +689,7 @@ public sealed class RealtimeTranslationSession
     /// a subtitle was 158px tall in a 220px block — well clear of a real line at 86px, but short of
     /// the 90% that makes a collapse, so no measure of the box was ever going to reject it.
     /// </remarks>
-    private static List<OcrTextBlock> RejectShortReadings(List<OcrTextBlock> blocks, int regionId)
+    internal static List<OcrTextBlock> RejectShortReadings(List<OcrTextBlock> blocks, int regionId)
     {
         List<OcrTextBlock>? kept = null;
 

--- a/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
+++ b/src/OverTranslate/Views/Realtime/RealtimeBlockWindow.xaml.cs
@@ -275,7 +275,6 @@ public partial class RealtimeBlockWindow : Window
         TranslatedBlock line, double canvasWidth, double canvasHeight, System.Drawing.Bitmap? frame)
     {
         double left = line.Bounds.X / _dpiX;
-        double top = line.Bounds.Y / _dpiY;
         double sourceWidth = line.Bounds.Width / _dpiX;
         double sourceHeight = line.Bounds.Height / _dpiY;
         if (sourceWidth <= 0 || sourceHeight <= 0) return null;
@@ -380,16 +379,18 @@ public partial class RealtimeBlockWindow : Window
 
         double scrimWidth = Math.Min(canvasWidth, Math.Max(textWidth, sourceWidth) + ScrimPaddingX * 2);
 
-        // A grouped block's bounds are the union of its lines, which is the area that has to be
-        // covered and is not an inflated single box, so it keeps using them.
-        double coverHeight = isGrouped ? sourceHeight : lineHeight;
+        // A union of loose Latin detection boxes still includes the first/last row's padding.
+        // Compact each row around its own center before taking the vertical span; keep the gap.
+        var coverage = isGrouped ? GroupedCoverage(line) : line.Bounds;
+        double coverHeight = isGrouped ? coverage.Height / _dpiY : lineHeight;
         double scrimHeight = Math.Max(coverHeight, textHeight) + ScrimPaddingY * 2;
 
         // The scrim covers the source, so it grows around the source's own centre — horizontally as
         // well as vertically — rather than hanging off its top-left corner.
         double scrimLeft = RealtimeBandPlacement.Left(left, sourceWidth, scrimWidth, canvasWidth);
         double scrimTop = Math.Clamp(
-            top + sourceHeight / 2 - scrimHeight / 2, 0, Math.Max(0, canvasHeight - scrimHeight));
+            coverage.Y / _dpiY + coverage.Height / _dpiY / 2 - scrimHeight / 2,
+            0, Math.Max(0, canvasHeight - scrimHeight));
 
         // The band's own geometry, which is also what the repaired patch falls back to. The guard
         // below only exists to hold the repair, so with 進階選項 off these stay as they are and the
@@ -683,6 +684,27 @@ public partial class RealtimeBlockWindow : Window
                 return size;
 
         return MinFontSize;
+    }
+
+    private static Rect GroupedCoverage(TranslatedBlock line)
+    {
+        // CJK-normalized boxes already carry compact coverage. Do not shrink them a second time.
+        if (line.RenderGlyphHeight is not { } glyphHeight || !double.IsFinite(glyphHeight) || glyphHeight <= 0 ||
+            line.SourceLineBounds is not { Count: > 1 } rows)
+            return line.Bounds;
+
+        double top = double.PositiveInfinity;
+        double bottom = double.NegativeInfinity;
+        foreach (var row in rows)
+        {
+            if (row.IsEmpty || row.Height <= 0 || !double.IsFinite(row.Y) || !double.IsFinite(row.Height))
+                return line.Bounds;
+            double height = Math.Min(row.Height, glyphHeight * LineHeightRatio);
+            double center = row.Y + row.Height / 2;
+            top = Math.Min(top, center - height / 2);
+            bottom = Math.Max(bottom, center + height / 2);
+        }
+        return new Rect(line.Bounds.X, top, line.Bounds.Width, bottom - top);
     }
 
     private double GetGlyphHeight(TranslatedBlock line, double fallbackHeight)

--- a/tests/OverTranslate.Tests/DetectorFrameGeometryTests.cs
+++ b/tests/OverTranslate.Tests/DetectorFrameGeometryTests.cs
@@ -1,0 +1,99 @@
+using System;
+using OverTranslate.Services.Ocr;
+using OverTranslate.Services.Realtime;
+using SkiaSharp;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The invariant #69 spent three rounds failing to name: the detector must see the aspect ratio it
+/// was handed, whatever pixel size the user's box happens to be.
+/// </summary>
+/// <remarks>
+/// It used not to. RapidOcrNet's ScaleParam quantises each axis on its own with (n / 32 - 1) * 32,
+/// and the old AlignForDetector-only approach avoided that solely when the library's scale came out
+/// exactly 1.0 — which it never did once alignment had grown the bitmap past the ImgResize computed
+/// from the size before alignment. A 465x76 dialogue box reached the detector 0.89x across and 0.67x
+/// down, and the leading "「うん、" was never detected.
+///
+/// These run no inference: geometry is decided before the model is loaded, so it can be asserted
+/// without one, and a test that needed a model would not run in CI.
+/// </remarks>
+public class DetectorFrameGeometryTests
+{
+    // Real captures and the awkward sizes around them: the two ja-game dialogue boxes that opened
+    // this, the subtitle strips the corpora are made of, and sizes either side of a stride boundary.
+    [Theory]
+    [InlineData(465, 76)]
+    [InlineData(450, 150)]
+    [InlineData(1150, 240)]
+    [InlineData(1825, 223)]
+    [InlineData(1824, 129)]
+    [InlineData(264, 56)]
+    [InlineData(270, 60)]
+    [InlineData(2473, 892)]
+    [InlineData(3840, 2160)]
+    public void TheDetectorSeesTheAspectRatioItWasHanded(int width, int height)
+    {
+        using var frame = FrameFor(width, height, RealtimeBlockMode.Subtitle);
+
+        // One rounded pixel on each axis is all the isotropic resize can introduce, and on the
+        // narrowest dimension here that is under half a percent.
+        Assert.InRange(frame.RatioX / frame.RatioY, 0.995, 1.005);
+    }
+
+    [Theory]
+    [InlineData(465, 76)]
+    [InlineData(1150, 240)]
+    [InlineData(1825, 223)]
+    [InlineData(2473, 892)]
+    public void TheLibraryIsGivenNothingLeftToResize(int width, int height)
+    {
+        using var frame = FrameFor(width, height, RealtimeBlockMode.Subtitle);
+
+        // Two conditions together are what skips the quantisation: the resize target cannot bind
+        // (so the ratio is exactly 1), and both padded dimensions are already on the stride (so the
+        // per-axis rounding has nothing to round). Either one alone leaves it running.
+        var padded = (
+            Width: frame.Bitmap.Width + 2 * frame.Options.Padding,
+            Height: frame.Bitmap.Height + 2 * frame.Options.Padding);
+
+        Assert.True(frame.Options.ImgResize >= Math.Max(padded.Width, padded.Height));
+        Assert.Equal(0, padded.Width % 32);
+        Assert.Equal(0, padded.Height % 32);
+    }
+
+    [Theory]
+    [InlineData(1150, 240, RealtimeBlockMode.Subtitle)]
+    [InlineData(1825, 223, RealtimeBlockMode.Subtitle)]
+    [InlineData(2473, 892, RealtimeBlockMode.Panel)]
+    public void TheDetectorSizeAskedForIsTheOneItGets(int width, int height, RealtimeBlockMode mode)
+    {
+        var requested = RealtimeDetectorSize.For(width, height, mode).Primary;
+        using var frame = FrameFor(width, height, mode);
+
+        // Alignment can add up to a stride on top, and nothing more: the request used to be rounded
+        // DOWN twice instead, by a different amount on each axis.
+        var longest = Math.Max(frame.Bitmap.Width, frame.Bitmap.Height);
+        Assert.InRange(longest, requested, requested + 31);
+    }
+
+    [Fact]
+    public void ASmallRegionIsNotResizedAtAll()
+    {
+        // Below RealtimeDetectorSize.DownscaleMinSide the region is read at native size, so the only
+        // thing the frame may do is align it — the case the 465x76 dialogue box falls into.
+        using var frame = FrameFor(465, 76, RealtimeBlockMode.Subtitle);
+
+        Assert.Equal(1.0, frame.RatioX);
+        Assert.Equal(1.0, frame.RatioY);
+    }
+
+    private static OnnxOcrEngine.DetectorFrame FrameFor(int width, int height, RealtimeBlockMode mode)
+    {
+        using var source = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+        return OnnxOcrEngine.CreateDetectorFrame(
+            source, RealtimeDetectorSize.For(width, height, mode).Primary);
+    }
+}

--- a/tests/OverTranslate.Tests/DialogueTextGrouperTests.cs
+++ b/tests/OverTranslate.Tests/DialogueTextGrouperTests.cs
@@ -1,0 +1,131 @@
+using System.Windows;
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using OverTranslate.Services.Realtime;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class DialogueTextGrouperTests
+{
+    [Fact]
+    public void ImaiSubtitleWideCaptureKeepsBothRowsTogether()
+    {
+        Assert.Single(DialogueTextGrouper.Group([
+            Block("I do want to see how you look", 482, 19, 833, 104),
+            Block("in Ako'sclothes, Imai-san.", 526, 108, 759, 71)]));
+    }
+
+    [Theory]
+    [InlineData(100, 45, 759)] // still too different in height
+    [InlineData(200, 71, 759)] // too far below the previous line
+    [InlineData(108, 71, 140)] // a short label cannot use the relaxed height check
+    public void SubtitleHeightToleranceDoesNotRemoveOtherGuards(double y, double height, double width)
+    {
+        Assert.Equal(2, DialogueTextGrouper.Group([
+            Block("I do want to see how you look", 482, 19, 833, 104),
+            Block("Other text", 526, y, width, height)]).Count);
+    }
+
+    [Theory]
+    [InlineData("想像を超えてく", "る每日", "想像を超えてくる每日")]
+    [InlineData("踏んできた修羅場が", "just like a", "踏んできた修羅場がjust like a")]
+    [InlineData("I", "am here.", "I am here.")]
+    public void InlineTextUsesTheExistingBoundarySpacing(string left, string right, string expected)
+    {
+        Assert.Equal(expected, Assert.Single(DialogueTextGrouper.Group([Block(left, 0, 0, 100), Block(right, 108, 0, 100)])).Text);
+    }
+
+    [Fact]
+    public void TwoIsolatedNoiseCharactersCannotBecomeAWord()
+    {
+        var grouped = OcrService.GroupRealtime([Block("元", 976, 2, 27, 19, 0.96), Block("V", 1015, 0, 23, 22, 0.81)], 223, RealtimeBlockMode.Subtitle);
+        Assert.Empty(RealtimeTranslationSession.RejectShortReadings(grouped, -1));
+    }
+
+    [Fact]
+    public void SmallerSpeakerNameAboveDialogueStaysSeparate()
+    {
+        Assert.Equal(2, DialogueTextGrouper.Group([Block("しろは", 211, 56, 86, 32), Block("「うん、じゃあ次はね……", 57, 114, 335, 48)]).Count);
+    }
+
+    [Fact]
+    public void DifferentSizedUiRowsStaySeparate()
+    {
+        Assert.Equal(3, DialogueTextGrouper.Group([Block("미스틸", 113, 0, 207, 52), Block("×××", 171, 58, 96, 32), Block("RP 8932-680", 59, 103, 369, 53)]).Count);
+    }
+
+    [Fact]
+    public void GuitarDialogueBenefitSurvives()
+    {
+        Assert.Single(DialogueTextGrouper.Group([Block("The news did say they were building", 70, 62, 921, 79),
+            Block("a facility to study that weird guitar...", 64, 127, 940, 78)]));
+    }
+
+    private static OcrTextBlock Block(string text, double x, double y, double w, double h = 20, double confidence = 0.99) =>
+        new(text, new Rect(x, y, w, h), Confidence: confidence, LayoutBounds: new Rect(x, y, w, h),
+            LayoutScript: OcrLayoutScript.Latin, LayoutGlyphHeight: h * 0.82);
+
+    [Fact]
+    public void JoinsSplitRowsBeforeJoiningTheNextSentence()
+    {
+        var a = Block("I heard a bunch", 0, 0, 140);
+        var b = Block("of experts.", 160, 0, 110);
+        var c = Block("They are studying it.", 20, 29, 220);
+        var group = Assert.Single(DialogueTextGrouper.Group([c, b, a]));
+        Assert.Equal("I heard a bunch of experts. They are studying it.", group.Text);
+        Assert.Equal(2, group.Lines.Count);
+    }
+
+    [Fact]
+    public void UnresolvedHorizontalGapCannotBeSkippedVertically()
+    {
+        var a = Block("left text", 0, 0, 100);
+        var b = Block("right text", 240, 0, 100);
+        var c = Block("below text", 0, 27, 100);
+        Assert.Equal(3, DialogueTextGrouper.Group([a, b, c]).Count);
+    }
+
+    [Theory]
+    [InlineData(0, 65, 160, 20)] // separate dialogue boxes
+    [InlineData(300, 28, 160, 20)] // another column
+    [InlineData(0, 28, 100, 8)] // tiny UI/name tag
+    public void DoesNotJoinUnrelatedGeometry(double x, double y, double w, double h)
+    {
+        Assert.Equal(2, DialogueTextGrouper.Group([Block("Main dialogue", 0, 0, 200), Block("Other text", x, y, w, h)]).Count);
+    }
+
+    [Fact]
+    public void NoiseIsRemovedBeforeItCanContaminateDialogue()
+    {
+        var noise = Block("EIN", 0, 0, 240, 110, 0.99);
+        var shortNoise = Block("x", 60, 10, 10, confidence: 0.5);
+        var text = Block("Actual dialogue", 0, 30, 180);
+        Assert.Equal(text, Assert.Single(OcrService.GroupRealtime([noise, shortNoise, text], 100, RealtimeBlockMode.Subtitle)));
+    }
+
+    [Fact]
+    public void PanelRoutingStillUsesTheOriginalGrouper()
+    {
+        var blocks = new List<OcrTextBlock> { Block("Title", 0, 0, 100), Block("Description", 0, 28, 180) };
+        var expected = OcrTextBlockGrouper.Group(OcrService.RejectUnconvincingBlocks(blocks), GroupingProfile.Realtime);
+        var actual = OcrService.GroupRealtime(blocks, 100, RealtimeBlockMode.Panel);
+        Assert.Equal(expected.Select(b => (b.Text, b.Bounds)), actual.Select(b => (b.Text, b.Bounds)));
+    }
+
+    [Fact]
+    public void DoesNotSkipAnInterveningSpeakerLabel()
+    {
+        var top = Block("Previous dialogue", 0, 0, 200);
+        var label = Block("Speaker", 0, 21, 60, 5);
+        var bottom = Block("Next dialogue", 0, 28, 200);
+        Assert.Equal(3, DialogueTextGrouper.Group([top, label, bottom]).Count);
+    }
+
+    [Fact]
+    public void ConfidentSingleLetterCanJoinItsSentence()
+    {
+        var result = OcrService.GroupRealtime([Block("I", 0, 0, 8), Block("am here.", 15, 0, 90)], 100, RealtimeBlockMode.Subtitle);
+        Assert.Equal("I am here.", Assert.Single(result).Text);
+    }
+}

--- a/tests/OverTranslate.Tests/RealtimeDialogueProgressTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeDialogueProgressTests.cs
@@ -1,0 +1,211 @@
+using System.Windows;
+using OverTranslate.Services;
+using OverTranslate.Services.Realtime;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class RealtimeDialogueProgressTests
+{
+    [Theory]
+    [InlineData(50, 0)]
+    [InlineData(-50, 0)]
+    [InlineData(0, 50)]
+    public void MovingAndResizingFollowsCenterBeforeConfirmingSize(double dx, double dy)
+    {
+        var tracker = new DialogueReadingTracker();
+        var initial = Read("Same dialogue.") with {
+            SourceLineBounds = [new Rect(10, 10, 420, 30)],
+            LayoutBounds = new Rect(10, 10, 420, 30), RenderGlyphHeight = 18 };
+        var result = tracker.Merge([], [initial]);
+        for (int step = 1; step <= 3; step++)
+        {
+            var raw = initial with { Bounds = new Rect(10 + dx * step, 10 + dy * step, 420, 38),
+                SourceLineBounds = [new Rect(10 + dx * step, 10 + dy * step, 420, 38)],
+                LayoutBounds = new Rect(10 + dx * step, 10 + dy * step, 420, 38), RenderGlyphHeight = 24 };
+            result = tracker.Merge(result.Lines, [raw]);
+            var displayed = result.Blocks[0];
+            Assert.True(result.Repositioned);
+            Assert.Equal(raw.Bounds.X + raw.Bounds.Width / 2, displayed.Bounds.X + displayed.Bounds.Width / 2);
+            Assert.Equal(raw.Bounds.Y + raw.Bounds.Height / 2, displayed.Bounds.Y + displayed.Bounds.Height / 2);
+            Assert.Equal(step == 1 ? 30 : 38, displayed.Bounds.Height);
+            Assert.Equal(displayed.Bounds, Assert.Single(displayed.Lines));
+            Assert.Equal(displayed.Bounds, displayed.LayoutBounds);
+            Assert.Equal(step == 1 ? 18 : 24, displayed.RenderGlyphHeight);
+        }
+    }
+
+    [Fact]
+    public void CuteSubtitleLoggedBoxWobbleDoesNotRedrawStableWords()
+    {
+        var tracker = new DialogueReadingTracker();
+        var boxes = new[] {
+            new Rect(780, 121.4, 158, 37.3), new Rect(775, 121.5, 165, 38.9),
+            new Rect(776, 119.3, 171, 40.4), new Rect(785, 121.2, 155, 36.6),
+            new Rect(779, 105.4, 161, 67.2), new Rect(780, 123.1, 160, 37.8) };
+        var result = tracker.Merge([], [new OcrTextBlock("Cute!", boxes[0], Confidence: 1)]);
+        foreach (var box in boxes.Skip(1))
+        {
+            result = tracker.Merge(result.Lines, [new OcrTextBlock("Cute!", box, Confidence: 1)]);
+            Assert.False(result.Changed);
+        }
+    }
+
+    [Fact]
+    public void MovingWithAlternatingSizesStillHasABoundedConfirmationBudget()
+    {
+        var tracker = new DialogueReadingTracker();
+        var result = tracker.Merge([], [Read("Same dialogue.")]);
+        int reads = 0;
+        for (int poll = 0; poll < 20; poll++)
+        {
+            if (!tracker.TryTakeConfirmation()) continue;
+            reads++;
+            var raw = Read("Same dialogue.", x: 10 + reads * 50) with {
+                Bounds = new Rect(10 + reads * 50, 10, 420, reads % 2 == 0 ? 58 : 38) };
+            result = tracker.Merge(result.Lines, [raw]);
+            Assert.True(result.Repositioned);
+            Assert.Equal(raw.Bounds.X, result.Blocks[0].Bounds.X);
+            Assert.Equal(30, result.Blocks[0].Bounds.Height);
+        }
+        Assert.Equal(DialogueReadingTracker.MaxConfirmationReads, reads);
+        Assert.False(tracker.NeedsConfirmation);
+    }
+
+    [Fact]
+    public void ExpiredTailNeedsFreshEvidenceAfterPixelChange()
+    {
+        var tracker = new DialogueReadingTracker();
+        var first = tracker.Merge([], [Read("Here we go.")]);
+        for (int i = 0; i < DialogueReadingTracker.MaxConfirmationReads; i++)
+        {
+            Assert.True(tracker.TryTakeConfirmation());
+            tracker.Merge(first.Lines, [Read(i % 2 == 0 ? "Here we go.x" : "Here we go.y")]);
+        }
+        Assert.False(tracker.NeedsConfirmation);
+        tracker.ObservePixelChange();
+        var fresh = tracker.Merge(first.Lines, [Read("Here we go.x")]);
+        Assert.False(fresh.Changed);
+        Assert.Equal("Here we go.x", tracker.Merge(fresh.Lines, [Read("Here we go.x")]).Lines[0].Text);
+    }
+
+    [Fact]
+    public void PersistentResizeIsConfirmedButDoesNotRenewOcrForever()
+    {
+        var tracker = new DialogueReadingTracker();
+        var first = tracker.Merge([], [Read("Same dialogue.")]);
+        var larger = new OcrTextBlock("Same dialogue.", new Rect(0, 0, 440, 50), Confidence: 0.98);
+        var pending = tracker.Merge(first.Lines, [larger]);
+        Assert.False(pending.Changed);
+        Assert.Equal(first.Blocks[0].Bounds, pending.Blocks[0].Bounds);
+        Assert.True(tracker.TryTakeConfirmation());
+        var confirmed = tracker.Merge(pending.Lines, [larger]);
+        Assert.True(confirmed.Repositioned);
+        Assert.Equal(larger.Bounds, confirmed.Blocks[0].Bounds);
+        Assert.False(tracker.NeedsConfirmation);
+        Assert.False(tracker.Merge(confirmed.Lines, [larger]).Changed);
+    }
+
+    [Fact]
+    public void NeighborChangeDoesNotPublishJitteringGeometryForHeldLine()
+    {
+        var tracker = new DialogueReadingTracker();
+        var held = Read("Same dialogue.") with {
+            SourceLineBounds = [new Rect(10, 10, 420, 30)], RenderGlyphHeight = 18 };
+        var first = tracker.Merge([], [held, Read("Old neighbor.")]);
+        var noisy = held with { Bounds = new Rect(8, 8, 428, 34),
+            SourceLineBounds = [new Rect(8, 8, 428, 34)], RenderGlyphHeight = 23 };
+        var changed = tracker.Merge(first.Lines, [noisy, Read("An entirely different sentence.")]);
+        Assert.True(changed.Changed);
+        Assert.Equal(held.Bounds, changed.Blocks[0].Bounds);
+        Assert.Equal(held.SourceLineBounds, changed.Blocks[0].SourceLineBounds);
+        Assert.Equal(held.RenderGlyphHeight, changed.Blocks[0].RenderGlyphHeight);
+    }
+
+    [Fact]
+    public void NewSentenceDoesNotInheritTheOldPlacement()
+    {
+        var tracker = new DialogueReadingTracker();
+        var first = tracker.Merge([], [Read("Same dialogue.")]);
+        var next = Read("An entirely different sentence.", x: 200);
+        var changed = tracker.Merge(first.Lines, [next]);
+        Assert.True(changed.Changed);
+        Assert.Equal(next.Bounds, changed.Blocks[0].Bounds);
+    }
+
+    private static OcrTextBlock Read(string text, double x = 10, double confidence = 0.98) =>
+        new(text, new Rect(x, 10, 420, 30), Confidence: confidence);
+
+    [Fact]
+    public void CompletedTailMustNotRemainSuppressedForever()
+    {
+        var shown = new[] { new RenderedLine("We should leave this place right no", 0.99) };
+        var complete = new[] { new OcrTextBlock("We should leave this place right now.", new Rect(10, 10, 420, 30), Confidence: 0.98) };
+        ReadingMerge result = default;
+        var tracker = new DialogueReadingTracker();
+        for (int frame = 0; frame < 3; frame++)
+        {
+            result = tracker.Merge(shown, complete);
+            shown = result.Lines.ToArray();
+        }
+        Assert.Equal(complete[0].Text, result.Blocks[0].Text);
+    }
+
+    [Fact]
+    public void OneExtraReadSettlesThenIdleNeedsNoMoreOcr()
+    {
+        var tracker = new DialogueReadingTracker();
+        var first = tracker.Merge([], [Read("A complete line.")]);
+        Assert.True(tracker.NeedsConfirmation);
+        var stable = tracker.Merge(first.Lines, [Read("A complete line.")]);
+        Assert.False(stable.Changed);
+        Assert.False(tracker.NeedsConfirmation);
+    }
+
+    [Fact]
+    public void TransientSuffixIsNotAcceptedAndDoesNotKeepPolling()
+    {
+        var tracker = new DialogueReadingTracker();
+        var first = tracker.Merge([], [Read("We should leave this place right now.")]);
+        var noise = tracker.Merge(first.Lines, [Read("We should leave this place right now.x")]);
+        Assert.False(noise.Changed);
+        Assert.True(tracker.NeedsConfirmation);
+        var stable = tracker.Merge(noise.Lines, [Read("We should leave this place right now.")]);
+        Assert.False(stable.Changed);
+        Assert.False(tracker.NeedsConfirmation);
+    }
+
+    [Fact]
+    public void LowConfidenceSuffixAndDifferentPositionCannotConfirm()
+    {
+        var tracker = new DialogueReadingTracker();
+        var first = tracker.Merge([], [Read("We should leave this place right no")]);
+        var low = tracker.Merge(first.Lines, [Read("We should leave this place right now.", confidence: 0.5)]);
+        Assert.Equal(first.Lines[0].Text, low.Lines[0].Text);
+        var pending = tracker.Merge(low.Lines, [Read("We should leave this place right now.")]);
+        var elsewhere = tracker.Merge(pending.Lines, [Read("We should leave this place right now.", x: 200)]);
+        Assert.Equal(first.Lines[0].Text, elsewhere.Lines[0].Text);
+    }
+
+    [Fact]
+    public void PositionChangeRefreshesWithoutChangingWordsButSmallJitterDoesNot()
+    {
+        var tracker = new DialogueReadingTracker();
+        var first = tracker.Merge([], [Read("Same dialogue.")]);
+        var jitter = tracker.Merge(first.Lines, [Read("Same dialogue.", x: 12)]);
+        Assert.False(jitter.Changed);
+        var moved = tracker.Merge(jitter.Lines, [Read("Same dialogue.", x: 40)]);
+        Assert.True(moved.Repositioned);
+        Assert.True(moved.Changed);
+        Assert.Equal(first.Lines[0].Text, moved.Blocks[0].Text);
+        Assert.Equal(40, moved.Blocks[0].Bounds.X);
+    }
+
+    [Fact]
+    public void PanelKeepsItsOriginalConfidencePolicy()
+    {
+        var shown = new[] { new RenderedLine("We should leave this place right no", 0.99) };
+        var merged = RealtimeReadingMerge.Merge(shown, [Read("We should leave this place right now.")]);
+        Assert.False(merged.Changed);
+    }
+}

--- a/tests/OverTranslate.Tests/RealtimeGroupedBackgroundTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeGroupedBackgroundTests.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Windows;
+using System.Windows.Controls;
+using OverTranslate.Services;
+using OverTranslate.Views.Realtime;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+public class RealtimeGroupedBackgroundTests
+{
+    private static TranslatedBlock Lisa(string translation = "好，Lisa。從入口再來一次。") => new(
+        "Okay, Lisa. Do it again, from the entrance.", translation,
+        new Rect(571, 17, 610, 157),
+        [new Rect(571, 17, 610, 98), new Rect(627, 101, 504, 73)], 40.95);
+
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(1.5)]
+    public void EnglishGroupCoversCompactLinesAndTheirGap(double dpi) => OnSta(() =>
+    {
+        var (background, _) = Build(Lisa(), dpi);
+        // Centers are 66 and 137.5; each compact line is 40.95 * 1.22 high.
+        Assert.Equal((71.5 + 40.95 * 1.22) / dpi + 6, background.Height, 6);
+        Assert.Equal((66 - 40.95 * 1.22 / 2) / dpi - 3, Canvas.GetTop(background), 6);
+    });
+
+    [Fact]
+    public void CjkNormalizedGroupKeepsItsCoverage() => OnSta(() =>
+    {
+        var line = Lisa() with { Bounds = new Rect(571, 48, 610, 108.1),
+            SourceLineBounds = [new Rect(571, 48, 610, 36), new Rect(627, 118.9, 504, 37.2)],
+            RenderGlyphHeight = null };
+        var (background, _) = Build(line);
+        Assert.Equal(114.1, background.Height, 6);
+    });
+
+    [Fact]
+    public void SingleLineStillUsesItsExistingCompactBand() => OnSta(() =>
+    {
+        var line = Lisa("好的。") with { Bounds = new Rect(571, 17, 610, 98), SourceLineBounds = null };
+        var (background, _) = Build(line);
+        Assert.InRange(background.Height, 49, 65);
+    });
+
+    [Fact]
+    public void ThreeRowsKeepTheirSpacingWithoutReusingGroupHeightAsFontHeight() => OnSta(() =>
+    {
+        var line = Lisa("三行來源。") with { Bounds = new Rect(571, 0, 610, 170),
+            SourceLineBounds = [new Rect(571, 0, 610, 50), new Rect(571, 60, 610, 50), new Rect(571, 120, 610, 50)],
+            RenderGlyphHeight = 20 };
+        var (background, _) = Build(line);
+        Assert.Equal(120 + 20 * 1.22 + 6, background.Height, 6);
+        Assert.Equal(25 - 20 * 1.22 / 2 - 3, Canvas.GetTop(background), 6);
+    });
+
+    [Fact]
+    public void LongTranslationCanGrowPastCompactSourceCoverage() => OnSta(() =>
+    {
+        var line = Lisa(string.Concat(Enumerable.Repeat("這是一段需要保留全部內容的較長翻譯。", 30)));
+        var (background, text) = Build(line);
+        Assert.True(text.Height > 71.5 + 40.95 * 1.22);
+        Assert.Equal(background.Height, text.Height);
+        var child = Assert.IsType<TextBlock>(text.Child);
+        child.Measure(new Size(text.Width - text.Padding.Left - text.Padding.Right, double.PositiveInfinity));
+        Assert.True(background.Height >= child.DesiredSize.Height + 6);
+        Assert.Equal(TextTrimming.None, child.TextTrimming);
+        Assert.Equal(line.TranslatedText, child.Text);
+    });
+
+    private static (Border Background, Border Text) Build(TranslatedBlock line, double dpi = 1)
+    {
+        var window = new RealtimeBlockWindow(0, new System.Drawing.Rectangle(0, 0, 1770, 210),
+            _ => null, "EN", "ZH-HANT", "#FFAA55", "#000000", 70);
+        try
+        {
+            var type = typeof(RealtimeBlockWindow);
+            type.GetField("_dpiY", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, dpi);
+            type.GetField("_dpiX", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, dpi);
+            var visual = type.GetMethod("BuildLine", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(window, [line, 1770 / dpi, 210 / dpi, null])!;
+            return ((Border)visual.GetType().GetProperty("Background")!.GetValue(visual)!,
+                (Border)visual.GetType().GetProperty("Text")!.GetValue(visual)!);
+        }
+        finally { window.Close(); }
+    }
+
+    private static void OnSta(Action action)
+    {
+        Exception? error = null;
+        var thread = new Thread(() => { try { action(); } catch (Exception ex) { error = ex; } });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        if (error is not null) ExceptionDispatchInfo.Capture(error).Throw();
+    }
+}

--- a/tests/OverTranslate.Tests/RealtimeRegionStateTests.cs
+++ b/tests/OverTranslate.Tests/RealtimeRegionStateTests.cs
@@ -6,6 +6,74 @@ namespace OverTranslate.Tests;
 
 public class RealtimeRegionStateTests
 {
+    [Fact]
+    public void AlternatingFalseTailsCannotForceOcrForever()
+    {
+        var state = new RealtimeRegionState();
+        var frame = new FakeFrame();
+        OverTranslate.Services.OcrTextBlock Read(string text) => new(text, new System.Windows.Rect(0, 0, 100, 20), Confidence: 0.98);
+        var first = state.Dialogue.Merge([], [Read("Here we go.")]);
+        state.MarkRendered(OneLine, frame.Capture, first.Lines);
+        int forced = 0;
+        for (int poll = 0; poll < 20; poll++)
+        {
+            if (!state.Observe(frame.Capture, dialogue: true)) continue;
+            forced++;
+            var merged = state.Dialogue.Merge(state.RenderedLines, [Read(poll % 2 == 0 ? "Here we go.x" : "Here we go.y")]);
+            state.MarkRendered(OneLine, frame.Capture, merged.Lines);
+        }
+        Assert.InRange(forced, 1, 3);
+        Assert.False(state.Dialogue.NeedsConfirmation);
+        Assert.Equal("Here we go.", state.RenderedText);
+        frame.ChangeText();
+        Assert.True(state.Observe(frame.Capture, dialogue: true));
+        var pending = state.Dialogue.Merge(state.RenderedLines, [Read("Here we go.z")]);
+        state.MarkRendered(OneLine, frame.Capture, pending.Lines);
+        Assert.True(state.Dialogue.NeedsConfirmation);
+        Assert.True(state.Observe(frame.Capture, dialogue: true));
+        var confirmed = state.Dialogue.Merge(state.RenderedLines, [Read("Here we go.z")]);
+        Assert.Equal("Here we go.z", confirmed.Lines[0].Text);
+    }
+
+    [Fact]
+    public void BusyRecognizerDoesNotSpendConfirmationBudget()
+    {
+        var tracker = new DialogueReadingTracker();
+        tracker.Merge([], [new OverTranslate.Services.OcrTextBlock("Here we go.", new System.Windows.Rect(0, 0, 100, 20))]);
+        for (int attempt = 0; attempt < 10; attempt++)
+        {
+            Assert.True(tracker.TryTakeConfirmation());
+            tracker.RecognitionUnavailable();
+        }
+        for (int attempt = 0; attempt < DialogueReadingTracker.MaxConfirmationReads; attempt++)
+            Assert.True(tracker.TryTakeConfirmation());
+        Assert.False(tracker.TryTakeConfirmation());
+    }
+
+    [Fact]
+    public void DialogueReadsKnownTextChangeOnTheFirstPoll()
+    {
+        var state = new RealtimeRegionState();
+        var frame = new FakeFrame();
+        state.MarkRendered(OneLine, frame.Capture, "hello");
+        frame.ChangeText();
+        Assert.True(state.Observe(frame.Capture, dialogue: true));
+    }
+
+    [Fact]
+    public void DialogueConfirmationCanReadAnUnchangedFingerprintOnce()
+    {
+        var state = new RealtimeRegionState();
+        var frame = new FakeFrame();
+        var read = new[] { new OverTranslate.Services.OcrTextBlock("Complete subtitle.", new System.Windows.Rect(0, 0, 100, 20)) };
+        var first = state.Dialogue.Merge([], read);
+        state.MarkRendered(OneLine, frame.Capture, first.Lines);
+        Assert.True(state.Observe(frame.Capture, dialogue: true));
+        var stable = state.Dialogue.Merge(state.RenderedLines, read);
+        state.MarkRendered(OneLine, frame.Capture, stable.Lines);
+        Assert.False(state.Observe(frame.Capture, dialogue: true));
+    }
+
     private static readonly List<Rectangle> OneLine = [new Rectangle(10, 40, 300, 20)];
 
     [Fact]

--- a/tools/OcrHarness/DetectorGeometryProbe.cs
+++ b/tools/OcrHarness/DetectorGeometryProbe.cs
@@ -1,0 +1,269 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using RapidOcrNet;
+using SkiaSharp;
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using OverTranslate.Services.Realtime;
+
+// Detector input geometry A/B.
+//
+// The shipped path hands the library an aligned bitmap and asks it to resize to ImgResize. The
+// library's ScaleParam computes an aspect-preserving target and then quantises EACH AXIS
+// INDEPENDENTLY with (n / 32 - 1) * 32 whenever that axis is not already a multiple of 32 — a full
+// stride below flooring. AlignForDetector only neutralises that when the resulting ratio is exactly
+// one, which needs ImgResize >= the aligned long side; the app computes ImgResize from the size
+// BEFORE alignment, so the ratio lands just under one and the quantisation runs anyway.
+//
+// The candidate does the downscale itself, isotropically, then aligns, then tells the library not
+// to resize at all (ImgResize far above the input). Prepared dimensions are then stride multiples
+// at ratio one, so the quantisation is skipped and the detector sees the aspect ratio it was
+// handed. Everything after the raw blocks is the app's own chain.
+internal static class DetectorGeometryProbe
+{
+    private const BindingFlags Hidden = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+    internal static int Run(string[] args)
+    {
+        string output = args[0];
+        Directory.CreateDirectory(output);
+        string language = "JA";
+        var mode = RealtimeBlockMode.Subtitle;
+        double[] scales = [1.0];
+        int[] pads = [0];
+        int[] anisoPads = [];
+        // What the stride-alignment strip on the right and bottom is filled with. The shipped path
+        // leaves it transparent and lets the library decide: composited white when a border runs,
+        // premultiplied black when Padding is 0. Naming it makes that an input rather than a leak.
+        string[] fills = ["clear"];
+        // The screenshot flow instead of the realtime one: no fraction (ScreenshotDetectSize), and
+        // the screenshot side's own grouping rather than GroupRealtime.
+        bool screenshot = false;
+        var profile = GroupingProfile.General;
+        var images = new List<string>();
+
+        for (int i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--lang": language = args[++i]; break;
+                case "--mode": mode = Enum.Parse<RealtimeBlockMode>(args[++i], true); break;
+                case "--pads": pads = args[++i].Split(',').Select(int.Parse).ToArray(); break;
+                case "--aniso-pads": anisoPads = args[++i].Split(',').Select(int.Parse).ToArray(); break;
+                case "--fills": fills = args[++i].Split(','); break;
+                case "--screenshot": screenshot = true; break;
+                case "--interface": profile = GroupingProfile.Interface; break;
+                case "--scales":
+                    scales = args[++i].Split(',').Select(s => double.Parse(s, CultureInfo.InvariantCulture)).ToArray();
+                    break;
+                default: images.Add(args[i]); break;
+            }
+        }
+
+        var root = Path.Combine(AppContext.BaseDirectory, "ocrmodels", "onnx");
+        string modelKey = OnnxOcrEngine.GetModelKeyForLanguage(language);
+        using var engine = new RapidOcr();
+        engine.InitModels(new RapidOcrModelSet
+        {
+            DetModelPath = Path.Combine(root, "shared", "det.onnx"),
+            ClsModelPath = Path.Combine(root, "shared", "cls.onnx"),
+            RecModelPath = Path.Combine(root, modelKey, "rec.onnx"),
+            KeysPath = Path.Combine(root, modelKey, "dict.txt"),
+            DetMean = [127.5f, 127.5f, 127.5f],
+            DetStd = [127.5f, 127.5f, 127.5f],
+        }, 2);
+
+        var prep = typeof(RapidOcr).GetMethod("PrepareDetectorInput", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)!;
+        bool cjk = OcrLanguageRouter.UsesCjkOnnx(language);
+        var rows = new List<object>();
+
+        foreach (string path in images)
+        {
+            using var source = SKBitmap.Decode(path);
+            if (source is null)
+            {
+                Console.WriteLine("SKIP " + path);
+                continue;
+            }
+
+            int? requested = screenshot
+                ? null
+                : RealtimeDetectorSize.For(source.Width, source.Height, mode).Primary;
+            var shipped = OnnxOcrEngine.CreateOptions(requested);
+            int primary = shipped.ImgResize;
+
+            // "shipped" is whatever the product does today, reached through the product's own
+            // builder. "legacy" reproduces the pre-fix pipeline — the library's 50px border and its
+            // per-axis quantised resize — so a run can still show what the distortion cost.
+            var variants = new List<(string Name, int Target, RapidOcrOptions Options, string Fill)>
+            {
+                ("shipped", 0, shipped, "clear"),
+                ("legacy", -1, shipped with { Padding = 50 }, "clear"),
+            };
+            // The other half of the 2x2: the border changed, the library's own resize left alone,
+            // so a border effect can be told apart from the geometry it silently drags with it.
+            foreach (int pad in anisoPads)
+                variants.Add(("aniso-p" + pad, -1, shipped with { Padding = pad }, "clear"));
+
+            foreach (double scale in scales)
+            foreach (int pad in pads)
+            foreach (string fill in fills)
+            {
+                int target = Math.Max(32, (int)Math.Round(primary * scale));
+                variants.Add((
+                    "iso-" + scale.ToString("0.##", CultureInfo.InvariantCulture) + "-p" + pad
+                        + (fill == "clear" ? "" : "-" + fill),
+                    target,
+                    shipped with { ImgResize = 8192, Padding = pad },
+                    fill));
+            }
+
+            foreach (var variant in variants)
+            {
+                bool product = variant.Name == "shipped";
+                bool ownResize = variant.Target > 0;
+                using var scaled = ownResize ? IsoResize(source, variant.Target) : source.Copy();
+                using var frame = product ? OnnxOcrEngine.CreateDetectorFrame(source, requested) : default;
+                double rx = product ? frame.RatioX : (double)scaled.Width / source.Width;
+                double ry = product ? frame.RatioY : (double)scaled.Height / source.Height;
+                var options = product ? frame.Options : variant.Options;
+
+                using var owned = product
+                    ? null
+                    : variant.Fill == "clear"
+                        ? OnnxOcrEngine.AlignForDetector(scaled, variant.Options.Padding)
+                        : AlignFilled(scaled, variant.Options.Padding, variant.Fill);
+                var input = product ? frame.Bitmap : owned!;
+                int preparedWidth, preparedHeight, dstWidth, dstHeight;
+                using (var prepared = (IDisposable)prep.Invoke(null, [input, options])!)
+                {
+                    var bitmap = (SKBitmap)prepared.GetType().GetField("Bitmap", Hidden)!.GetValue(prepared)!;
+                    var scaleParam = prepared.GetType().GetField("Scale", Hidden)!.GetValue(prepared)!;
+                    preparedWidth = bitmap.Width;
+                    preparedHeight = bitmap.Height;
+                    dstWidth = (int)scaleParam.GetType().GetProperty("DstWidth", Hidden)!.GetValue(scaleParam)!;
+                    dstHeight = (int)scaleParam.GetType().GetProperty("DstHeight", Hidden)!.GetValue(scaleParam)!;
+                }
+
+                string[] finalText = [];
+                double milliseconds = 0;
+                object[] raw = [];
+                for (int pass = 0; pass < 2; pass++)
+                {
+                    var watch = Stopwatch.StartNew();
+                    var result = engine.Detect(input, options);
+                    milliseconds = watch.Elapsed.TotalMilliseconds;
+
+                    var mapped = result.TextBlocks.Select(b => new TextBlock
+                    {
+                        Text = b.Text,
+                        Chars = b.Chars,
+                        CharScores = b.CharScores,
+                        BoxScore = b.BoxScore,
+                        BoxPoints = b.BoxPoints
+                            .Select(p => new SKPointI((int)Math.Round(p.X / rx), (int)Math.Round(p.Y / ry)))
+                            .ToArray(),
+                    }).ToArray();
+
+                    var kept = OnnxOcrEngine.ApplyBlockFilters(
+                        mapped, language, cjk, OcrLanguageRouter.UsesAutomaticLayout(language));
+                    List<OcrTextBlock> grouped;
+                    if (screenshot)
+                    {
+                        using var drawing = new System.Drawing.Bitmap(path);
+                        grouped = OcrTextBlockGrouper.Group(
+                            OcrService.PrepareScreenshotGrouping(drawing, kept, profile), profile);
+                    }
+                    else
+                    {
+                        grouped = RealtimeTranslationSession.RejectShortReadings(
+                            RealtimeTranslationSession.RejectCollapsedBlocks(
+                                OcrService.GroupRealtime(kept, source.Height, mode), source.Height, -1), -1);
+                    }
+
+                    finalText = grouped.Select(b => b.Text).ToArray();
+                    raw = result.TextBlocks.Select(b => (object)new
+                    {
+                        b.Text,
+                        Score = b.CharScores is { Length: > 0 } s ? s.Average() : 0f,
+                        Points = b.BoxPoints.Select(p => new[] { (int)Math.Round(p.X / rx), (int)Math.Round(p.Y / ry) }),
+                    }).ToArray();
+                }
+
+                rows.Add(new
+                {
+                    Image = path,
+                    variant.Name,
+                    Language = language,
+                    Mode = mode.ToString(),
+                    Primary = primary,
+                    Target = variant.Target,
+                    SourceWidth = source.Width,
+                    SourceHeight = source.Height,
+                    ScaledWidth = scaled.Width,
+                    ScaledHeight = scaled.Height,
+                    PreparedWidth = preparedWidth,
+                    PreparedHeight = preparedHeight,
+                    DstWidth = dstWidth,
+                    DstHeight = dstHeight,
+                    NetworkScaleX = Math.Round((double)dstWidth / preparedWidth * rx, 4),
+                    NetworkScaleY = Math.Round((double)dstHeight / preparedHeight * ry, 4),
+                    Milliseconds = Math.Round(milliseconds, 1),
+                    Raw = raw,
+                    Final = finalText,
+                });
+
+                Console.WriteLine(
+                    $"GEO {Path.GetFileName(path)} {variant.Name} {milliseconds:F0}ms " +
+                    $"sx={(double)dstWidth / preparedWidth * rx:F3} sy={(double)dstHeight / preparedHeight * ry:F3}: " +
+                    string.Join(" | ", finalText));
+            }
+        }
+
+        File.WriteAllText(
+            Path.Combine(output, "geometry.json"),
+            JsonSerializer.Serialize(rows, new JsonSerializerOptions { WriteIndented = true })
+                .ReplaceLineEndings("\r\n"));
+        return 0;
+    }
+
+    // AlignForDetector with the strip painted rather than left to whatever the library composites
+    // it against.
+    private static SKBitmap AlignFilled(SKBitmap source, int pad, string fill)
+    {
+        using var clear = OnnxOcrEngine.AlignForDetector(source, pad);
+        var filled = new SKBitmap(clear.Width, clear.Height, source.ColorType, source.AlphaType);
+        using (var canvas = new SKCanvas(filled))
+        {
+            canvas.Clear(fill == "black" ? SKColors.Black : SKColors.White);
+            using var image = SKImage.FromBitmap(source);
+            canvas.DrawImage(image, 0, 0);
+        }
+
+        return filled;
+    }
+
+    // Same sampler the library resizes with, so the comparison is about geometry and not about
+    // which filter drew the glyphs.
+    private static SKBitmap IsoResize(SKBitmap source, int target)
+    {
+        double ratio = Math.Min(1.0, (double)target / Math.Max(source.Width, source.Height));
+        if (ratio >= 1.0)
+            return source.Copy();
+
+        int width = Math.Max(1, (int)Math.Round(source.Width * ratio));
+        int height = Math.Max(1, (int)Math.Round(source.Height * ratio));
+        var resized = new SKBitmap(width, height, source.ColorType, source.AlphaType);
+        using (var canvas = new SKCanvas(resized))
+        {
+            canvas.Clear(SKColors.Transparent);
+            using var image = SKImage.FromBitmap(source);
+            canvas.DrawImage(image, new SKRect(0, 0, width, height), new SKSamplingOptions(SKCubicResampler.Mitchell));
+        }
+
+        return resized;
+    }
+}

--- a/tools/OcrHarness/DialogueProbe.cs
+++ b/tools/OcrHarness/DialogueProbe.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Text.Json;
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using OverTranslate.Services.Realtime;
+
+internal static class DialogueProbe
+{
+    internal static async Task<int> Run(string[] args)
+    {
+        if (args.Length < 2) throw new ArgumentException("--dialogue-probe output.json images... (or cached input.json)");
+        var captures = new List<GroupingPrototype.Capture>();
+        if (args.Length == 2 && args[1].EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            captures.AddRange(JsonSerializer.Deserialize<GroupingPrototype.Capture[]>(File.ReadAllText(args[1]))!);
+        else
+        {
+            using var engine = new OnnxOcrEngine();
+            var entries = args.Skip(1).SelectMany(arg => arg.StartsWith('@') ? File.ReadAllLines(arg[1..]) : [arg]);
+            foreach (var entry in entries.Where(s => !string.IsNullOrWhiteSpace(s)))
+            {
+                var fields = entry.Split('\t');
+                var path = fields[0];
+                using var bitmap = new Bitmap(path);
+                var language = fields.Length > 1 ? fields[1] : path.Contains("-ja") ? "JA" : "EN";
+                var size = RealtimeDetectorSize.For(bitmap.Width, bitmap.Height, RealtimeBlockMode.Subtitle).Primary;
+                List<OcrTextBlock> raw = [];
+                for (int pass = 0; pass < 3; pass++)
+                {
+                    var timer = Stopwatch.StartNew();
+                    raw = await engine.TryRecognizeAsync(bitmap, language, size) ?? throw new InvalidOperationException("No OCR slot");
+                    Console.WriteLine($"OCR {Path.GetFileName(path)} pass={pass} size={size} ms={timer.Elapsed.TotalMilliseconds:F2} blocks={raw.Count}");
+                }
+                captures.Add(new(path, "realtime", language, raw.Select(GroupingPrototype.Block.From).ToArray()));
+            }
+        }
+        var results = new List<object>();
+        foreach (var capture in captures)
+        {
+            var raw = capture.Blocks.Select(b => b.Restore()).ToList();
+            using var bitmap = new Bitmap(capture.Image);
+            foreach (var mode in new[] { RealtimeBlockMode.Panel, RealtimeBlockMode.Subtitle })
+            {
+                var label = mode == RealtimeBlockMode.Panel ? "legacy-realtime" : "dialogue";
+                List<OcrTextBlock> Finish(List<OcrTextBlock> b) => RealtimeTranslationSession.RejectShortReadings(
+                    RealtimeTranslationSession.RejectCollapsedBlocks(b, bitmap.Height, -1), -1);
+                List<OcrTextBlock> Group() => OcrService.GroupRealtime(raw, bitmap.Height, mode);
+                for (int i = 0; i < 100; i++) Group();
+                var timer = Stopwatch.StartNew();
+                for (int i = 0; i < 2000; i++) Group();
+                var us = timer.Elapsed.TotalMicroseconds / 2000;
+                var trace = new GroupingTrace();
+                var grouped = OcrService.GroupRealtime(raw, bitmap.Height, mode, trace);
+                var sources = trace.Lines.ToDictionary(l => l.Id, l => l.SourceIds);
+                var ids = trace.Blocks.ToDictionary(b => b.Id, b => Array.FindIndex(raw.ToArray(), x => ReferenceEquals(x, b.Block)));
+                var kept = Finish(grouped);
+                var groups = trace.Groups.Where((g, i) => kept.Contains(grouped[i])).Select(g => g.SelectMany(l => sources[l]).Select(id => ids[id]).ToArray()).ToArray();
+                grouped = kept;
+                Console.WriteLine($"GROUP {label} {Path.GetFileName(capture.Image)} blocks={raw.Count} groups={grouped.Count} us={us:F2}");
+                results.Add(new { capture.Image, Mode = label, Microseconds = us, Groups = groups, Output = grouped.Select(GroupingPrototype.Block.From).ToArray() });
+            }
+        }
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(args[0]))!);
+        File.WriteAllText(args[0], JsonSerializer.Serialize(results, options).ReplaceLineEndings("\r\n"));
+        if (!args[1].EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            File.WriteAllText(Path.ChangeExtension(args[0], ".inputs.json"), JsonSerializer.Serialize(captures, options).ReplaceLineEndings("\r\n"));
+        return 0;
+    }
+}

--- a/tools/OcrHarness/LeadingEdgeFusionProbe.cs
+++ b/tools/OcrHarness/LeadingEdgeFusionProbe.cs
@@ -1,0 +1,117 @@
+using System.IO;
+using System.Text.Json;
+using System.Windows;
+using OverTranslate.Services;
+using OverTranslate.Services.Realtime;
+
+// Offline hypothesis only. Never changes engine settings or production readings.
+internal static class LeadingEdgeFusionProbe
+{
+    internal record Read(string Image, string? Language, string Name, int Pass, GroupingPrototype.Block[] Raw);
+    internal record Proposal(string Prefix, Rect Bounds, Rect LayoutBounds);
+
+    internal static int Run(string[] args)
+    {
+        if (args.Length < 2) throw new ArgumentException("--leading-edge-fusion output.json saved-sweeps.json...");
+        SelfTest();
+        var results = new List<object>();
+        foreach (var file in args.Skip(1))
+        foreach (var image in JsonSerializer.Deserialize<Read[]>(File.ReadAllText(file))!.GroupBy(r => r.Image))
+        foreach (var pass in image.GroupBy(r => r.Pass))
+        {
+            var baseline = pass.Single(r => r.Name == "baseline");
+            var a = pass.Single(r => r.Name == "pad-24");
+            var b = pass.Single(r => r.Name == "pad-16");
+            var fused = baseline.Raw.Select(x => x.Restore()).ToList();
+            var changes = baseline.Raw.Select((old, index) =>
+            {
+                var first = Propose(old, baseline.Raw, a.Raw);
+                var second = Propose(old, baseline.Raw, b.Raw);
+                bool accepted = (baseline.Language == null || baseline.Language == "JA") &&
+                    first != null && second != null && first.Prefix == second.Prefix;
+                if (accepted)
+                {
+                    // Keep baseline recognition metrics. Only expand the source extent to
+                    // include the confirmed prefix; alternative groups are never imported.
+                    var bounds = fused[index].Bounds;
+                    bounds.Union(first!.Bounds);
+                    var layout = fused[index].LayoutBounds;
+                    layout.Union(first.LayoutBounds);
+                    fused[index] = fused[index] with { Text = first.Prefix + old.Text,
+                        Bounds = bounds, LayoutBounds = layout };
+                }
+                return new { Index = index, Before = old.Text,
+                    After = accepted ? first!.Prefix + old.Text : old.Text,
+                    Accepted = accepted, Pad24 = first?.Prefix, Pad16 = second?.Prefix };
+            }).ToArray();
+            using var bitmap = new System.Drawing.Bitmap(baseline.Image);
+            List<OcrTextBlock> Finish(List<OcrTextBlock> raw) =>
+                RealtimeTranslationSession.RejectShortReadings(RealtimeTranslationSession.RejectCollapsedBlocks(
+                    OcrService.GroupRealtime(raw, bitmap.Height, RealtimeBlockMode.Subtitle), bitmap.Height, -1), -1);
+            var before = Finish(baseline.Raw.Select(x => x.Restore()).ToList()).Select(GroupingPrototype.Block.From).ToArray();
+            var after = Finish(fused).Select(GroupingPrototype.Block.From).ToArray();
+            if (!changes.Any(c => c.Accepted) && JsonSerializer.Serialize(before) != JsonSerializer.Serialize(after))
+                throw new Exception("Unmodified inputs changed final output");
+            var finalText = Compact(string.Concat(after.Select(x => x.Text)));
+            if (before.Any(x => !finalText.Contains(Compact(x.Text), StringComparison.Ordinal)))
+                throw new Exception("Fusion lost a previously published reading: " + baseline.Image);
+            results.Add(new { baseline.Image, baseline.Language, baseline.Pass, Changes = changes,
+                Before = before, After = after });
+            Console.WriteLine($"FUSION {Path.GetFileName(baseline.Image)} pass={baseline.Pass}: " +
+                string.Join(" | ", changes.Where(c => c.Accepted).Select(c => c.Before + " -> " + c.After)));
+        }
+        File.WriteAllText(args[0], JsonSerializer.Serialize(results, new JsonSerializerOptions { WriteIndented = true }).ReplaceLineEndings("\r\n"));
+        return 0;
+    }
+
+    private static string Compact(string s) => string.Concat(s.Where(c => !char.IsWhiteSpace(c)));
+    private static Rect Box(GroupingPrototype.Block b) => new(b.LayoutBounds[0], b.LayoutBounds[1], b.LayoutBounds[2], b.LayoutBounds[3]);
+    private static bool SameRow(Rect a, Rect b) =>
+        Math.Min(a.Bottom, b.Bottom) - Math.Max(a.Top, b.Top) >= .6 * Math.Min(a.Height, b.Height) &&
+        Math.Abs(a.Top + a.Height / 2 - b.Top - b.Height / 2) <= .35 * Math.Max(a.Height, b.Height);
+
+    private static Proposal? Propose(GroupingPrototype.Block old, GroupingPrototype.Block[] owners, GroupingPrototype.Block[] alternative)
+    {
+        string anchor = Compact(old.Text).TrimEnd('。', '、', '.', ',', '!', '?', '！', '？', '…', '」', '』');
+        if (anchor.Count(char.IsLetterOrDigit) < 4) return null;
+        var rect = Box(old);
+        var row = alternative.Where(x => SameRow(rect, Box(x)) &&
+            Box(x).Right >= rect.Left - rect.Height && Box(x).Left <= rect.Right &&
+            (x.Confidence == null || x.Confidence >= .8)).OrderBy(x => Box(x).Left).ToArray();
+        if (row.Length == 0) return null;
+        // Do not absorb another baseline-owned inline fragment or a character name.
+        if (owners.Any(x => !ReferenceEquals(x, old) && row.Any(r => Rect.Intersect(Box(x), Box(r)).Width > 0 && SameRow(Box(x), Box(r))))) return null;
+        for (int i = 1; i < row.Length; i++)
+            if (Box(row[i]).Left - Box(row[i - 1]).Right > rect.Height) return null;
+        var union = Box(row[0]);
+        foreach (var part in row.Skip(1)) union.Union(Box(part));
+        if (union.Left >= rect.Left || Math.Abs(union.Right - rect.Right) > rect.Height * .5) return null;
+        string candidate = string.Concat(row.Select(x => Compact(x.Text)));
+        int start = candidate.IndexOf(anchor, StringComparison.Ordinal);
+        if (start <= 0 || candidate.LastIndexOf(anchor, StringComparison.Ordinal) != start) return null;
+        string suffix = candidate[(start + anchor.Length)..];
+        if (suffix.Any(char.IsLetterOrDigit)) return null;
+        string prefix = candidate[..start];
+        if (!prefix.Any(char.IsLetterOrDigit)) return null;
+        var renderUnion = row[0].Restore().Bounds;
+        foreach (var part in row.Skip(1)) renderUnion.Union(part.Restore().Bounds);
+        return new(prefix, renderUnion, union);
+    }
+
+    private static void SelfTest()
+    {
+        GroupingPrototype.Block Block(string text, double x, double y, double w) =>
+            new(text, [x, y, w, 30], [x, y, w, 30], default, null, null, .99);
+        var old = Block("じゃあ次はね……", 100, 0, 200);
+        void Check(bool value, string name) { if (!value) throw new Exception("Fusion guard failed: " + name); }
+        Check(Propose(old, [old], [Block("うん、じゃあ次はね", 50, 0, 250)])?.Prefix == "うん、", "preserve baseline punctuation");
+        Check(Propose(old, [old], [Block("うん、じゃあ次だね", 50, 0, 250)]) == null, "substitution");
+        Check(Propose(old, [old], [Block("うん、じゃあ次はね別の文", 50, 0, 250)]) == null, "new suffix");
+        Check(Propose(old, [old], [Block("うん、じゃあ次はね", 50, -60, 250)]) == null, "different row");
+        var name = Block("しろは", 20, 0, 70);
+        Check(Propose(old, [old, name], [Block("しろはじゃあ次はね", 20, 0, 280)]) == null, "owned prefix");
+        // Deliberate counterexample: agreement alone cannot prove an added word exists.
+        Check(Propose(old, [old], [Block("偽物じゃあ次はね", 50, 0, 250)]) != null, "documented shared hallucination limitation");
+        Console.WriteLine("Fusion self-checks: 6 PASS (includes known shared-hallucination limitation)");
+    }
+}

--- a/tools/OcrHarness/LeadingEdgeProbe.cs
+++ b/tools/OcrHarness/LeadingEdgeProbe.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Text.Json;
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+using OverTranslate.Services.Realtime;
+
+// Diagnostic only: one-axis comparisons, no candidate is selected or installed by this probe.
+internal static class LeadingEdgeProbe
+{
+    internal static async Task<int> Run(string[] args, bool controls = false)
+    {
+        if (args.Length < 2) throw new ArgumentException("--leading-edge-probe output.json images...");
+        using var engine = new OnnxOcrEngine();
+        var results = new List<object>();
+        try
+        {
+            var entries = args.Skip(1).SelectMany(p => p.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+                ? JsonSerializer.Deserialize<GroupingPrototype.Capture[]>(File.ReadAllText(p))!.Select(c => (c.Image, c.Language))
+                : new[] { (Image: p, Language: "JA") });
+            foreach (var entry in entries)
+            {
+                var path = entry.Image;
+                using var bitmap = new Bitmap(path);
+                var primary = RealtimeDetectorSize.For(bitmap.Width, bitmap.Height, RealtimeBlockMode.Subtitle).Primary;
+                var variants = new List<(string Name, int Size, int? Padding)> { ("baseline", primary, null) };
+                variants.AddRange((controls ? new[] { 16, 24 } : new[] { 0, 8, 16, 24, 32, 64, 96 }).Select(p => ($"pad-{p}", primary, (int?)p)));
+                if (!controls) variants.AddRange(new[] { 0.5, 0.65, 0.75, 0.95, 1.0 }.Select(f =>
+                    ($"scale-{f}", Math.Max(32, (int)Math.Round(Math.Max(bitmap.Width, bitmap.Height) * f / 32) * 32), (int?)null)));
+                foreach (var variant in variants)
+                {
+                    OnnxOcrEngine.DetectorPaddingOverride = variant.Padding;
+                    for (int pass = 0; pass < 2; pass++)
+                    {
+                        var clock = Stopwatch.StartNew();
+                        var raw = await engine.TryRecognizeAsync(bitmap, entry.Language, variant.Size) ?? throw new InvalidOperationException("No OCR slot");
+                        var ms = clock.Elapsed.TotalMilliseconds;
+                        var grouped = RealtimeTranslationSession.RejectShortReadings(
+                            RealtimeTranslationSession.RejectCollapsedBlocks(
+                                OcrService.GroupRealtime(raw, bitmap.Height, RealtimeBlockMode.Subtitle), bitmap.Height, -1), -1);
+                        results.Add(new { Image = path, entry.Language, variant.Name, variant.Size, variant.Padding, Pass = pass, Milliseconds = ms,
+                            Raw = raw.Select(GroupingPrototype.Block.From).ToArray(), Output = grouped.Select(GroupingPrototype.Block.From).ToArray() });
+                        Console.WriteLine($"EDGE {Path.GetFileName(path)} {variant.Name} pass={pass} ms={ms:F1}: {string.Join(" | ", grouped.Select(b => b.Text))}");
+                    }
+                }
+            }
+        }
+        finally { OnnxOcrEngine.DetectorPaddingOverride = null; }
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(args[0]))!);
+        File.WriteAllText(args[0], JsonSerializer.Serialize(results, new JsonSerializerOptions { WriteIndented = true }).ReplaceLineEndings("\r\n"));
+        return 0;
+    }
+}

--- a/tools/OcrHarness/OcrRootProbe.cs
+++ b/tools/OcrHarness/OcrRootProbe.cs
@@ -1,0 +1,206 @@
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using RapidOcrNet;
+using SkiaSharp;
+using OverTranslate.Services.Ocr;
+using OverTranslate.Services.Realtime;
+using OverTranslate.Services;
+
+// Isolated native-library experiment. No grouping, filtering, fusion, or translation.
+internal static class OcrRootProbe
+{
+    private const BindingFlags Hidden = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+    internal static int Run(string[] args)
+    {
+        if (args.Length < 2) throw new ArgumentException("--ocr-root-probe output-folder images...");
+        Directory.CreateDirectory(args[0]);
+        if (args[1] == "--replay") return Replay(args);
+        var root = Path.Combine(AppContext.BaseDirectory, "ocrmodels", "onnx");
+        using var engine = new RapidOcr();
+        engine.InitModels(new RapidOcrModelSet {
+            DetModelPath = Path.Combine(root,"shared","det.onnx"),
+            ClsModelPath = Path.Combine(root,"shared","cls.onnx"),
+            RecModelPath = Path.Combine(root,"cjk","rec.onnx"), KeysPath = Path.Combine(root,"cjk","dict.txt"),
+            DetMean = [127.5f,127.5f,127.5f], DetStd = [127.5f,127.5f,127.5f]
+        }, 2);
+        var prep = typeof(RapidOcr).GetMethod("PrepareDetectorInput", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)!;
+        var recognizer = (TextRecognizer)typeof(RapidOcr).GetField("_textRecognizer", Hidden)!.GetValue(engine)!;
+        if (args[1] == "--grid") return Grid(args, engine, recognizer, prep);
+        var results = new List<object>();
+        bool geometry = args[1] == "--geometry";
+        bool preset = args[1] == "--preset";
+        bool candidate = args[1] == "--candidate";
+        bool sampling = args[1] == "--sampling";
+        foreach (var path in args.Skip(geometry || preset || candidate || sampling ? 2 : 1))
+        {
+            using var original = SKBitmap.Decode(path);
+            int size = RealtimeDetectorSize.For(original.Width, original.Height, RealtimeBlockMode.Subtitle).Primary;
+            var shipped = OnnxOcrEngine.CreateOptions(size);
+            var variants = new (string Name, RapidOcrOptions Options, bool Align)[] {
+                ("shipped", shipped, true), ("unaligned", shipped, false),
+                ("pad0", shipped with { Padding = 0 }, true),
+                ("native", shipped with { Padding = 0, ImgResize = 4096 }, true),
+                ("pad24", shipped with { Padding = 24 }, true),
+                ("shortside", shipped with { Padding = 0, ImgResize = 0, LimitSideLen = 256 }, false),
+                ("shortside512", shipped with { Padding = 0, ImgResize = 0, LimitSideLen = 512 }, false),
+            };
+            if (geometry) variants = new[] { ("shipped", shipped, true) }.Concat(
+                new[] { "iso-0.5", "iso-0.75", "iso-1", "iso-1.25", "iso-white", "iso-black" }
+                .Select(n => (n, shipped with { Padding = 0, ImgResize = 8192 }, true))).ToArray();
+            if (preset) variants = [("shipped",shipped,true), ("v6-preset",RapidOcrOptions.PPOCRv6 with {DoAngle=false},false)];
+            if (candidate) variants = [("shipped",shipped,true), ("iso-0.75",shipped with {Padding=0,ImgResize=8192},true), ("iso-1.25",shipped with {Padding=0,ImgResize=8192},true)];
+            if (sampling) variants = [("iso-0.75-linear",shipped with {Padding=0,ImgResize=8192},true), ("iso-1.25-linear",shipped with {Padding=0,ImgResize=8192},true)];
+            foreach (var variant in variants)
+            {
+                using var transformed = Transform(original, variant.Name);
+                using var input = variant.Align ? OnnxOcrEngine.AlignForDetector(transformed, variant.Options.Padding) : transformed.Copy();
+                using var prepared = (IDisposable)prep.Invoke(null, [input, variant.Options])!;
+                var bitmap = (SKBitmap)prepared.GetType().GetField("Bitmap", Hidden)!.GetValue(prepared)!;
+                var scale = prepared.GetType().GetField("Scale", Hidden)!.GetValue(prepared)!;
+                var scales = scale.GetType().GetFields(Hidden).ToDictionary(f => f.Name, f => f.GetValue(scale));
+                using (var img = SKImage.FromBitmap(bitmap))
+                using (var data = img.Encode(SKEncodedImageFormat.Png, 100))
+                using (var stream = File.Create(Path.Combine(args[0], Path.GetFileNameWithoutExtension(path) + "-" + variant.Name + "-input.png"))) data.SaveTo(stream);
+                for (int pass = 0; pass < 2; pass++)
+                {
+                    var watch = Stopwatch.StartNew();
+                    var output = engine.Detect(input, variant.Options);
+                    var ms = watch.Elapsed.TotalMilliseconds;
+                    var boxes = engine.DetectBoxes(input, variant.Options);
+                    var (ratio, offset) = TransformSpec(variant.Name);
+                    double rx = Math.Round(original.Width * ratio) / original.Width;
+                    double ry = Math.Round(original.Height * ratio) / original.Height;
+                    var mapped = output.TextBlocks.Select(b => new TextBlock { Text=b.Text, Chars=b.Chars, CharScores=b.CharScores, BoxScore=b.BoxScore,
+                        BoxPoints=b.BoxPoints.Select(p => new SKPointI((int)Math.Round((p.X-offset)/rx), (int)Math.Round((p.Y-offset)/ry))).ToArray() }).ToArray();
+                    var blocks = OnnxOcrEngine.ApplyBlockFilters(mapped, "JA", true, false);
+                    var final = RealtimeTranslationSession.RejectShortReadings(RealtimeTranslationSession.RejectCollapsedBlocks(
+                        OcrService.GroupRealtime(blocks, original.Height, RealtimeBlockMode.Subtitle), original.Height, -1), -1);
+                    results.Add(new { Image=path, variant.Name, Pass=pass, Size=size, InputWidth=input.Width, InputHeight=input.Height,
+                        PreparedWidth=bitmap.Width, PreparedHeight=bitmap.Height, Scale=scales, Milliseconds=ms,
+                        Boxes=boxes.Select(b => new { Points=b.BoxPoints.Select(p => new[]{p.X,p.Y}), b.Score }),
+                        Text=output.TextBlocks.Select(b => new { b.Text, b.Chars, b.CharScores, Points=b.BoxPoints.Select(p => new[]{p.X,p.Y}) }),
+                        Final=final.Select(GroupingPrototype.Block.From).ToArray() });
+                    Console.WriteLine($"ROOT {Path.GetFileName(path)} {variant.Name} p{pass} {ms:F1}ms: {string.Join(" | ", output.TextBlocks.Select(b => b.Text))}");
+                }
+            }
+            // Oracle only: known complete text-line rectangles distinguish detector loss
+            // from recognizer loss. Never used to select production boxes.
+            var crop = path.Contains("game-1") ? new SKRectI(75,130,1070,215) : new SKRectI(15,0,350,original.Height);
+            if (path.Contains("ja-game-") && crop.Right <= original.Width && crop.Bottom <= original.Height)
+            {
+                using var line = new SKBitmap();
+                original.ExtractSubset(line, crop);
+                var lines = recognizer.GetTextLines([line]);
+                results.Add(new { Image=path, Name="oracle-recognition-only", Text=lines.Select(l => string.Concat(l.Chars ?? [])), Scores=lines.Select(l => l.CharScores) });
+                Console.WriteLine("ORACLE " + path + ": " + string.Join(" | ", lines.Select(l => string.Concat(l.Chars ?? []))));
+            }
+        }
+        File.WriteAllText(Path.Combine(args[0], "results.json"), JsonSerializer.Serialize(results, new JsonSerializerOptions {WriteIndented=true}).ReplaceLineEndings("\r\n"));
+        return 0;
+    }
+
+    private static SKBitmap Transform(SKBitmap source, string name)
+    {
+        if (!name.StartsWith("iso-")) return source.Copy();
+        var (ratio, padding) = TransformSpec(name);
+        int w = (int)Math.Round(source.Width * ratio), h = (int)Math.Round(source.Height * ratio);
+        var bitmap = new SKBitmap((w + padding * 2 + 31) / 32 * 32, (h + padding * 2 + 31) / 32 * 32);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(name == "iso-black" ? SKColors.Black : SKColors.White);
+        using var image = SKImage.FromBitmap(source);
+        var sampling = name.EndsWith("-linear") ? new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None) : new SKSamplingOptions(SKCubicResampler.Mitchell);
+        canvas.DrawImage(image, new SKRect(padding,padding,padding+w,padding+h), sampling);
+        return bitmap;
+    }
+
+    private static (double Ratio, int Padding) TransformSpec(string name) =>
+        !name.StartsWith("iso-") ? (1, 0) : name is "iso-white" or "iso-black" ? (1, 32) :
+        (double.Parse(name.Split('-')[1], System.Globalization.CultureInfo.InvariantCulture), 0);
+
+    private static int Replay(string[] args)
+    {
+        var results = new List<object>();
+        foreach (var path in args.Skip(2))
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            foreach (var row in document.RootElement.EnumerateArray())
+            {
+                if (!row.TryGetProperty("Pass", out var pass)) continue;
+                string image = row.GetProperty("Image").GetString()!;
+                string name = row.GetProperty("Name").GetString()!;
+                using var bitmap = SKBitmap.Decode(image);
+                var (ratio, offset) = TransformSpec(name);
+                double rx = Math.Round(bitmap.Width * ratio) / bitmap.Width, ry = Math.Round(bitmap.Height * ratio) / bitmap.Height;
+                var blocks = row.GetProperty("Text").EnumerateArray().Select(t => new TextBlock {
+                    Text=t.GetProperty("Text").GetString()!, Chars=t.GetProperty("Chars").Deserialize<string[]>(),
+                    CharScores=t.GetProperty("CharScores").Deserialize<float[]>(),
+                    BoxPoints=t.GetProperty("Points").EnumerateArray().Select(p => new SKPointI(
+                        (int)Math.Round((p[0].GetInt32()-offset)/rx), (int)Math.Round((p[1].GetInt32()-offset)/ry))).ToArray()
+                }).ToArray();
+                var raw = OnnxOcrEngine.ApplyBlockFilters(blocks,"JA",true,false);
+                var final = RealtimeTranslationSession.RejectShortReadings(RealtimeTranslationSession.RejectCollapsedBlocks(
+                    OcrService.GroupRealtime(raw,bitmap.Height,RealtimeBlockMode.Subtitle),bitmap.Height,-1),-1);
+                results.Add(new { Image=image, Name=name, Pass=pass.GetInt32(), Final=final.Select(GroupingPrototype.Block.From).ToArray() });
+                if (pass.GetInt32()==1) Console.WriteLine($"FINAL {Path.GetFileName(image)} {name}: {string.Join(" | ",final.Select(x=>x.Text))}");
+            }
+        }
+        File.WriteAllText(Path.Combine(args[0],"final.json"),JsonSerializer.Serialize(results,new JsonSerializerOptions{WriteIndented=true}).ReplaceLineEndings("\r\n"));
+        return 0;
+    }
+
+    private static int Grid(string[] args, RapidOcr engine, TextRecognizer recognizer, MethodInfo prep)
+    {
+        var detector = (TextDetector)typeof(RapidOcr).GetField("_textDetector",Hidden)!.GetValue(engine)!;
+        var partsMethod = typeof(RapidOcr).Assembly.GetType("RapidOcrNet.OcrUtils")!.GetMethod("GetPartImages", BindingFlags.Static|BindingFlags.Public|BindingFlags.NonPublic)!;
+        var rows = new List<object>();
+        foreach (var path in args.Skip(2))
+        {
+            using var source = SKBitmap.Decode(path);
+            var options = OnnxOcrEngine.CreateOptions(RealtimeDetectorSize.For(source.Width,source.Height,RealtimeBlockMode.Subtitle).Primary);
+            using var aligned = OnnxOcrEngine.AlignForDetector(source,options.Padding);
+            using var prepared = (IDisposable)prep.Invoke(null,[aligned,options])!;
+            var bitmap = (SKBitmap)prepared.GetType().GetField("Bitmap",Hidden)!.GetValue(prepared)!;
+            var legacy = (ScaleParam)prepared.GetType().GetField("Scale",Hidden)!.GetValue(prepared)!;
+            foreach (string name in new[]{"grid-legacy","grid-floor","grid-nearest","grid-ceil"})
+            {
+                double ratio = (Math.Min(options.ImgResize,Math.Max(aligned.Width,aligned.Height))+2d*options.Padding)/Math.Max(bitmap.Width,bitmap.Height);
+                int Round(double n) => Math.Max(32,32*(int)(name=="grid-floor" ? Math.Floor(n/32) : name=="grid-ceil" ? Math.Ceiling(n/32) : Math.Round(n/32)));
+                var scale = name=="grid-legacy" ? legacy : new ScaleParam(bitmap.Width,bitmap.Height,Round(bitmap.Width*ratio),Round(bitmap.Height*ratio));
+                for (int pass=0;pass<2;pass++)
+                {
+                    var watch=Stopwatch.StartNew();
+                    var boxes=detector.GetTextBoxes(bitmap,scale,options.BoxScoreThresh,options.BoxThresh,options.UnClipRatio);
+                    var parts=(SKBitmap[])partsMethod.Invoke(null,[bitmap,boxes])!;
+                    try
+                    {
+                        var lines=recognizer.GetTextLines(parts);
+                        var blocks=new List<TextBlock>();
+                        for(int i=0;i<boxes!.Count;i++)
+                        {
+                            if(lines[i].CharScores is not {Length:>0} scores || scores.Average()<options.TextScore) continue;
+                            var points=(SKPointI[])boxes[i].BoxPoints.Clone();
+                            prepared.GetType().GetMethod("MapToOriginal",Hidden)!.Invoke(prepared,[points]);
+                            blocks.Add(new TextBlock{ Text=string.Concat(lines[i].Chars??[]),Chars=lines[i].Chars,CharScores=scores,BoxScore=boxes[i].Score,BoxPoints=points });
+                        }
+                        var ms=watch.Elapsed.TotalMilliseconds;
+                        var kept=OnnxOcrEngine.ApplyBlockFilters(blocks.ToArray(),"JA",true,false);
+                        var final=RealtimeTranslationSession.RejectShortReadings(RealtimeTranslationSession.RejectCollapsedBlocks(
+                            OcrService.GroupRealtime(kept,source.Height,RealtimeBlockMode.Subtitle),source.Height,-1),-1);
+                        if(name=="grid-legacy" && pass==0)
+                        {
+                            var actual=engine.Detect(aligned,options).TextBlocks.Select(b=>b.Text).ToArray();
+                            if(!actual.SequenceEqual(blocks.Select(b=>b.Text))) throw new Exception("Raw path parity failed: "+path);
+                        }
+                        rows.Add(new{Image=path,Name=name,Pass=pass,Milliseconds=ms,Scale=scale,Text=blocks.Select(b=>new{b.Text,b.CharScores,Points=b.BoxPoints.Select(p=>new[]{p.X,p.Y})}),Final=final.Select(GroupingPrototype.Block.From).ToArray()});
+                        Console.WriteLine($"GRID {Path.GetFileName(path)} {name} p{pass} {ms:F1}ms: {string.Join(" | ",final.Select(b=>b.Text))}");
+                    }
+                    finally{foreach(var part in parts)part.Dispose();}
+                }
+            }
+        }
+        File.WriteAllText(Path.Combine(args[0],"grid.json"),JsonSerializer.Serialize(rows,new JsonSerializerOptions{WriteIndented=true}).ReplaceLineEndings("\r\n"));
+        return 0;
+    }
+}

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -920,7 +920,7 @@ if (args[0] == "--pad-sweep")
             var text = kept is null || kept.Count == 0
                 ? ""
                 : "  " + string.Join(" | ", kept.Select(b => b.Text.Replace("\n", " ")));
-            var mark = padding == 0 ? " <- shipped" : "";
+            var mark = padding == 8 ? " <- shipped" : "";
 
             Console.WriteLine(
                 $"  pad={padding,3} : {kept?.Count ?? -1} box chars={chars,3} " +

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -1419,7 +1419,10 @@ if (args[0] == "--group-explain")
         {
             var size = harnessSize
                 ?? RealtimeDetectorSize.For(image.Width, image.Height, harnessMode).Primary;
-            Console.WriteLine($"FLOW: 即時翻譯 (detect={size})");
+            // The mode is named because it picks the grouper, not just the thresholds: Subtitle
+            // runs DialogueTextGrouper and Panel runs the screenshot grouper on the Realtime
+            // profile. A file that does not say which one ran cannot be read against the other.
+            Console.WriteLine($"FLOW: 即時翻譯 (detect={size}, mode={harnessMode})");
             raw = await explainEngine.TryRecognizeAsync(image, harnessLanguage, size);
         }
         else
@@ -1460,7 +1463,17 @@ if (args[0] == "--group-explain")
             raw = OcrService.PrepareScreenshotGrouping(image, raw, explainProfile);
         var decisions = new List<OcrTextBlockGrouper.NextLineDecision>();
         var groupingTrace = harnessTrace ? new GroupingTrace() : null;
-        var grouped = OcrTextBlockGrouper.Group(raw, explainProfile, decisions, groupingTrace);
+        // Through the app's own realtime entry point rather than straight into the screenshot
+        // grouper. Calling the grouper directly is what this diagnostic used to do, and on Subtitle
+        // that reported the Panel branch's verdicts for a pipeline that never runs it — the
+        // dialogue rules were invisible here for the whole round that changed them.
+        var grouped = harnessRealtime
+            ? OcrService.GroupRealtime(raw, image.Height, harnessMode, groupingTrace, decisions)
+            : OcrTextBlockGrouper.Group(raw, explainProfile, decisions, groupingTrace);
+        if (harnessRealtime && harnessMode == RealtimeBlockMode.Subtitle)
+            Console.WriteLine(
+                "  dialogue grouper: profile thresholds below do not apply; scene-sized boxes are " +
+                "dropped inside GroupRealtime, so a line counted here may not have reached it");
 
         if (groupingTrace is not null)
         {
@@ -1580,6 +1593,13 @@ if (args[0] == "--group-explain")
         Console.WriteLine(
             "  --- next: align=left alignC=centre alignR=right alignMin=what the gate read, " +
             "bar=wrapped-final-line limit, solid=this group's set-solid limit ---");
+        // Same columns, different quantities. Printing the screenshot legend over dialogue verdicts
+        // would put a paragraph rule's name on a number no paragraph rule produced.
+        if (harnessRealtime && harnessMode == RealtimeBlockMode.Subtitle)
+            Console.WriteLine(
+                "  --- dialogue mode: row hgap=horizontal gap, overlap=vertical overlap of the two " +
+                "boxes; next size=height ratio, bar=the height floor it was judged on (0.60 for two " +
+                "substantial rows, else 0.75), solid=the alignment ceiling (2.50 or 1.25) ---");
         foreach (var decision in decisions)
         {
             var verdict = decision.Joined ? "JOIN  " : "SPLIT ";

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -16,6 +16,24 @@ using OverTranslate.Services.Realtime;
 // the text it belongs to, which is the half that says whether a verdict was right.
 Console.OutputEncoding = System.Text.Encoding.UTF8;
 
+if (args.Length > 0 && args[0] == "--dialogue-probe")
+    return await DialogueProbe.Run(args.Skip(1).ToArray());
+
+if (args.Length > 0 && args[0] == "--leading-edge-probe")
+    return await LeadingEdgeProbe.Run(args.Skip(1).ToArray());
+
+if (args.Length > 0 && args[0] == "--leading-edge-controls")
+    return await LeadingEdgeProbe.Run(args.Skip(1).ToArray(), controls: true);
+
+if (args.Length > 0 && args[0] == "--leading-edge-fusion")
+    return LeadingEdgeFusionProbe.Run(args.Skip(1).ToArray());
+
+if (args.Length > 0 && args[0] == "--ocr-root-probe")
+    return OcrRootProbe.Run(args.Skip(1).ToArray());
+
+if (args.Length > 0 && args[0] == "--detector-geometry")
+    return DetectorGeometryProbe.Run(args.Skip(1).ToArray());
+
 if (args.Length > 0 && args[0] == "--group-prototype")
     return await GroupingPrototype.Run(args.Skip(1).ToArray());
 
@@ -902,7 +920,7 @@ if (args[0] == "--pad-sweep")
             var text = kept is null || kept.Count == 0
                 ? ""
                 : "  " + string.Join(" | ", kept.Select(b => b.Text.Replace("\n", " ")));
-            var mark = padding == 50 ? " <- shipped" : "";
+            var mark = padding == 0 ? " <- shipped" : "";
 
             Console.WriteLine(
                 $"  pad={padding,3} : {kept?.Count ?? -1} box chars={chars,3} " +
@@ -1823,21 +1841,14 @@ if (args[0] == "--roi-stability")
     {
         using var crop = roiSource.Clone(rect, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
-        var options = OnnxOcrEngine.CreateOptions(null);
         using var sk = OnnxOcrEngine.ConvertToSkBitmap(crop);
-        var aligned = OnnxOcrEngine.AlignForDetector(sk, options.Padding);
 
-        // What the library does next: pad by options.Padding on all four sides, then scale that so
-        // its long side lands on the target. ImgResize is a CAP and not a target — measured, a
-        // 260x200 capture reads identically at ImgResize 512, 1024, 2048 and 4096 — so the target is
-        // the padded long side whenever that is the smaller of the two, and the scale is then 1.0
-        // and nothing is resampled at all. Asking GetScaleParam for ImgResize directly reports the
-        // upscale it would apply if it were a target, which is not what runs.
-        var paddedWidth = aligned.Width + 2 * options.Padding;
-        var paddedHeight = aligned.Height + 2 * options.Padding;
-        using var padded = new SkiaSharp.SKBitmap(paddedWidth, paddedHeight);
-        var scale = RapidOcrNet.ScaleParam.GetScaleParam(
-            padded, Math.Min(options.ImgResize, Math.Max(paddedWidth, paddedHeight)));
+        // The detector's own input, built the way the engine builds it. What used to stand here —
+        // align, add the border back, then ask ScaleParam what the library would make of it —
+        // described a pipeline the engine no longer runs: the downscale is now isotropic and done
+        // before the library sees the image, and the library's own resize is the identity.
+        var frame = OnnxOcrEngine.CreateDetectorFrame(sk, null);
+        var aligned = frame.Bitmap;
 
         var boxes = roiEngine.DetectBoxesOnly(crop, harnessLanguage)
             .Select(box => (
@@ -1860,7 +1871,7 @@ if (args[0] == "--roi-stability")
         var probed = new RoiProbed(
             rect,
             $"{aligned.Width}x{aligned.Height}",
-            $"{scale.ScaleWidth:0.0000}x{scale.ScaleHeight:0.0000}",
+            $"{frame.RatioX:0.0000}x{frame.RatioY:0.0000}",
             aligned,
             boxes,
             blocks,
@@ -2110,9 +2121,8 @@ if (args[0] == "--roi-snap")
     {
         using var crop = snapSource.Clone(analysis, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
-        var options = OnnxOcrEngine.CreateOptions(null);
         using var sk = OnnxOcrEngine.ConvertToSkBitmap(crop);
-        var aligned = OnnxOcrEngine.AlignForDetector(sk, options.Padding);
+        var aligned = OnnxOcrEngine.CreateDetectorFrame(sk, null).Bitmap;
 
         var read = await snapEngine.RecognizeAsync(crop, harnessLanguage);
 
@@ -2359,22 +2369,17 @@ if (args[0] == "--roi-fullframe")
     ffDetectWatch.Stop();
     var ffAfterMemory = Environment.WorkingSet;
 
-    var ffOptions = OnnxOcrEngine.CreateOptions(ffSize);
     using (var ffSk = OnnxOcrEngine.ConvertToSkBitmap(ffSource))
-    using (var ffAligned = OnnxOcrEngine.AlignForDetector(ffSk, ffOptions.Padding))
+    using (var ffFrame = OnnxOcrEngine.CreateDetectorFrame(ffSk, ffSize))
     {
-        // The same reading of ImgResize as --roi-stability's: a cap on the padded long side, not a
-        // target, so the scale is 1.0 whenever the page already fits. This is the line that says
-        // whether question B has anything to answer on this image.
-        var paddedWidth = ffAligned.Width + 2 * ffOptions.Padding;
-        var paddedHeight = ffAligned.Height + 2 * ffOptions.Padding;
-        using var ffPadded = new SkiaSharp.SKBitmap(paddedWidth, paddedHeight);
-        var ffScale = RapidOcrNet.ScaleParam.GetScaleParam(
-            ffPadded, Math.Min(ffOptions.ImgResize, Math.Max(paddedWidth, paddedHeight)));
+        // The isotropic downscale the engine applied before the library saw the image. It is 1.0
+        // whenever the page already fits, and this is the line that says whether question B has
+        // anything to answer on this image.
+        var ffAligned = ffFrame.Bitmap;
 
         Console.WriteLine(
             $"FULL FRAME DETECT  canvas={ffAligned.Width}x{ffAligned.Height}  " +
-            $"scale={ffScale.ScaleWidth:0.0000}x{ffScale.ScaleHeight:0.0000}  boxes={ffAllBoxes.Count}  " +
+            $"scale={ffFrame.RatioX:0.0000}x{ffFrame.RatioY:0.0000}  boxes={ffAllBoxes.Count}  " +
             $"{ffDetectWatch.ElapsedMilliseconds}ms  workingSet {(ffAfterMemory - ffBeforeMemory) / 1024 / 1024:+0;-0;0}MB");
     }
 
@@ -2486,15 +2491,9 @@ if (args[0] == "--roi-fullframe")
                 block.Text))
             .ToList();
 
-        var baselineOptions = OnnxOcrEngine.CreateOptions(null);
         using var baselineSk = OnnxOcrEngine.ConvertToSkBitmap(crop);
-        using var baselineAligned = OnnxOcrEngine.AlignForDetector(baselineSk, baselineOptions.Padding);
-        var baselinePaddedWidth = baselineAligned.Width + 2 * baselineOptions.Padding;
-        var baselinePaddedHeight = baselineAligned.Height + 2 * baselineOptions.Padding;
-        using var baselinePadded = new SkiaSharp.SKBitmap(baselinePaddedWidth, baselinePaddedHeight);
-        var baselineScale = RapidOcrNet.ScaleParam.GetScaleParam(
-            baselinePadded,
-            Math.Min(baselineOptions.ImgResize, Math.Max(baselinePaddedWidth, baselinePaddedHeight)));
+        using var baselineFrame = OnnxOcrEngine.CreateDetectorFrame(baselineSk, null);
+        var baselineAligned = baselineFrame.Bitmap;
 
         return new FullFrameProbed(
             logical,
@@ -2507,7 +2506,7 @@ if (args[0] == "--roi-fullframe")
             baselineBlocks,
             baselineWatch.ElapsedMilliseconds,
             $"{baselineAligned.Width}x{baselineAligned.Height}",
-            $"{baselineScale.ScaleWidth:0.0000}x{baselineScale.ScaleHeight:0.0000}");
+            $"{baselineFrame.RatioX:0.0000}x{baselineFrame.RatioY:0.0000}");
     }
 
     void FullFrameStabilityReport(string side, int step, FullFrameProbed b, FullFrameProbed v)

--- a/tools/OcrHarness/README.md
+++ b/tools/OcrHarness/README.md
@@ -78,10 +78,11 @@ OcrHarness.exe --compare-models 圖.png [更多.png ...]
 OcrHarness.exe --pad-sweep 圖.png [更多.png ...]
 ```
 
-`--pad-sweep` 的白邊不是「多一圈留白」而已：它參與 `AlignForDetector` 的對齊算式，也算進
-`ImgResize` 的長邊上限，所以白邊越寬、偵測器看到的文字越小。實測 0/8/16/24/32/50/64/96，
-**50 在字幕條帶、遊戲面板、小截圖三類上都是最高分，而且兩側都比它差** —— 是峰值不是地板，
-調大不會比較保險。細節與數字記在 `OnnxOcrEngine.DetectorPaddingOverride`。
+`--pad-sweep` 的白邊以前不是獨立變因：它參與 `AlignForDetector` 的對齊算式，會連帶改變偵測器
+輸入被壓扁多少，所以舊那張「50 最高分、兩側都比它差」的表其實是在排「哪個白邊剛好落在扭曲最少
+的幾何上」。偵測器輸入幾何修好之後（`OnnxOcrEngine.CreateDetectorFrame`）白邊才第一次只是白邊，
+重掃的結果是 **0 最好**，也是現行值。細節與數字記在 `OnnxOcrEngine.DetectorPadding`
+與 `.ai/realtime-dialogue/ocr-detector-geometry.md`。
 
 `--scale-sweep` 會一併印出 `RealtimeDetectorSize` 對該尺寸區塊會挑的 primary 與 fallback，
 所以掃描結果可以直接對照 app 真正會用的尺寸來讀。它走的是主專案的 `OnnxOcrEngine`，
@@ -135,7 +136,7 @@ OcrHarness.exe --roi-stability 圖.png --roi X,Y,W,H --grow down,right,all --ste
 | 層 | 看什麼 |
 |---|---|
 | 1 來源像素 | 兩個 ROI 重疊區來自同一個檔案，只可能因為實驗切錯而不同 |
-| 2 前處理 | `AlignForDetector` 產生的畫布，以及函式庫接著套用的縮放比 |
+| 2 前處理 | `CreateDetectorFrame` 產生的畫布，以及它套用的等比例縮放（函式庫不再縮放）|
 | 3 偵測器輸入 | 對齊後的點陣圖在重疊區逐像素比對（`same` / `MOVED`） |
 | 4 偵測框 | `DetectBoxesOnly`，在辨識與所有過濾之前 |
 | 5 辨識 | 同一位置回來的文字是否相同 |

--- a/tools/OcrHarness/README.md
+++ b/tools/OcrHarness/README.md
@@ -81,7 +81,9 @@ OcrHarness.exe --pad-sweep 圖.png [更多.png ...]
 `--pad-sweep` 的白邊以前不是獨立變因：它參與 `AlignForDetector` 的對齊算式，會連帶改變偵測器
 輸入被壓扁多少，所以舊那張「50 最高分、兩側都比它差」的表其實是在排「哪個白邊剛好落在扭曲最少
 的幾何上」。偵測器輸入幾何修好之後（`OnnxOcrEngine.CreateDetectorFrame`）白邊才第一次只是白邊，
-重掃的結果是 **0 最好**，也是現行值。細節與數字記在 `OnnxOcrEngine.DetectorPadding`
+重掃的結果是 **8 最好**，也是現行值——0 在語料上跟 8 打平且更快，但在「框整個對話框」
+這種實際框選型態上差很多（同一畫面挪 ±8px 共 45 種框法，讀到行首詞 22/45 對 44/45）。
+細節與數字記在 `OnnxOcrEngine.DetectorPadding`
 與 `.ai/realtime-dialogue/ocr-detector-geometry.md`。
 
 `--scale-sweep` 會一併印出 `RealtimeDetectorSize` 對該尺寸區塊會挑的 primary 與 fallback，


### PR DESCRIPTION
即時翻譯的對話模式（字幕／對話）原本有兩個相關的問題：日文行首漏字，以及漏字之後兩行併不起來。根因不在分組，在偵測器的輸入幾何。

## 根因

RapidOcrNet 的 `ScaleParam.GetScaleParam` 會對寬、高各自套 `(n / 32 - 1) * 32`，只要該軸不是 32 的倍數就整整往下砍一個 stride。`AlignForDetector` 只有在庫算出的縮放剛好等於 1.0 時才能抵銷它，而 `ImgResize` 是在 align 之前算的，所以縮放永遠差一點點，量化照跑。

結果是偵測器從來沒看過我們交給它的長寬比：465x76 的對話框進到模型時橫向 0.889、縱向 0.667，行首的「うん、」直接消失。同一段文字換一個框選大小讀出來不一樣，也是這個原因。#69 當時量到的「只在短軸上有 knife-edge」，其實就是跨過了一個 32px 的量化階。

## 修正

`OnnxOcrEngine` 新增 `DetectorFrame`：自己等比縮到目標尺寸、對齊 stride、再把 `ImgResize` 設到遠高於輸入，讓庫的縮放變成 identity，量化就不會跑。座標映射集中在 `DetectorFrame.MapToSource`。偵測邊界從庫預設的 50px 改為 8px。

`DialogueTextGrouper.NextRow` 的對齊閘，對「雙方寬度都 ≥ 6 倍高、彼此寬度差不到一半」的兩列放寬到 2.5 個字高（原本一律 1.25）。行首詞被漏掉的那一列會整整往右跳，卡在舊的閘上，一個漏字會變成兩個疊圖框。短的說話者名字或孤立符號進不了這個條件。

## 量測

依實機框選（整個對話框，不是貼緊文字的 ROI）重建 45 種框法：

| | 讀到行首詞 | 兩行併成一組 |
|---|---|---|
| 修正前 | 0 / 45 | 1 / 45 |
| 修正後 | 44 / 45 | 45 / 45 |

語料迴歸（medoid 字元 F1，修正前 → 修正後）：

| 語料 | 前 | 後 |
|---|---|---|
| region-subtitle-mixed-boxshape (123) | 97.4% | 99.7% |
| region-subtitle-ja-card (52) | 98.2% | 99.3% |
| region-subtitle-ja-video (32) | 97.4% | 99.8% |
| region-subtitle-en (53) | 99.0% | 99.7% |
| screen-panel-en-ja + region-panel-en (19) | 98.5% | 99.2% |
| screen-panel-ko (9) | 96.5% | 96.9% |
| screen-subtitle-en-ja (28) | 92.6% | 95.9% |
| web-v2 (6) | 98.3% | 99.1% |

速度同時快 5~15%（少了一次庫內縮放）。260 張字幕語料逐張比對，對齊閘的放寬造成的分組差異是零。

介面模式另外用 25 種框法驗過：合併行為 25/25 穩定，組數穩定在 7 組。順帶確認 `PanelFraction` 0.68 不要往上調——1.25x 與 1.47x 的 F1 都更差、框更碎、成本多 50%。

## 診斷

`--group-explain --realtime` 原本走 Panel 分支，字幕模式的分組決策從來看不到。改成走 `OcrService.GroupRealtime`，並讓 `DialogueTextGrouper` 記錄每組 row／next 判定與拒絕原因。`NextRow` 的條件從一個大 if 拆成逐條，數值與順序沒動。

## 已知殘留

- 行首詞仍有 1/45 讀不到，是從「必定漏」變成「偶爾漏」。
- 行首片段若自成一個矮框（高度比 0.57，門檻 0.6）仍可能不併回去。沒放寬這條，放寬會讓雜訊小框有機會併進正文。
- 介面模式中孤立的單字元鍵位徽章（如 `E PICK UP` 的 `E`，約 21x25px）讀不穩，4~5/25；修正前是 12/25。放大偵測尺寸救不了，退回 0px 邊界能拿回但會讓對話框框選掉回 22/45，不划算。
