### PR TITLE
修復暗底彩色日文標題被偵測器切碎造成的截圖漏字

### DIFF
--- a/src/OverTranslate/Services/Ocr/ChromaticBoxRepair.cs
+++ b/src/OverTranslate/Services/Ocr/ChromaticBoxRepair.cs
@@ -1,0 +1,184 @@
+using SkiaSharp;
+
+namespace OverTranslate.Services.Ocr;
+
+/// <summary>
+/// Rejoins a row of coloured text that the detector returned in pieces, before anything crops from
+/// those pieces.
+/// </summary>
+/// <remarks>
+/// <para>The case this exists for is a Japanese page title set in colour on a flat dark background.
+/// The detector's probability map fades across the thin coloured strokes, so the row comes back as
+/// several boxes with gaps between them, and the glyphs in the gaps are never recognised at all —
+/// <c>BanG Dream!</c> / <c>（バンドリ</c> / <c>J!)</c> / <c>）公式サイ</c> where the page reads
+/// <c>BanG Dream!（バンドリ！）公式サイト</c>. Widening the recognition crop does not help: the
+/// trailing <c>ト</c> peaks at about .015 on the probability map, far below the .2 box threshold,
+/// so there is no box to widen. Reading the whole row as one box does read it correctly.</para>
+///
+/// <para>Three earlier attempts at this symptom were measured and rejected, and why each failed is
+/// why this one is shaped the way it is. Recognising a second, greyscale pass and splicing its text
+/// over the first could silently drop a low-confidence original. Converting the whole capture to
+/// luminance before detection fired on 27 of 395 captures and changed 18 of them, because "flat
+/// dark background with some colour in it" is the definition of every dark-mode web page. Switching
+/// the detector to the official ImageNet normalisation changed 195 of 413. All three moved boxes
+/// everywhere; this one changes nothing unless a row is actually broken.</para>
+///
+/// <para>So the decision is local. The whole-image test below is only a cheap pre-filter — passing
+/// it does nothing on its own — and every condition after it is measured on one row of ink: the row
+/// must be mostly coloured, wide, continuous, already carry a substantial detector box, and hold
+/// coloured ink that no box covers. Across 413 captures exactly two rows satisfy all of them, and
+/// both were broken titles.</para>
+///
+/// <para>Screenshot captures only. The realtime path passes an explicit detector size and never
+/// reaches here: a frame missed there is repaired by the next one 250ms later, and none of this has
+/// been measured against a realtime corpus.</para>
+/// </remarks>
+internal static class ChromaticBoxRepair
+{
+    /// <param name="Owners">Indices into the box list that the repaired rectangle replaces.</param>
+    internal record Repair(int[] Owners, SKRect Bounds);
+
+    /// <summary>
+    /// The rows worth repairing, measured on the capture's own pixels in its own coordinates.
+    /// </summary>
+    internal static List<Repair> Find(SKBitmap source, IReadOnlyList<SKRect> boxes)
+    {
+        // The pre-filter: one large, flat, neutral, dark background colour. Strided, so it costs
+        // about the same on a 4K capture as on a small one, and everything expensive is behind it.
+        var histogram = new int[4096];
+        var step = Math.Max(1, Math.Max(source.Width, source.Height) / 512);
+        var samples = 0;
+        for (var y = 0; y < source.Height; y += step)
+        for (var x = 0; x < source.Width; x += step)
+        {
+            var c = source.GetPixel(x, y);
+            histogram[(c.Red >> 4) * 256 + (c.Green >> 4) * 16 + (c.Blue >> 4)]++;
+            samples++;
+        }
+        var mode = Array.IndexOf(histogram, histogram.Max());
+        var bg = new SKColor((byte)((mode >> 8) * 16 + 8), (byte)(((mode >> 4) & 15) * 16 + 8), (byte)((mode & 15) * 16 + 8));
+        var bgHigh = Math.Max(bg.Red, Math.Max(bg.Green, bg.Blue));
+        if (histogram[mode] < samples * .6 || bgHigh > 96 || bgHigh - Math.Min(bg.Red, Math.Min(bg.Green, bg.Blue)) > 32) return [];
+        bool Ink(SKColor c) => Math.Max(Math.Abs(c.Red - bg.Red), Math.Max(Math.Abs(c.Green - bg.Green), Math.Abs(c.Blue - bg.Blue))) > 40;
+        // Coloured, but not a saturated graphic: an icon or a logo is kept out by the second half.
+        bool Color(SKColor c)
+        {
+            var high = Math.Max(c.Red, Math.Max(c.Green, c.Blue));
+            var low = Math.Min(c.Red, Math.Min(c.Green, c.Blue));
+            return high - low >= 32 && low * 2 >= high;
+        }
+        var counts = new int[source.Height];
+        for (var y = 0; y < source.Height; y++)
+        for (var x = 0; x < source.Width; x++) if (Ink(source.GetPixel(x, y))) counts[y]++;
+        var repairs = new List<Repair>();
+        for (var y = 0; y < source.Height; y++)
+        {
+            if (counts[y] < 4) continue;
+            var top = y;
+            while (y < source.Height && counts[y] >= 4) y++;
+            var bottom = y;
+            var height = bottom - top;
+            if (height < 18) continue;
+            var ink = 0; var color = 0; var left = source.Width; var right = 0;
+            var occupied = new bool[source.Width];
+            for (var yy = top; yy < bottom; yy++)
+            for (var x = 0; x < source.Width; x++)
+            {
+                var c = source.GetPixel(x, yy);
+                if (!Ink(c)) continue;
+                ink++; if (Color(c)) color++;
+                occupied[x] = true;
+                left = Math.Min(left, x); right = Math.Max(right, x + 1);
+            }
+            // A line of text, mostly coloured, and not a filled panel: the last term rejects a row
+            // whose ink covers most of its own area.
+            if (right - left < height * 6 || color < ink * .6 || ink > (right - left) * height * .65) continue;
+            var owners = Enumerable.Range(0, boxes.Count).Where(i =>
+                Math.Min(boxes[i].Bottom, bottom) - Math.Max(boxes[i].Top, top) >= Math.Min(boxes[i].Height, height) * .6 &&
+                boxes[i].Right > left && boxes[i].Left < right).OrderBy(i => boxes[i].Left).ToArray();
+            if (owners.Length == 0 || owners.Any(i => repairs.Any(r => r.Owners.Contains(i)))) continue;
+            // Something real was detected on this row. Without it, a row of ink the detector refused
+            // outright — scenery, a logo, a progress bar — would be handed to recognition as text.
+            if (owners.Max(i => boxes[i].Width) < height * 2.5) continue;
+            // The ink runs across the gaps. A row of separate items with real space between them has
+            // a gap wider than a line height somewhere, and must not be glued into one box.
+            var gap = 0; var maxGap = 0;
+            for (var x = left; x < right; x++) { gap = occupied[x] ? 0 : gap + 1; maxGap = Math.Max(maxGap, gap); }
+            if (maxGap > height) continue;
+            if (owners.Any(i => boxes[i].Top < top - height * .6 || boxes[i].Bottom > bottom + height * .6)) continue;
+            // The evidence that something is actually missing: coloured ink inside the row that no
+            // existing box covers, and enough of it to be glyphs rather than antialiasing.
+            var missing = 0; var missingTop = bottom; var missingBottom = top; var missingLeft = right; var missingRight = left;
+            for (var yy = top; yy < bottom; yy++)
+            for (var x = left; x < right; x++)
+            {
+                var c = source.GetPixel(x, yy);
+                if (!Ink(c) || !Color(c) || owners.Any(i => boxes[i].Contains(x, yy))) continue;
+                missing++; missingLeft = Math.Min(missingLeft, x); missingRight = Math.Max(missingRight, x + 1);
+                missingTop = Math.Min(missingTop, yy); missingBottom = Math.Max(missingBottom, yy + 1);
+            }
+            if (missing < height || missingBottom - missingTop < height * .5 || missingRight - missingLeft < height * .2) continue;
+            var margin = Math.Max(2, height * .1f);
+            var rect = new SKRect(Math.Max(0, Math.Min(left - margin, owners.Min(i => boxes[i].Left))),
+                Math.Max(0, Math.Min(top - margin, owners.Min(i => boxes[i].Top))),
+                Math.Min(source.Width, Math.Max(right + margin, owners.Max(i => boxes[i].Right))),
+                Math.Min(source.Height, Math.Max(bottom + margin, owners.Max(i => boxes[i].Bottom))));
+            // A repair may not absorb another row or an unrelated overlapping detector box.
+            if (Enumerable.Range(0, boxes.Count).Any(i => !owners.Contains(i) && SKRect.Intersect(rect, boxes[i]).Width > 0 && SKRect.Intersect(rect, boxes[i]).Height > 0)) continue;
+            repairs.Add(new(owners, rect));
+        }
+        return repairs;
+    }
+
+    /// <summary>
+    /// The detector's boxes with each repaired row's pieces replaced by the single box spanning
+    /// them, in the detector's own coordinates so recognition can crop from them directly.
+    /// </summary>
+    /// <remarks>
+    /// Returns the list it was handed whenever nothing qualifies, which is the overwhelmingly common
+    /// case and the one that has to stay free: no allocation, no reordering, no coordinate round
+    /// trip. A box outside a repair comes back as the same instance in the same position.
+    /// </remarks>
+    internal static IReadOnlyList<RapidOcrNet.TextBox> Apply(
+        SKBitmap source,
+        IReadOnlyList<SKRect> sourceBounds,
+        IReadOnlyList<RapidOcrNet.TextBox> detectorBoxes,
+        double ratioX,
+        double ratioY,
+        int padding)
+    {
+        var repairs = Find(source, sourceBounds);
+        if (repairs.Count == 0) return detectorBoxes;
+
+        var result = new List<RapidOcrNet.TextBox>(detectorBoxes.Count);
+        for (var i = 0; i < detectorBoxes.Count; i++)
+        {
+            var repair = repairs.FirstOrDefault(r => r.Owners.Contains(i));
+            if (repair is null) { result.Add(detectorBoxes[i]); continue; }
+            // Emitted once, in the place of its leftmost piece, so reading order does not move.
+            if (i != repair.Owners.Min()) continue;
+
+            // Back into detector space: the frame's own scale, then the padding the library added
+            // around it. Floor and ceiling rather than rounding, because a repaired box landing a
+            // pixel inside its own glyphs is the clipping this exists to stop.
+            var left = (int)Math.Floor(repair.Bounds.Left * ratioX + padding);
+            var right = (int)Math.Ceiling(repair.Bounds.Right * ratioX + padding);
+            var top = (int)Math.Floor(repair.Bounds.Top * ratioY + padding);
+            var bottom = (int)Math.Ceiling(repair.Bounds.Bottom * ratioY + padding);
+            result.Add(new RapidOcrNet.TextBox
+            {
+                // The lowest of the pieces it replaces. A merged box is no more certain than the
+                // least certain thing it was built from, and downstream filters read this.
+                Score = repair.Owners.Min(id => detectorBoxes[id].Score),
+                BoxPoints =
+                [
+                    new SKPointI(left, top),
+                    new SKPointI(right, top),
+                    new SKPointI(right, bottom),
+                    new SKPointI(left, bottom),
+                ],
+            });
+        }
+        return result;
+    }
+}

--- a/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
+++ b/src/OverTranslate/Services/Ocr/OnnxOcrEngine.cs
@@ -236,20 +236,42 @@ internal sealed class OnnxOcrEngine : IOcrEngine
                 runtime.ModelName,
                 ThreadCount);
 
-            using var skBitmap = ConvertToSkBitmap(bitmap);
-            using var frame = CreateDetectorFrame(skBitmap, maxDetectSize);
-            var result = runtime.Engine.Detect(frame.Bitmap, frame.Options);
-            frame.MapToSource(result.TextBlocks);
-            var blocks = ApplyBlockFilters(result.TextBlocks, normalizedLanguage, useCjkRenderMetrics, usesAutomaticLayout);
+            TextBlock[] recognised;
+            List<OcrTextBlock> blocks;
+            if (maxDetectSize is null)
+            {
+                // The screenshot path runs through the detect/recognise seam so ChromaticBoxRepair
+                // can rejoin a broken row of coloured text before anything crops from it. The seam
+                // is not a second implementation of recognition: across all 413 corpus captures it
+                // returns the same text, in boxes at the same coordinates, as the library's one-shot
+                // Detect — so what this path adds is that one repair and nothing else.
+                using var session = new DetectionSession(
+                    this, runtime, bitmap, normalizedLanguage, null, releasesRuntime: false);
+                blocks = session
+                    .Recognize(Enumerable.Range(0, session.Boxes.Count).ToArray(), out recognised)
+                    .ToList();
+            }
+            else
+            {
+                using var skBitmap = ConvertToSkBitmap(bitmap);
+                using var frame = CreateDetectorFrame(skBitmap, maxDetectSize);
+                var result = runtime.Engine.Detect(frame.Bitmap, frame.Options);
+                frame.MapToSource(result.TextBlocks);
+                recognised = result.TextBlocks;
+                blocks = ApplyBlockFilters(
+                    recognised, normalizedLanguage, useCjkRenderMetrics, usesAutomaticLayout);
+            }
 
             // Counts and lengths only — enough to tell "found nothing" from "found the wrong thing"
             // without the recognised text itself, which LogBlocks keeps at Debug.
             Log.Info(
                 "ONNX OCR lang={Lang} rawBlocks={RawBlocks} blocks={Blocks} strLen={StrLen}",
                 normalizedLanguage,
-                result.TextBlocks.Length,
+                recognised.Length,
                 blocks.Count,
-                result.StrRes?.Length ?? 0);
+                // Summed here rather than taken from the library's own concatenation, which the
+                // seam does not produce. The same quantity: how much text came back at all.
+                recognised.Sum(block => block.Text?.Length ?? 0));
 
             // Before the filters rather than after, and only when they took everything: a region
             // that reads as empty has nothing left to log, which is exactly the case anyone is
@@ -257,8 +279,8 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             // line framed outside the block (a box against an edge, a couple of clipped glyphs)
             // from one the confidence floor threw away (a box over the text, plausible words, a
             // score just under the bar).
-            if (blocks.Count == 0 && result.TextBlocks.Length > 0)
-                LogRejectedBlocks(normalizedLanguage, result.TextBlocks);
+            if (blocks.Count == 0 && recognised.Length > 0)
+                LogRejectedBlocks(normalizedLanguage, recognised);
 
             LogBlocks(normalizedLanguage, blocks);
             return blocks;
@@ -372,16 +394,20 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         private readonly object _detectorInput;
         private readonly SKBitmap _detectorBitmap;
         private readonly RapidOcrOptions _options;
-        private readonly IReadOnlyList<RapidOcrNet.TextBox> _detectorSpaceBoxes;
+        private IReadOnlyList<RapidOcrNet.TextBox> _detectorSpaceBoxes;
+        // False when the caller acquired the runtime itself and releases it in its own finally.
+        private readonly bool _releasesRuntime;
 
         internal DetectionSession(
             OnnxOcrEngine owner,
             RapidOcrRuntime runtime,
             Bitmap bitmap,
             string normalizedLanguage,
-            int? maxDetectSize)
+            int? maxDetectSize,
+            bool releasesRuntime = true)
         {
             _owner = owner;
+            _releasesRuntime = releasesRuntime;
             _engine = runtime.Engine;
             _language = normalizedLanguage;
             _skBitmap = ConvertToSkBitmap(bitmap);
@@ -399,14 +425,46 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             // The caller works in the coordinates of the bitmap it handed in, so every box is
             // reported there. The detector-space originals are what recognition crops with and are
             // kept beside them, because mapping is not reversible once the resize is not 1.0.
-            Boxes = _detectorSpaceBoxes
-                .Select(box =>
+            var mapped = ToSourceSpace(_detectorSpaceBoxes);
+
+            // Screenshot captures only, which is what a null detector size means here — the
+            // realtime path always names a size. Run before anything crops, because the whole point
+            // is that the pieces are never cropped: the glyphs in the gaps between them have no box
+            // of their own to read. Apply hands back the same list when nothing qualifies, which is
+            // all but two captures in the corpus.
+            if (maxDetectSize is null)
+            {
+                var repaired = ChromaticBoxRepair.Apply(
+                    _skBitmap,
+                    mapped.Select(box => new SKRect(
+                        (float)box.Bounds.Left,
+                        (float)box.Bounds.Top,
+                        (float)box.Bounds.Right,
+                        (float)box.Bounds.Bottom)).ToList(),
+                    _detectorSpaceBoxes,
+                    _frame.RatioX,
+                    _frame.RatioY,
+                    _options.Padding);
+
+                if (!ReferenceEquals(repaired, _detectorSpaceBoxes))
                 {
-                    var points = (SKPointI[])box.BoxPoints.Clone();
-                    MapToOriginalMethod.Invoke(_detectorInput, new object[] { points });
-                    return (Bounds: _frame.ToSourceBounds(points), box.Score);
-                })
-                .ToList();
+                    _detectorSpaceBoxes = repaired;
+                    mapped = ToSourceSpace(repaired);
+                }
+            }
+
+            Boxes = mapped;
+
+            List<(System.Windows.Rect Bounds, float Score)> ToSourceSpace(
+                IReadOnlyList<RapidOcrNet.TextBox> boxes) =>
+                boxes
+                    .Select(box =>
+                    {
+                        var points = (SKPointI[])box.BoxPoints.Clone();
+                        MapToOriginalMethod.Invoke(_detectorInput, new object[] { points });
+                        return (Bounds: _frame.ToSourceBounds(points), box.Score);
+                    })
+                    .ToList();
         }
 
         /// <summary>Every box the detector found, in the handed-in bitmap's own coordinates.</summary>
@@ -415,8 +473,18 @@ internal sealed class OnnxOcrEngine : IOcrEngine
         /// <summary>
         /// Recognises the boxes at the given indices into <see cref="Boxes"/> and nothing else.
         /// </summary>
-        internal IReadOnlyList<OcrTextBlock> Recognize(IReadOnlyList<int> boxIndices)
+        internal IReadOnlyList<OcrTextBlock> Recognize(IReadOnlyList<int> boxIndices) =>
+            Recognize(boxIndices, out _);
+
+        /// <param name="recognised">
+        /// What recognition produced before <see cref="ApplyBlockFilters"/> ran, which is the only
+        /// thing that can tell a box the filters threw away from one the detector never found.
+        /// </param>
+        /// <inheritdoc cref="Recognize(IReadOnlyList{int})"/>
+        internal IReadOnlyList<OcrTextBlock> Recognize(
+            IReadOnlyList<int> boxIndices, out TextBlock[] recognised)
         {
+            recognised = Array.Empty<TextBlock>();
             if (boxIndices.Count == 0) return Array.Empty<OcrTextBlock>();
 
             var chosen = boxIndices.Select(index => _detectorSpaceBoxes[index]).ToList();
@@ -454,8 +522,9 @@ internal sealed class OnnxOcrEngine : IOcrEngine
                     });
                 }
 
+                recognised = textBlocks.ToArray();
                 return ApplyBlockFilters(
-                    textBlocks.ToArray(),
+                    recognised,
                     _language,
                     OcrLanguageRouter.UsesCjkOnnx(_language),
                     OcrLanguageRouter.UsesAutomaticLayout(_language));
@@ -471,7 +540,8 @@ internal sealed class OnnxOcrEngine : IOcrEngine
             ((IDisposable)_detectorInput).Dispose();
             _frame.Dispose();
             _skBitmap.Dispose();
-            _owner.ReleaseRuntime();
+            if (_releasesRuntime)
+                _owner.ReleaseRuntime();
         }
     }
 

--- a/tests/OverTranslate.Tests/ChromaticBoxRepairTests.cs
+++ b/tests/OverTranslate.Tests/ChromaticBoxRepairTests.cs
@@ -1,0 +1,108 @@
+using OverTranslate.Services.Ocr;
+using SkiaSharp;
+using Xunit;
+
+namespace OverTranslate.Tests;
+
+/// <summary>
+/// The repair fires on a broken row of coloured text and on nothing else.
+/// </summary>
+/// <remarks>
+/// Written against synthetic pixels rather than captures, because what has to hold is the shape of
+/// the conditions, not one page's luck: a corpus run says the rule fired twice in 413 captures, but
+/// not which condition kept it quiet on the other 411. Each case below removes exactly one.
+/// </remarks>
+public class ChromaticBoxRepairTests
+{
+    private const int Height = 24;
+    private const int Top = 20;
+
+    [Fact]
+    public void ABrokenRowOfColouredTextIsRejoined()
+    {
+        using var page = Page();
+        var repairs = ChromaticBoxRepair.Find(page, [Box(20, 120), Box(200, 120)]);
+
+        var repair = Assert.Single(repairs);
+        Assert.Equal(new[] { 0, 1 }, repair.Owners.ToArray().AsEnumerable());
+        // Outside both pieces and the ink between them, which is the gap that had no box at all.
+        Assert.True(repair.Bounds.Left <= 20 && repair.Bounds.Right >= 320);
+    }
+
+    [Fact]
+    public void APaleBackgroundIsNotThisCase()
+    {
+        // The symptom is a detector fading out on thin colour against flat dark. On a light page
+        // the boxes are not broken, so there is nothing here to rejoin and no reason to look.
+        using var page = Page(background: new SKColor(240, 240, 244));
+
+        Assert.Empty(ChromaticBoxRepair.Find(page, [Box(20, 120), Box(200, 120)]));
+    }
+
+    [Fact]
+    public void SeparateItemsWithRealSpaceBetweenThemAreNotOneRow()
+    {
+        // A nav bar or a row of labels: the same colour, the same line, genuinely separate. The ink
+        // stops for longer than a line height, and that is what tells it apart from a broken word.
+        using var page = Page(gapFrom: 150, gapTo: 150 + Height * 2);
+
+        Assert.Empty(ChromaticBoxRepair.Find(page, [Box(20, 120), Box(200, 120)]));
+    }
+
+    [Fact]
+    public void ARowTheDetectorAlreadyCoveredIsLeftAlone()
+    {
+        // Nothing is missing, so nothing is repaired — a complete reading must never be reboxed.
+        using var page = Page();
+
+        Assert.Empty(ChromaticBoxRepair.Find(page, [Box(18, 304)]));
+    }
+
+    [Fact]
+    public void ColouredInkWithoutASubstantialBoxIsNotTreatedAsText()
+    {
+        // Scenery, a logo, a progress bar: ink the detector refused. Without a real box on the row
+        // to anchor it, a repair would be handing recognition something never detected as text.
+        using var page = Page();
+
+        Assert.Empty(ChromaticBoxRepair.Find(page, [Box(20, 40), Box(200, 40)]));
+    }
+
+    [ScreenshotFact("web-v4/3.png")]
+    public void TheColouredTitleIsReadWhole()
+    {
+        // The capture that started this. The detector returns the title as four pieces and the
+        // trailing glyphs sit in the gaps between them, so before the repair the reading stopped at
+        // 公式サイ. Runs the real screenshot entry point, not the seam directly.
+        using var engine = new OnnxOcrEngine();
+        using var capture = ExternalScreenshot.Load("web-v4/3.png");
+
+        var text = string.Concat(
+            engine.RecognizeAsync(capture, "JA").GetAwaiter().GetResult().Select(block => block.Text));
+
+        Assert.Contains("公式サイト", text);
+    }
+
+    // A dark page carrying one row of thin coloured strokes: ink enough to be a line of text, gaps
+    // narrow enough to be the spaces inside one, and nowhere near solid enough to be a filled panel.
+    private static SKBitmap Page(SKColor? background = null, int gapFrom = 0, int gapTo = 0)
+    {
+        var bg = background ?? new SKColor(24, 24, 32);
+        var page = new SKBitmap(400, 80, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using (var canvas = new SKCanvas(page))
+            canvas.Clear(bg);
+
+        var ink = new SKColor(120, 160, 220);
+        for (var x = 20; x < 320; x += 6)
+        {
+            if (x >= gapFrom && x < gapTo) continue;
+            for (var stroke = 0; stroke < 2; stroke++)
+            for (var y = Top; y < Top + 20; y++)
+                page.SetPixel(x + stroke, y, ink);
+        }
+        return page;
+    }
+
+    private static SKRect Box(int left, int width) =>
+        new(left, Top, left + width, Top + Height);
+}

--- a/tools/OcrHarness/Program.cs
+++ b/tools/OcrHarness/Program.cs
@@ -16,6 +16,9 @@ using OverTranslate.Services.Realtime;
 // the text it belongs to, which is the half that says whether a verdict was right.
 Console.OutputEncoding = System.Text.Encoding.UTF8;
 
+if (args.Length > 0 && args[0] == "--session-equivalence")
+    return SessionEquivalenceProbe.Run(args.Skip(1).ToArray());
+
 if (args.Length > 0 && args[0] == "--dialogue-probe")
     return await DialogueProbe.Run(args.Skip(1).ToArray());
 

--- a/tools/OcrHarness/SessionEquivalenceProbe.cs
+++ b/tools/OcrHarness/SessionEquivalenceProbe.cs
@@ -1,0 +1,69 @@
+using System.Drawing;
+using System.IO;
+using System.Text.Json;
+using OverTranslate.Services;
+using OverTranslate.Services.Ocr;
+
+// Does the split detect/recognise seam return what the library's own one-shot Detect returns?
+//
+// RecognizeCore calls RapidOcr.Detect, which detects and recognises in one library call and leaves
+// no point between the two. DetectionSession reimplements that split so a caller can see the boxes
+// first — and until now it was only ever used by this harness, so nothing depended on the two
+// agreeing. Repairing boxes before recognition needs the seam on the shipped screenshot path, which
+// makes the agreement load-bearing: every capture where no repair fires must read exactly as it
+// reads today, or the repair's small blast radius is an illusion created by measuring the seam
+// against itself.
+internal static class SessionEquivalenceProbe
+{
+    internal static int Run(string[] args)
+    {
+        var language = args[0];
+        var output = args[1];
+        var differing = 0;
+        var rows = new List<object>();
+        using var engine = new OnnxOcrEngine();
+
+        foreach (var path in args.Skip(2))
+        {
+            using var bitmap = new Bitmap(path);
+
+            var shipped = engine.RecognizeAsync(bitmap, language).GetAwaiter().GetResult();
+
+            List<OcrTextBlock> seam;
+            using (var session = engine.BeginDetection(bitmap, language))
+                seam = session.Recognize(Enumerable.Range(0, session.Boxes.Count).ToArray()).ToList();
+
+            // Text and geometry both, because a seam that reads the same words out of boxes a few
+            // pixels apart is not the same input to grouping, which is where this has to be safe.
+            var texts = !shipped.Select(b => b.Text).SequenceEqual(seam.Select(b => b.Text));
+            var boxes = !shipped.Select(Box).SequenceEqual(seam.Select(Box));
+            if (texts || boxes) differing++;
+
+            rows.Add(new
+            {
+                path,
+                language,
+                shippedCount = shipped.Count,
+                seamCount = seam.Count,
+                textsDiffer = texts,
+                boxesDiffer = boxes,
+                shipped = shipped.Select(b => new { b.Text, box = Box(b) }).ToArray(),
+                seam = seam.Select(b => new { b.Text, box = Box(b) }).ToArray(),
+            });
+
+            Console.WriteLine(
+                $"SEAM {(texts || boxes ? "DIFFERS" : "same   ")} " +
+                $"{shipped.Count}/{seam.Count} {Path.GetFileName(path)}");
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(output))!);
+        File.WriteAllText(
+            output,
+            JsonSerializer.Serialize(rows, new JsonSerializerOptions { WriteIndented = true })
+                .ReplaceLineEndings("\r\n"));
+        return differing == 0 ? 0 : 1;
+    }
+
+    private static string Box(OcrTextBlock block) =>
+        $"{block.Bounds.X:0.##},{block.Bounds.Y:0.##},{block.Bounds.Width:0.##},{block.Bounds.Height:0.##}";
+}


### PR DESCRIPTION
暗色背景上的彩色日文標題，偵測器會把一整行切成好幾個框，而框與框之間的字**完全不會被辨識**。`BanG Dream!（バンドリ！）公式サイト` 讀成 `BanG Dream!` / `（バンドリ` / `J!)` / `）公式サイ`。

## 為什麼不是調門檻或放大裁切

行尾的 `ト` 在機率圖上的最大值約 **0.015**，遠低於 0.2 的框門檻；把 `BoxThresh` 一路降到 0.01 也生不出框。既然沒有框，加寬辨識裁切自然無效。但**強制用一個框蓋住整行，辨識讀得完全正確**——所以像素沒問題、辨識器沒問題，缺的只是一個框。

## 為什麼是這個做法

同一個症狀先試過三種全域做法，都量過並否決：

| 做法 | 影響面 |
|---|---|
| 二次灰階重讀後拼接文字 | 可能靜默取代低信心原文 |
| 整張截圖轉灰階後再偵測 | 395 張觸發 27 張、改變 18 張 |
| 改用官方 ImageNet normalization | 413 張改變 195 張 |

三者的副作用清單幾乎一模一樣（選單誤併、表格跨欄、說話者掉字），因為它們都在重採樣或重正規化，框就跟著動。所以這個修正不碰像素、不碰模型、不碰門檻，只在**偵測之後、裁切之前**把同一列被切碎的框接回去。

判斷是逐列的：該列必須大部分是彩色、夠寬、墨跡連續、已經有一個實質的偵測框，而且有彩色墨跡是任何框都沒蓋到的。全圖那道暗底檢查只是廉價的前置過濾，過了它本身不做任何事。

## 量測

before = `1af2ead`，after = 本分支，逐張比對組內成員文字，走真正的截圖入口。

- **413 張語料中只有 2 張改變**，兩張都是修好：

```
web-v4/3.png       BanG Dream!（バンドリJ!)）公式サイ → BanG Dream!（バンドリ！）公式サイト
shots/new/en-1.png バンドリ！ガールズバン            → バンドリ！ガールズバンドパーティ！
```

- 字幕三集（277 張）、遊戲面板、韓文、直排、漫畫、暗色英文網頁全部零觸發。
- 成本量不到：405 張的耗時差中位 −1.0ms，最大的一張 52MP 也沒有成本。全圖逐像素掃描在暗底閘之後才跑。

## 接縫等價

截圖流程改走 `DetectionSession` 的偵測／辨識接縫，才有地方在裁切前修框。接上去之前先證明這條接縫等於原本的一次性 `Detect`：同一張圖兩邊都跑，比文字序列與框座標，**413 張皆為 0 差異**。驗證工具留在 `--session-equivalence`。

## 範圍

只走截圖。即時翻譯兩個呼叫都帶明確偵測尺寸，結構上到不了這段；即時漏一幀 250ms 後就會補回來，而且沒有對即時語料驗證過。

## 測試

`ChromaticBoxRepairTests` 六項。五項用合成像素，各自只拿掉一個條件（暗底、墨跡連續性、缺墨證據、實質框、亮底），確認每道閘都真的在擋——語料只能說「411 張沒觸發」，說不出是哪個條件擋住的。這五項不需要模型，CI 會跑。第六項用實圖斷言標題完整讀出。

全套 1163 通過 / 0 失敗。

## 已知未涵蓋

同一張截圖的**灰色內文**也有同類問題（行首碎裂、行尾截斷），但該列彩色比只有 28–30%，這條規則到不了。那是獨立議題，已另行記錄，不在此 PR 範圍。

未驗證：實機疊圖、翻譯服務、直排兩階段、4K 記憶體。
